### PR TITLE
feat: implement proper CLI handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1387,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93a719913643003b84bd13022b4b7e703c09342cd03b679c4641c7d2e50dc34d"
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clickhouse"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,6 +1480,12 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -3748,6 +3844,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4447,6 +4549,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
@@ -6438,6 +6546,7 @@ name = "streamling"
 version = "0.1.0"
 dependencies = [
  "arrow-schema",
+ "clap",
  "datafusion",
  "futures",
  "humantime",
@@ -6705,6 +6814,12 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -8441,6 +8556,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ percent-encoding = "2.3.1"
 lazy_static = "1.5.0"
 humantime = "2.2.0"
 bigdecimal = "0.4.8"
+clap = { version = "4.5", features = ["derive"] }
 
 # WASM dependencies
 extism = "1.21.0"

--- a/crates/streamling/Cargo.toml
+++ b/crates/streamling/Cargo.toml
@@ -21,6 +21,7 @@ streamling-config = { workspace = true }
 streamling-state = { workspace = true }
 
 # Core dependencies
+clap.workspace = true
 datafusion.workspace = true
 tokio.workspace = true
 humantime.workspace = true

--- a/crates/streamling/src/main.rs
+++ b/crates/streamling/src/main.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use std::fs::read_to_string;
 use std::process::ExitCode;
 use std::sync::{Arc, Mutex};
@@ -19,6 +20,25 @@ use tracing_subscriber::EnvFilter;
 mod initializations;
 use initializations::{initialize_live_data_inspect, start_admin_api_server};
 use streamling_common::logging::FlatJsonFormat;
+
+#[derive(Parser)]
+#[command(version, about)]
+struct Cli {
+    /// Pipeline definition file; overrides pipeline_definition_location from config.
+    pipeline_file: Option<String>,
+
+    /// Config file base name or path (.yaml/.yml/.json auto-detected).
+    #[arg(long, default_value = "config")]
+    config: String,
+
+    /// Build and validate the pipeline without running it (no data is processed).
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Validate the pipeline definition (implies --dry-run). Emits JSON results.
+    #[arg(long)]
+    validate: bool,
+}
 
 fn build_env_filter(default_level: &str) -> EnvFilter {
     let base = match std::env::var("RUST_LOG") {
@@ -92,13 +112,15 @@ fn init_logging_capture(app_config: &AppConfig) -> Arc<Mutex<Vec<CapturedLog>>> 
     logs
 }
 
-async fn run_pipeline(args: &[String], app_config: AppConfig, dry_run: bool) -> Result<()> {
+async fn run_pipeline(
+    pipeline_file: Option<String>,
+    app_config: AppConfig,
+    dry_run: bool,
+) -> Result<()> {
     load_and_initialize_plugins(&app_config)?;
 
-    let pipeline_definition_location = args
-        .first()
-        .cloned()
-        .unwrap_or(app_config.pipeline_definition_location.clone());
+    let pipeline_definition_location =
+        pipeline_file.unwrap_or_else(|| app_config.pipeline_definition_location.clone());
     let plugin_preprocessors = build_plugin_preprocessors(&app_config);
     let preprocessor = TopologyPreprocessor::new(plugin_preprocessors);
     let config_string = read_to_string(&pipeline_definition_location)
@@ -193,26 +215,11 @@ fn emit_validation_json(run_error: Option<&StreamlingError>, logs: &[CapturedLog
 async fn main() -> ExitCode {
     install_global_panic_hook();
 
-    let mut args = std::env::args().skip(1).collect::<Vec<String>>();
-    let mut dry_run = false;
-    let mut validate = false;
-    args.retain(|arg| match arg.as_str() {
-        "--dry-run" => {
-            dry_run = true;
-            false
-        }
-        "--validate" => {
-            validate = true;
-            false
-        }
-        _ => true,
-    });
+    let cli = Cli::parse();
+    let validate = cli.validate;
+    let dry_run = cli.dry_run || cli.validate;
 
-    if validate {
-        dry_run = true;
-    }
-
-    let app_config = match AppConfig::load_from_path("config") {
+    let app_config = match AppConfig::load_from_path(&cli.config) {
         Ok(config) => config,
         Err(e) => {
             if validate {
@@ -230,7 +237,7 @@ async fn main() -> ExitCode {
         None
     };
 
-    let result = run_pipeline(&args, app_config, dry_run).await;
+    let result = run_pipeline(cli.pipeline_file, app_config, dry_run).await;
 
     if let Err(ref e) = result {
         tracing::error!(

--- a/crates/streamling/src/main.rs
+++ b/crates/streamling/src/main.rs
@@ -40,6 +40,12 @@ struct Cli {
     validate: bool,
 }
 
+impl Cli {
+    fn is_dry_run(&self) -> bool {
+        self.dry_run || self.validate
+    }
+}
+
 fn build_env_filter(default_level: &str) -> EnvFilter {
     let base = match std::env::var("RUST_LOG") {
         Ok(val) if !val.is_empty() => EnvFilter::from_default_env(),
@@ -217,7 +223,7 @@ async fn main() -> ExitCode {
 
     let cli = Cli::parse();
     let validate = cli.validate;
-    let dry_run = cli.dry_run || cli.validate;
+    let dry_run = cli.is_dry_run();
 
     let app_config = match AppConfig::load_from_path(&cli.config) {
         Ok(config) => config,
@@ -264,4 +270,63 @@ async fn main() -> ExitCode {
     }
 
     ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::{CommandFactory, Parser};
+
+    #[test]
+    fn cli_definition_is_valid() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn defaults_when_no_args() {
+        let cli = Cli::try_parse_from(["streamling"]).unwrap();
+        assert_eq!(cli.pipeline_file, None);
+        assert_eq!(cli.config, "config");
+        assert!(!cli.dry_run);
+        assert!(!cli.validate);
+        assert!(!cli.is_dry_run());
+    }
+
+    #[test]
+    fn pipeline_file_is_captured_positionally() {
+        let cli = Cli::try_parse_from(["streamling", "pipeline.yaml"]).unwrap();
+        assert_eq!(cli.pipeline_file.as_deref(), Some("pipeline.yaml"));
+    }
+
+    #[test]
+    fn config_flag_overrides_default() {
+        let cli = Cli::try_parse_from(["streamling", "--config", "custom.yaml"]).unwrap();
+        assert_eq!(cli.config, "custom.yaml");
+    }
+
+    #[test]
+    fn dry_run_flag_enables_dry_run() {
+        let cli = Cli::try_parse_from(["streamling", "--dry-run"]).unwrap();
+        assert!(cli.dry_run);
+        assert!(!cli.validate);
+        assert!(cli.is_dry_run());
+    }
+
+    #[test]
+    fn validate_implies_dry_run() {
+        let cli = Cli::try_parse_from(["streamling", "--validate"]).unwrap();
+        assert!(cli.validate);
+        assert!(!cli.dry_run);
+        assert!(cli.is_dry_run());
+    }
+
+    #[test]
+    fn unknown_flag_is_rejected() {
+        assert!(Cli::try_parse_from(["streamling", "--nope"]).is_err());
+    }
+
+    #[test]
+    fn extra_positional_is_rejected() {
+        assert!(Cli::try_parse_from(["streamling", "a.yaml", "b.yaml"]).is_err());
+    }
 }


### PR DESCRIPTION
Using `clap` to get a rich CLI experience. `streamling --help` now prints:

```
streamling --help
Streamling: Performant and extensible streaming data runtime

Usage: streamling [OPTIONS] [PIPELINE_FILE]

Arguments:
  [PIPELINE_FILE]  Pipeline definition file; overrides pipeline_definition_location from config

Options:
      --config <CONFIG>  Config file base name or path (.yaml/.yml/.json auto-detected) [default: config]
      --dry-run          Build and validate the pipeline without running it (no data is processed)
      --validate         Validate the pipeline definition (implies --dry-run). Emits JSON results
  -h, --help             Print help
  -V, --version          Print version
```

NOTE: by default, for compatibility reasons, just running `streamling` still attempts to run a pipeline at the location specified in the config.