### PR TITLE
feat(clickhouse): adaptive sort-key-range source pagination

### DIFF
--- a/crates/streamling-common/src/utils/dedup.rs
+++ b/crates/streamling-common/src/utils/dedup.rs
@@ -342,6 +342,7 @@ pub fn deduplicate_record_batches_by_version(
 
     deduplicate_record_batch_by_version(&concatenated, primary_key, version_column, tombstone)
 }
+
 /// Feed an array value at `index` into `hasher`. Used to bucket rows by their
 /// primary-key hash; equality is verified separately via `make_comparator` so
 /// `u64` hash collisions do not drop rows (STRM-5990).

--- a/crates/streamling-common/src/utils/dedup.rs
+++ b/crates/streamling-common/src/utils/dedup.rs
@@ -265,12 +265,23 @@ pub fn deduplicate_record_batch_by_version(
         let bucket = buckets.entry(hash).or_default();
         let mut updated = false;
         for entry in bucket.iter_mut() {
-            let (existing, _) = *entry;
+            let (existing, existing_is_tomb) = *entry;
             if pk_eq(existing, row_index) {
-                // Replace when the new row's version >= the current winner's.
-                // `>=` (existing is NOT greater) makes ties resolve to the later
-                // position, matching ReplacingMergeTree merges.
-                if !version_cmp(existing, row_index).is_gt() {
+                // Keep the higher version. On a tie, prefer the tombstone: a
+                // delete at the same version supersedes the live row, so the
+                // key is dropped — ReplacingMergeTree FINAL with an `is_deleted`
+                // flag. The scan has no ORDER BY, so without this the winner is
+                // order-dependent and a live row scanned after the delete
+                // survives, silently losing the deletion. When neither side is a
+                // tombstone (e.g. no tombstone rule), ties keep the later row,
+                // matching merge order.
+                let should_replace = match version_cmp(existing, row_index) {
+                    o if o.is_lt() => true,  // new row has the higher version
+                    o if o.is_gt() => false, // current winner has the higher version
+                    // tie: tombstone wins; if both/neither, later position wins
+                    _ => !existing_is_tomb || row_is_tomb,
+                };
+                if should_replace {
                     *entry = (row_index, row_is_tomb);
                 }
                 updated = true;
@@ -1535,6 +1546,63 @@ mod tests {
             .downcast_ref::<StringArray>()
             .unwrap();
         assert_eq!(op_col.value(0), "i");
+    }
+
+    #[test]
+    fn test_dedup_by_version_tie_prefers_tombstone() {
+        // id=1: a live row and a delete at the SAME version. A delete at the
+        // same version supersedes the live row (the row's final state is
+        // deleted), so the whole key must be dropped regardless of row order —
+        // ReplacingMergeTree FINAL with an `is_deleted` flag.
+        //
+        // Regression: the previous tiebreak kept the later-position row, so a
+        // live row scanned AFTER the delete survived and the deletion was
+        // silently lost. The scan has no ORDER BY, so this is order-dependent
+        // and intermittently drops deletes.
+        let tombstone = TombstoneRule {
+            column: "_gs_op".to_string(),
+            value: "d".to_string(),
+        };
+
+        // Order 1: delete first, then live.
+        let batch_del_first = create_versioned_batch(
+            vec![Some("1"), Some("1")],
+            vec![Some(10), Some(20)],
+            vec![Some(100), Some(100)],
+            vec![Some("d"), Some("i")],
+        );
+        let result_del_first = deduplicate_record_batch_by_version(
+            &batch_del_first,
+            "id",
+            "insert_timestamp",
+            Some(&tombstone),
+        )
+        .unwrap();
+        assert_eq!(
+            result_del_first.num_rows(),
+            0,
+            "tied delete must drop the key (delete-first order)"
+        );
+
+        // Order 2: live first, then delete.
+        let batch_live_first = create_versioned_batch(
+            vec![Some("1"), Some("1")],
+            vec![Some(10), Some(20)],
+            vec![Some(100), Some(100)],
+            vec![Some("i"), Some("d")],
+        );
+        let result_live_first = deduplicate_record_batch_by_version(
+            &batch_live_first,
+            "id",
+            "insert_timestamp",
+            Some(&tombstone),
+        )
+        .unwrap();
+        assert_eq!(
+            result_live_first.num_rows(),
+            0,
+            "tied delete must drop the key (live-first order)"
+        );
     }
 
     #[test]

--- a/crates/streamling-common/src/utils/dedup.rs
+++ b/crates/streamling-common/src/utils/dedup.rs
@@ -1,12 +1,14 @@
 use crate::error::{Result, ResultExt};
 use crate::{streamling_err, streamling_user_err};
-use arrow::array::{ArrayRef, Int64Array, make_comparator};
+use arrow::array::{ArrayRef, Int64Array, LargeStringArray, StringArray, make_comparator};
 use arrow::compute::SortOptions;
 use arrow::compute::concat_batches;
 use arrow::record_batch::RecordBatch;
+use arrow_schema::DataType;
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
+use std::sync::Arc;
 
 pub fn deduplicate_record_batch(batch: &RecordBatch, primary_key: &str) -> Result<RecordBatch> {
     if primary_key.is_empty() {
@@ -148,6 +150,198 @@ pub fn deduplicate_record_batches(
     deduplicate_record_batch(&concatenated, primary_key)
 }
 
+/// Tombstone detection for version-aware deduplication. A row is a tombstone
+/// when the Utf8/LargeUtf8 `column` equals `value`; if such a row is the
+/// max-version winner for its key, the key is dropped entirely, mirroring
+/// ReplacingMergeTree `FINAL` semantics.
+#[derive(Debug, Clone)]
+pub struct TombstoneRule {
+    pub column: String,
+    pub value: String,
+}
+
+/// Deduplicate a RecordBatch by `primary_key`, keeping the row with the maximum
+/// `version_column` value per key.
+///
+/// Unlike [`deduplicate_record_batch`] (which keeps the last row by position),
+/// this picks the winner by version, so it is correct for streams whose rows do
+/// not arrive in version order — e.g. a ClickHouse source scan that deliberately
+/// omits `ORDER BY`. Ties on `version_column` break by position (later wins),
+/// matching ReplacingMergeTree merge behaviour.
+///
+/// When `tombstone` is set, keys whose winning row is a tombstone are dropped
+/// entirely (ReplacingMergeTree `FINAL` semantics).
+pub fn deduplicate_record_batch_by_version(
+    batch: &RecordBatch,
+    primary_key: &str,
+    version_column: &str,
+    tombstone: Option<&TombstoneRule>,
+) -> Result<RecordBatch> {
+    if primary_key.is_empty() {
+        return Ok(batch.clone());
+    }
+
+    let primary_keys = crate::utils::parse_primary_key_columns(primary_key);
+
+    let pk_indices: Vec<usize> = primary_keys
+        .iter()
+        .map(|name| {
+            batch.schema().index_of(name).map_err(|_| {
+                streamling_user_err!("Primary key column '{}' not found in schema", name)
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if pk_indices.is_empty() {
+        return Ok(batch.clone());
+    }
+
+    let version_idx = batch.schema().index_of(version_column).map_err(|_| {
+        streamling_user_err!("Version column '{}' not found in schema", version_column)
+    })?;
+
+    let key_columns: Vec<ArrayRef> = pk_indices
+        .iter()
+        .map(|i| batch.column(*i).clone())
+        .collect();
+    let version_array = batch.column(version_idx).clone();
+
+    let pk_comparators: Vec<_> = key_columns
+        .iter()
+        .map(|col| make_comparator(col.as_ref(), col.as_ref(), SortOptions::default()))
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .streamling_context("failed to build primary key comparator for dedup")?;
+    let pk_eq = |i: usize, j: usize| -> bool { pk_comparators.iter().all(|cmp| cmp(i, j).is_eq()) };
+
+    let version_cmp = make_comparator(
+        version_array.as_ref(),
+        version_array.as_ref(),
+        SortOptions::default(),
+    )
+    .streamling_context("failed to build version comparator for dedup")?;
+
+    // Tombstone: row matches when `tombstone_column[row] == value`. Build a
+    // single-element literal array of the column's own type so the comparison
+    // is type-safe without a per-row ScalarValue allocation.
+    let tombstone_cmp = match tombstone {
+        Some(rule) => match batch.schema().index_of(&rule.column) {
+            Ok(idx) => {
+                let col = batch.column(idx);
+                let value_arr: ArrayRef = match col.data_type() {
+                    DataType::Utf8 => Arc::new(StringArray::from(vec![Some(rule.value.as_str())])),
+                    DataType::LargeUtf8 => {
+                        Arc::new(LargeStringArray::from(vec![Some(rule.value.as_str())]))
+                    }
+                    other => {
+                        return Err(streamling_user_err!(
+                            "Tombstone column '{}' must be Utf8 or LargeUtf8, got {:?}",
+                            rule.column,
+                            other
+                        ));
+                    }
+                };
+                let cmp = make_comparator(col.as_ref(), value_arr.as_ref(), SortOptions::default())
+                    .streamling_context("failed to build tombstone comparator for dedup")?;
+                Some(cmp)
+            }
+            Err(_) => None,
+        },
+        None => None,
+    };
+    let is_tombstone = |row: usize| tombstone_cmp.as_ref().is_some_and(|c| c(row, 0).is_eq());
+
+    // Bucket winning row index (and whether it is a tombstone) per primary-key
+    // hash. Collisions are resolved by real PK equality, same as
+    // `deduplicate_record_batch` (STRM-5990).
+    let mut buckets: HashMap<u64, Vec<(usize, bool)>> = HashMap::with_capacity(batch.num_rows());
+
+    for row_index in 0..batch.num_rows() {
+        let mut hasher = DefaultHasher::new();
+        for col in &key_columns {
+            hash_array_value(&mut hasher, col, row_index);
+        }
+        let hash = hasher.finish();
+        let row_is_tomb = is_tombstone(row_index);
+
+        let bucket = buckets.entry(hash).or_default();
+        let mut updated = false;
+        for entry in bucket.iter_mut() {
+            let (existing, _) = *entry;
+            if pk_eq(existing, row_index) {
+                // Replace when the new row's version >= the current winner's.
+                // `>=` (existing is NOT greater) makes ties resolve to the later
+                // position, matching ReplacingMergeTree merges.
+                if !version_cmp(existing, row_index).is_gt() {
+                    *entry = (row_index, row_is_tomb);
+                }
+                updated = true;
+                break;
+            }
+        }
+        if !updated {
+            bucket.push((row_index, row_is_tomb));
+        }
+    }
+
+    // Survivors in original ascending order; drop tombstoned keys entirely.
+    let mut unique_indices: Vec<i64> = buckets
+        .into_values()
+        .flatten()
+        .filter(|(_, is_tomb)| !is_tomb)
+        .map(|(row, _)| row as i64)
+        .collect();
+    unique_indices.sort_unstable();
+    let indices_array = Int64Array::from(unique_indices);
+
+    let unique_columns: Vec<ArrayRef> = batch
+        .columns()
+        .iter()
+        .map(|col| {
+            crate::utils::arrow::safe_take(col, &indices_array)
+                .streamling_context("failed to take unique rows from column")
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let new_schema = crate::utils::arrow::build_schema_from_columns(
+        &batch.schema(),
+        &unique_columns,
+        batch.schema().metadata().clone(),
+    );
+
+    let unique_batch = RecordBatch::try_new(new_schema, unique_columns)
+        .streamling_context("failed to create deduplicated batch")?;
+
+    Ok(unique_batch)
+}
+
+/// Deduplicate across multiple RecordBatches by version, keeping the max-version
+/// row per primary key. Concatenates the batches first, so duplicates that
+/// straddle batch boundaries (common when a page is split into multiple IPC
+/// blocks) are collapsed correctly.
+pub fn deduplicate_record_batches_by_version(
+    batches: &[RecordBatch],
+    primary_key: &str,
+    version_column: &str,
+    tombstone: Option<&TombstoneRule>,
+) -> Result<RecordBatch> {
+    if batches.is_empty() {
+        return Err(streamling_err!("Cannot deduplicate empty batch list"));
+    }
+
+    if batches.len() == 1 {
+        return deduplicate_record_batch_by_version(
+            &batches[0],
+            primary_key,
+            version_column,
+            tombstone,
+        );
+    }
+
+    let schema = batches[0].schema();
+    let concatenated = concat_batches(&schema, batches.iter())
+        .streamling_context("failed to concatenate batches for dedup")?;
+
+    deduplicate_record_batch_by_version(&concatenated, primary_key, version_column, tombstone)
+}
 /// Feed an array value at `index` into `hasher`. Used to bucket rows by their
 /// primary-key hash; equality is verified separately via `make_comparator` so
 /// `u64` hash collisions do not drop rows (STRM-5990).
@@ -1221,5 +1415,177 @@ mod tests {
         // id=a appears twice; latest occurrence (value=3) wins.
         assert_eq!(row_for("a"), 3);
         assert_eq!(row_for("b"), 2);
+    }
+    fn create_versioned_batch(
+        id_values: Vec<Option<&str>>,
+        value_values: Vec<Option<i64>>,
+        version_values: Vec<Option<i64>>,
+        op_values: Vec<Option<&str>>,
+    ) -> RecordBatch {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Utf8, true),
+            Field::new("value", DataType::Int64, true),
+            Field::new("insert_timestamp", DataType::Int64, true),
+            Field::new("_gs_op", DataType::Utf8, true),
+        ]);
+        let id_array: ArrayRef = Arc::new(StringArray::from(id_values));
+        let value_array: ArrayRef = Arc::new(Int64Array::from(value_values));
+        let version_array: ArrayRef = Arc::new(Int64Array::from(version_values));
+        let op_array: ArrayRef = Arc::new(StringArray::from(op_values));
+        RecordBatch::try_new(
+            Arc::new(schema),
+            vec![id_array, value_array, version_array, op_array],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_dedup_by_version_keeps_max_version_not_position() {
+        // id=1 appears twice; the EARLIER row has the HIGHER version.
+        // Position-based dedup would wrongly keep row 1; version-aware keeps row 0.
+        let batch = create_versioned_batch(
+            vec![Some("1"), Some("1")],
+            vec![Some(10), Some(20)],
+            vec![Some(100), Some(50)],
+            vec![Some("i"), Some("i")],
+        );
+        let result =
+            deduplicate_record_batch_by_version(&batch, "id", "insert_timestamp", None).unwrap();
+        assert_eq!(result.num_rows(), 1);
+        let value_col = result
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(
+            value_col.value(0),
+            10,
+            "max-version row (value=10) must win"
+        );
+    }
+
+    #[test]
+    fn test_dedup_by_version_tie_keeps_later_position() {
+        // Equal versions: later position wins (ReplacingMergeTree merge order).
+        let batch = create_versioned_batch(
+            vec![Some("1"), Some("1")],
+            vec![Some(10), Some(20)],
+            vec![Some(100), Some(100)],
+            vec![Some("i"), Some("i")],
+        );
+        let result =
+            deduplicate_record_batch_by_version(&batch, "id", "insert_timestamp", None).unwrap();
+        assert_eq!(result.num_rows(), 1);
+        let value_col = result
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(value_col.value(0), 20);
+    }
+
+    #[test]
+    fn test_dedup_by_version_tombstone_drops_key_when_winner() {
+        // id=1: live insert (version 100) then a delete (version 200). The
+        // delete is the max-version winner -> the whole key is dropped (FINAL).
+        let batch = create_versioned_batch(
+            vec![Some("1"), Some("1"), Some("2")],
+            vec![Some(10), Some(20), Some(30)],
+            vec![Some(100), Some(200), Some(50)],
+            vec![Some("i"), Some("d"), Some("i")],
+        );
+        let tombstone = TombstoneRule {
+            column: "_gs_op".to_string(),
+            value: "d".to_string(),
+        };
+        let result =
+            deduplicate_record_batch_by_version(&batch, "id", "insert_timestamp", Some(&tombstone))
+                .unwrap();
+        assert_eq!(result.num_rows(), 1);
+        let id_col = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(id_col.value(0), "2", "tombstoned id=1 must be dropped");
+    }
+
+    #[test]
+    fn test_dedup_by_version_tombstone_kept_when_not_winner() {
+        // id=1: delete (version 50) then live insert (version 200). The delete
+        // is NOT the winner -> key survives with the live row.
+        let batch = create_versioned_batch(
+            vec![Some("1"), Some("1")],
+            vec![Some(10), Some(20)],
+            vec![Some(50), Some(200)],
+            vec![Some("d"), Some("i")],
+        );
+        let tombstone = TombstoneRule {
+            column: "_gs_op".to_string(),
+            value: "d".to_string(),
+        };
+        let result =
+            deduplicate_record_batch_by_version(&batch, "id", "insert_timestamp", Some(&tombstone))
+                .unwrap();
+        assert_eq!(result.num_rows(), 1);
+        let op_col = result
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(op_col.value(0), "i");
+    }
+
+    #[test]
+    fn test_dedup_by_version_missing_version_column_errors() {
+        let batch = create_versioned_batch(
+            vec![Some("1")],
+            vec![Some(10)],
+            vec![Some(100)],
+            vec![Some("i")],
+        );
+        let result = deduplicate_record_batch_by_version(&batch, "id", "nope", None);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Version column 'nope' not found")
+        );
+    }
+
+    #[test]
+    fn test_dedup_by_version_across_batches() {
+        // Same key split across two batches; the higher version lives in batch 1.
+        let batch1 = create_versioned_batch(
+            vec![Some("1")],
+            vec![Some(10)],
+            vec![Some(300)],
+            vec![Some("i")],
+        );
+        let batch2 = create_versioned_batch(
+            vec![Some("1")],
+            vec![Some(20)],
+            vec![Some(100)],
+            vec![Some("i")],
+        );
+        let result = deduplicate_record_batches_by_version(
+            &[batch1, batch2],
+            "id",
+            "insert_timestamp",
+            None,
+        )
+        .unwrap();
+        assert_eq!(result.num_rows(), 1);
+        let value_col = result
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(
+            value_col.value(0),
+            10,
+            "max-version (batch1, value=10) must win"
+        );
     }
 }

--- a/crates/streamling-config/src/app_config.rs
+++ b/crates/streamling-config/src/app_config.rs
@@ -382,7 +382,7 @@ pub struct ClickHouseSourceConfig {
     /// Limits scan width to prevent timeouts on large tables. Automatically halved on timeout.
     /// Only applies when the first sorting key is a numeric type.
     /// Default: 1,000,000
-    pub block_range: Option<i64>,
+    pub sort_key_range: Option<i64>,
 }
 
 pub type ClickHouseSinkConfig = ClickHouseConfig;

--- a/crates/streamling-config/src/app_config.rs
+++ b/crates/streamling-config/src/app_config.rs
@@ -382,6 +382,7 @@ pub struct ClickHouseSourceConfig {
     /// Limits scan width to prevent timeouts on large tables. Automatically halved on timeout.
     /// Only applies when the first sorting key is a numeric type.
     /// Default: 1,000,000
+    #[serde(alias = "block_range")]
     pub sort_key_range: Option<i64>,
 }
 

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -74,7 +74,9 @@ static CLICKHOUSE_ERROR_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"Code: \d+\. \w+::\w*Exception:").unwrap());
 
 mod query_builder;
+mod range_controller;
 use query_builder::{ClickHousePaginationConfig, ClickHouseQueryBuilder};
+use range_controller::RangeController;
 
 fn scalar_to_i128(value: &ScalarValue) -> Option<i128> {
     match value {
@@ -102,7 +104,7 @@ fn i128_to_scalar_like(value: i128, template: &ScalarValue) -> ScalarValue {
         ScalarValue::UInt32(_) => ScalarValue::UInt32(Some(value as u32)),
         ScalarValue::UInt64(_) => ScalarValue::UInt64(Some(value as u64)),
         other => panic!(
-            "unsupported scalar type for block range arithmetic: {:?}",
+            "unsupported scalar type for sort key range arithmetic: {:?}",
             other
         ),
     }
@@ -130,7 +132,7 @@ struct SourceParams {
     initial_split_args: Vec<ScalarValue>,
     state_store: Arc<ClickHouseSourceStateStore>,
     datafusion_buffer_size: usize,
-    block_range: i64,
+    sort_key_range: i64,
     table_name: String,
     has_persisted_split: bool,
 }
@@ -151,9 +153,9 @@ struct SinkParams {
 }
 
 impl ClickHouseTableProvider {
-    const DEFAULT_BLOCK_RANGE: i64 = 1_000_000;
+    const DEFAULT_SORT_KEY_RANGE: i64 = 1_000_000;
     const DEFAULT_PAGE_SIZE: usize = 10_000_000;
-    const MIN_BLOCK_RANGE: i64 = 100;
+    const MIN_SORT_KEY_RANGE: i64 = 100;
     const SOURCE_QUERY_TIMEOUT_SECS: u64 = 60;
 
     pub fn new_source(
@@ -169,7 +171,7 @@ impl ClickHouseTableProvider {
     ) -> Result<Self, DataFusionError> {
         let database_name = config.connection.database.clone();
         let page_size = config.page_size.unwrap_or(Self::DEFAULT_PAGE_SIZE);
-        let block_range_config = config.block_range;
+        let sort_key_range_config = config.sort_key_range;
         let client = ClickHouseClient::new(config.connection.clone());
 
         let columns_copy = columns.clone();
@@ -203,9 +205,9 @@ impl ClickHouseTableProvider {
             page_size,
         };
 
-        // Require a wide numeric first sorting key for block range pagination.
+        // Require a wide numeric first sorting key for sort key range pagination.
         // Narrow types (Int8, UInt8, Int16, UInt16) would silently overflow in
-        // i128_to_scalar_like when computing block range boundaries.
+        // i128_to_scalar_like when computing sort key range boundaries.
         let first_key_name = sorting_keys.first().unwrap();
         let first_key_type = schema
             .field_with_name(first_key_name)
@@ -222,20 +224,20 @@ impl ClickHouseTableProvider {
 
         if !is_wide_integer {
             return Err(streamling_err!(
-                "ClickHouse source requires a 32-bit or wider integer first sorting key for block range \
+                "ClickHouse source requires a 32-bit or wider integer first sorting key for sort key range \
                  pagination, but '{}' on table {}.{} has type {:?}",
                 first_key_name, database_name, table_name, first_key_type
             )
             .into());
         }
 
-        let block_range = block_range_config
-            .map(|br| br.max(Self::MIN_BLOCK_RANGE))
-            .unwrap_or(Self::DEFAULT_BLOCK_RANGE);
+        let sort_key_range = sort_key_range_config
+            .map(|br| br.max(Self::MIN_SORT_KEY_RANGE))
+            .unwrap_or(Self::DEFAULT_SORT_KEY_RANGE);
 
         info!(
-            "[{}] block range pagination configured (block_range={}, page_size={})",
-            reference_name, block_range, page_size
+            "[{}] sort key range pagination configured (sort_key_range={}, page_size={})",
+            reference_name, sort_key_range, page_size
         );
 
         let mut query_builder = ClickHouseQueryBuilder::of(
@@ -285,7 +287,7 @@ impl ClickHouseTableProvider {
             initial_split_args,
             state_store,
             datafusion_buffer_size,
-            block_range,
+            sort_key_range,
             table_name: table_name.to_string(),
             has_persisted_split,
         };
@@ -999,10 +1001,11 @@ impl ExecutionPlan for ClickHouseSourceExec {
             .pagination_config()
             .expect("pagination config must be set")
             .page_size;
-        let sorting_keys = self.split.sorting_keys.clone();
-        let default_block_range = source_params.block_range;
+        let default_sort_key_range = source_params.sort_key_range;
         let table_name_for_exec = source_params.table_name.clone();
-        let first_sorting_key_name = sorting_keys
+        let first_sorting_key_name = self
+            .split
+            .sorting_keys
             .first()
             .cloned()
             .expect("sorting keys must not be empty");
@@ -1080,14 +1083,6 @@ impl ExecutionPlan for ClickHouseSourceExec {
 
             debug!("Starting ClickHouse execution with continuous pagination");
 
-            struct BlockRangeState {
-                block_range: i128,
-                default_block_range: i128,
-                max_key: i128,
-                range_start: i128,
-                template: ScalarValue,
-            }
-
             let max_val = client
                 .fetch_max_sorting_key(&table_name_for_exec, &first_sorting_key_name)
                 .await
@@ -1098,51 +1093,117 @@ impl ExecutionPlan for ClickHouseSourceExec {
                 .map_err(DataFusionError::from)?;
             // When the table is empty, SELECT max(first_key) returns NULL. In that case
             // scalar_to_i128 returns None; treat this as "no rows to scan" by defaulting to 0,
-            // so the pagination loop will immediately terminate (next_start > max_key).
+            // so the pagination loop terminates immediately (range_start > max_key).
             let max_key = scalar_to_i128(&max_val).unwrap_or(0);
 
-            let initial_keyset = {
+            // The persisted cursor (split.args) holds [range_start] — the start of the
+            // range to resume from. Ranges are disjoint half-open block_number windows,
+            // so restarting at range_start re-reads at most the in-progress range
+            // (at-least-once, covered by downstream dedup).
+            // Resume from the persisted cursor. Only the first sorting key matters;
+            // see ClickHouseSourceSplit::range_start for checkpoint compatibility.
+            let range_start = {
                 let guard = split.lock().unwrap();
-                if !guard.args.is_empty() { Some(guard.args.clone()) } else { None }
+                guard.range_start().unwrap_or(0)
             };
-            let range_start = initial_keyset.as_ref()
-                .and_then(|ks| ks.first().and_then(scalar_to_i128))
-                .unwrap_or(0);
             let template = i128_to_scalar_like(0, &max_val);
 
-            let default_block_range = default_block_range as i128;
-            let upper = i128_to_scalar_like(range_start + default_block_range, &template);
-            query_builder.set_block_range_upper_bound(Some(upper));
+            let default_sort_key_range = default_sort_key_range as i128;
+            // Let width grow well past the default for sparse filters: cap at the
+            // remaining span so an ultra-sparse table can be covered in few queries.
+            // The page_size + 1 tripwire still shrinks a too-dense range. The lower
+            // floor (one key) lives in RangeController; see RangeController::MIN_WIDTH.
+            let max_width = (max_key - range_start).max(default_sort_key_range);
 
-            info!(
-                "[{}] block range pagination enabled (block_range={}, max_key={}, start={})",
-                reference_name, default_block_range, max_key, range_start
-            );
-            let mut block_state = BlockRangeState {
-                block_range: default_block_range,
-                default_block_range,
-                max_key,
-                range_start,
-                template,
+            let source_query_timeout =
+                Duration::from_secs(ClickHouseTableProvider::SOURCE_QUERY_TIMEOUT_SECS);
+            // Shrink proactively at half the hard timeout, before the query is killed.
+            let soft_time_budget = source_query_timeout / 2;
+
+            // Up-front count probe: size the first range to ~page_size rows from the
+            // observed density over the remaining span. A probe failure is non-fatal —
+            // fall back to the widest range and let the controller adapt.
+            let where_clause_for_exec = query_builder.where_clause().map(|s| s.to_string());
+            let scan_span = (max_key - range_start + 1).max(1);
+            let total_count = match client
+                .fetch_count(
+                    &table_name_for_exec,
+                    where_clause_for_exec.as_deref(),
+                    Some(range_start),
+                    &first_sorting_key_name,
+                )
+                .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!("[{}] count probe failed ({}); using widest initial range", reference_name, e);
+                    0
+                }
+            };
+            let initial_width = if total_count == 0 {
+                max_width
+            } else {
+                // RangeController clamps this into [MIN_WIDTH, max_width].
+                let density = total_count as f64 / scan_span as f64;
+                (page_size as f64 / density) as i128
             };
 
-            let mut has_more_data = true;
+            let mut controller = RangeController::new(
+                page_size as u64,
+                range_start,
+                max_key,
+                initial_width,
+                max_width,
+                soft_time_budget,
+            );
+            info!(
+                "[{}] adaptive range pagination (max_key={}, start={}, count={}, initial_width={}, page_size={})",
+                reference_name, max_key, range_start, total_count, controller.width(), page_size
+            );
+
             let mut page_count = 0;
             let mut query_retry_attempts: u32 = 0;
             let mut query_retry_backoff_ms: u64 = 100;
 
-            let source_query_timeout = Duration::from_secs(ClickHouseTableProvider::SOURCE_QUERY_TIMEOUT_SECS);
-            let recovery_threshold = source_query_timeout / 4;
+            // Attach any buffered checkpoint messages to a batch about to be emitted.
+            // Clears the buffer after attaching, so messages ride exactly one batch.
+            let attach_checkpoints = {
+                let buffer_arc = checkpoint_buffer_for_data.clone();
+                move |batch: RecordBatch| -> RecordBatch {
+                    let mut buffer = buffer_arc.lock().unwrap();
+                    if buffer.is_empty() {
+                        return batch;
+                    }
+                    debug!("Attaching {} buffered checkpoint messages to batch", buffer.len());
+                    let mut metadata = batch.schema().metadata().clone();
+                    enrich_batch_metadata_with_checkpoints(&mut metadata, &buffer);
+                    let enriched = enrich_batch_with_metadata(batch, metadata)
+                        .expect("Failed to enrich batch with checkpoint metadata");
+                    buffer.clear();
+                    enriched
+                }
+            };
 
-            while has_more_data {
+            while !controller.is_done() {
                 page_count += 1;
+                let (range_start, upper_bound) = controller.current_range();
+                query_builder
+                    .set_sort_key_range_upper_bound(Some(i128_to_scalar_like(upper_bound, &template)));
+                query_builder.start_at_page(vec![i128_to_scalar_like(range_start, &template)]);
                 let current_query = query_builder.get_query();
-                trace!("ClickHouseSourceExec: executing page {} with query: {}", page_count, current_query);
+                trace!(
+                    "ClickHouseSourceExec: page {} range [{}, {}) width {} query: {}",
+                    page_count, range_start, upper_bound, controller.width(), current_query
+                );
 
                 let page_start = std::time::Instant::now();
+                // LIMIT page_size + 1 is a tripwire, not a cursor: page_size + 1 rows
+                // means the range overflowed and must be re-read smaller. run() buffers
+                // the whole response before we emit, so an overflow is discarded with no
+                // duplicates.
                 let run_result = tokio::time::timeout(
                     source_query_timeout,
-                    Self::run(client.clone(), current_query, Some(page_size)),
+                    Self::run(client.clone(), current_query, Some(page_size + 1)),
                 ).await;
 
                 let run_result = match run_result {
@@ -1159,148 +1220,109 @@ impl ExecutionPlan for ClickHouseSourceExec {
                     Ok(mut stream) => {
                         query_retry_attempts = 0;
                         query_retry_backoff_ms = 100;
-                        let mut batch_count = 0;
-                        let mut total_rows_in_page = 0;
-                        let mut last_batch_keyset: Option<Vec<ScalarValue>> = None;
 
+                        // Buffer the whole page before emitting so the overflow tripwire
+                        // can discard a too-dense range without sending duplicates. The
+                        // response is already fully in memory inside run(), so this only
+                        // holds parsed batches, bounded by page_size + 1 rows.
+                        let mut batches: Vec<RecordBatch> = Vec::new();
+                        let mut total_rows_in_page: usize = 0;
+                        let mut stream_failed = false;
                         while let Some(item_result) = stream.next().await {
                             match item_result {
                                 Ok(batch) => {
-                                    batch_count += 1;
                                     total_rows_in_page += batch.num_rows();
-
-                                    let args = match Self::extract_keyset_from_batch(&batch, &sorting_keys) {
-                                        Ok(keyset_values) => keyset_values,
-                                        Err(e) => {
-                                            error!("Failed to extract keyset from batch: {}", e);
-                                            let df_error: DataFusionError = e.into();
-                                            if tx.send(Err(df_error)).await.is_err() {
-                                                warn!("ClickHouseSourceExec: receiver dropped");
-                                            }
-                                            has_more_data = false;
-                                            break;
-                                        }
-                                    };
-
-                                    last_batch_keyset = Some(args.clone());
-
-                                    let enriched_batch = {
-                                        let mut buffer = checkpoint_buffer_for_data.lock().unwrap();
-                                        if !buffer.is_empty() {
-                                            debug!("Attaching {} buffered checkpoint messages to batch", buffer.len());
-                                            let mut metadata = batch.schema().metadata().clone();
-                                            enrich_batch_metadata_with_checkpoints(&mut metadata, &buffer);
-                                            let enriched = enrich_batch_with_metadata(batch, metadata)
-                                                .expect("Failed to enrich batch with checkpoint metadata");
-                                            buffer.clear();
-                                            enriched
-                                        } else {
-                                            batch
-                                        }
-                                    };
-
-                                    if tx.send(Ok(enriched_batch)).await.is_err() {
-                                        warn!("ClickHouseSourceExec: receiver dropped during batch {} of page {}", batch_count, page_count);
-                                        has_more_data = false;
-                                        break;
-                                    } else {
-                                        if let Ok(mut split_guard) = split.lock() {
-                                            split_guard.update_args(args.clone());
-                                        }
-                                        trace!("ClickHouseSourceExec: batch {} completed successfully", batch_count);
-                                    }
+                                    batches.push(batch);
                                 }
                                 Err(e) => {
                                     error!("Error processing ClickHouse batch: {}", e);
                                     if tx.send(Err(DataFusionError::ArrowError(Box::new(e), None))).await.is_err() {
                                         warn!("ClickHouseSourceExec: receiver dropped while sending error");
                                     }
-                                    has_more_data = false;
+                                    stream_failed = true;
                                     break;
                                 }
                             }
                         }
-
-                        trace!("ClickHouseSourceExec: page {} summary - total_rows: {}, page_size: {}, batch_count: {}", page_count, total_rows_in_page, page_size, batch_count);
-
-                        // Emit an empty batch on empty scans so downstream operators
-                        // still receive a batch and buffered checkpoint messages can flow.
-                        if total_rows_in_page == 0 {
-                            let empty_batch = {
-                                let batch = RecordBatch::new_empty(empty_batch_schema.clone());
-                                let mut buffer = checkpoint_buffer_for_data.lock().unwrap();
-                                if !buffer.is_empty() {
-                                    debug!("Attaching {} buffered checkpoint messages to empty batch", buffer.len());
-                                    let mut metadata = batch.schema().metadata().clone();
-                                    enrich_batch_metadata_with_checkpoints(&mut metadata, &buffer);
-                                    let enriched = enrich_batch_with_metadata(batch, metadata)
-                                        .expect("Failed to enrich empty batch with checkpoint metadata");
-                                    buffer.clear();
-                                    enriched
-                                } else {
-                                    batch
-                                }
-                            };
-                            info!("[{}] empty scan on block range [{}, {})",
-                                reference_name, block_state.range_start, block_state.range_start + block_state.block_range);
-                            if tx.send(Ok(empty_batch)).await.is_err() {
-                                warn!("ClickHouseSourceExec: receiver dropped while sending empty batch");
-                                has_more_data = false;
-                                continue;
-                            }
+                        if stream_failed {
+                            break;
                         }
 
-                        let page_exhausted = total_rows_in_page < page_size;
+                        trace!("ClickHouseSourceExec: page {} read {} rows (page_size {})", page_count, total_rows_in_page, page_size);
 
-                        if page_exhausted {
-                            let next_start = block_state.range_start + block_state.block_range;
-                            if next_start > block_state.max_key {
-                                has_more_data = false;
-                                info!("[{}] scanned past max_key {} — done", reference_name, block_state.max_key);
-                            } else {
-                                block_state.range_start = next_start;
+                        // Overflow: the range holds more than page_size rows. Shrink and
+                        // re-read the SAME range. Nothing was emitted, so no duplicates
+                        // and no advance.
+                        if total_rows_in_page > page_size {
+                            if controller.at_min_width() {
+                                // A min-width range still overflows: a single key holds more
+                                // than page_size matching rows and cannot be split further.
+                                // Surface it rather than silently skip data.
+                                let _ = tx.send(Err(DataFusionError::from(streamling_core::streamling_err!(
+                                    "ClickHouse source: range [{}, {}) at min width still exceeds page_size {} ({} rows); increase page_size",
+                                    range_start, upper_bound, page_size, total_rows_in_page
+                                )))).await;
+                                break;
+                            }
+                            controller.on_overflow(None);
+                            info!(
+                                "[{}] range [{}, {}) overflowed page_size {} ({} rows); width -> {}",
+                                reference_name, range_start, upper_bound, page_size, total_rows_in_page, controller.width()
+                            );
+                            page_count -= 1;
+                            continue;
+                        }
 
-                                let page_elapsed = page_start.elapsed();
-                                if block_state.block_range < block_state.default_block_range
-                                    && page_elapsed < recovery_threshold
-                                {
-                                    block_state.block_range = (block_state.block_range * 2).min(block_state.default_block_range);
-                                    info!("[{}] recovering block range to {} (page took {:?})", reference_name, block_state.block_range, page_elapsed);
-                                }
-
-                                let upper = i128_to_scalar_like(next_start + block_state.block_range, &block_state.template);
-                                query_builder.set_block_range_upper_bound(Some(upper));
-                                let start_val = i128_to_scalar_like(next_start, &block_state.template);
-                                query_builder.start_at_page(vec![start_val]);
-
-                                info!("[{}] advancing to next block range [{}, {})", reference_name, next_start, next_start + block_state.block_range);
+                        // Complete page. Emit all buffered batches, emitting one empty
+                        // batch for an empty scan so buffered checkpoint messages flow.
+                        let mut receiver_dropped = false;
+                        if total_rows_in_page == 0 {
+                            info!("[{}] empty scan on range [{}, {})", reference_name, range_start, upper_bound);
+                            let empty_batch = attach_checkpoints(RecordBatch::new_empty(empty_batch_schema.clone()));
+                            if tx.send(Ok(empty_batch)).await.is_err() {
+                                receiver_dropped = true;
                             }
                         } else {
-                            // More rows in this range — continue keyset pagination
-                            if let Some(keyset) = last_batch_keyset {
-                                query_builder.update_keyset(keyset);
-                            } else {
-                                has_more_data = false;
+                            for batch in batches.into_iter() {
+                                let batch = attach_checkpoints(batch);
+                                if tx.send(Ok(batch)).await.is_err() {
+                                    receiver_dropped = true;
+                                    break;
+                                }
                             }
                         }
+                        if receiver_dropped {
+                            warn!("ClickHouseSourceExec: receiver dropped during page {}", page_count);
+                            break;
+                        }
 
-                        trace!("ClickHouseSourceExec: done reading page {} (batches: {}, has_more: {})", page_count, batch_count, has_more_data);
+                        // Completed range: advance the cursor and persist it. on_complete
+                        // moves range_start past this range; the while condition (is_done)
+                        // ends the scan once the cursor passes max_key. On restart we re-read
+                        // from the persisted cursor.
+                        let page_elapsed = page_start.elapsed();
+                        controller.on_complete(total_rows_in_page, page_elapsed);
+                        if let Ok(mut split_guard) = split.lock() {
+                            split_guard.update_args(vec![i128_to_scalar_like(controller.range_start(), &template)]);
+                        }
+                        if controller.is_done() {
+                            info!("[{}] scanned past max_key {} — done", reference_name, max_key);
+                        } else {
+                            trace!(
+                                "[{}] advanced to [{}, {}) ({} rows in {:?})",
+                                reference_name, controller.range_start(), controller.current_range().1, total_rows_in_page, page_elapsed
+                            );
+                        }
                     }
                     Err(df_error) => {
                         if is_timeout_error(&df_error) {
-                            let old_br = block_state.block_range;
-                            block_state.block_range = (block_state.block_range / 2).max(ClickHouseTableProvider::MIN_BLOCK_RANGE as i128);
+                            let old_width = controller.width();
+                            // Too slow: shrink and re-read the same range (no advance).
+                            controller.on_timeout();
                             warn!(
-                                "[{}] timeout on page {}; reducing block range {} -> {}",
-                                reference_name, page_count, old_br, block_state.block_range
+                                "[{}] timeout on page {}; reducing width {} -> {}",
+                                reference_name, page_count, old_width, controller.width()
                             );
-                            let upper = i128_to_scalar_like(block_state.range_start + block_state.block_range, &block_state.template);
-                            query_builder.set_block_range_upper_bound(Some(upper));
-                            // Reset keyset to retry from the start of the current block range,
-                            // otherwise the stale keyset can contradict the new upper bound.
-                            let start_val = i128_to_scalar_like(block_state.range_start, &block_state.template);
-                            query_builder.start_at_page(vec![start_val]);
-
                             page_count -= 1;
                             tokio::time::sleep(Duration::from_millis(1_000)).await;
                             continue;
@@ -1696,6 +1718,47 @@ impl ClickHouseClient {
         let max_val = ScalarValue::try_from_array(&batch.column(0), 0)
             .streamling_context("failed to extract max sorting key value")?;
         Ok(max_val)
+    }
+
+    /// Count rows matching the source filter at or above `lower_bound` on the
+    /// first sorting key. Used as an up-front density probe to size the first
+    /// pagination range. Carries no ORDER BY, so a matching projection serves it
+    /// cheaply; a slow probe is itself a signal that the filter is scan-bound.
+    pub async fn fetch_count(
+        &self,
+        table_name: &str,
+        where_clause: Option<&str>,
+        lower_bound: Option<i128>,
+        first_key: &str,
+    ) -> streamling_core::error::Result<u64> {
+        let mut conditions: Vec<String> = Vec::new();
+        if let Some(w) = where_clause {
+            conditions.push(format!("({})", w));
+        }
+        if let Some(lb) = lower_bound {
+            conditions.push(format!("{} >= {}", first_key, lb));
+        }
+        let where_sql = if conditions.is_empty() {
+            String::new()
+        } else {
+            format!(" WHERE {}", conditions.join(" AND "))
+        };
+        let query = format!(
+            "SELECT count() FROM {}{} FORMAT Arrow",
+            table_name, where_sql
+        );
+        let response_result = self.send_query(reqwest::Method::GET, query.as_str()).await;
+        let response_bytes = self
+            .process_http_response(response_result, query.as_str(), "count")
+            .await?;
+
+        let mut reader = self.create_arrow_reader(response_bytes, &query)?;
+        let batch = reader
+            .next()
+            .ok_or_else(|| streamling_err!("no rows returned for count query"))??;
+        let scalar = ScalarValue::try_from_array(&batch.column(0), 0)
+            .streamling_context("failed to extract count value")?;
+        Ok(scalar_to_i128(&scalar).unwrap_or(0).max(0) as u64)
     }
 
     /// Normalize schema for ClickHouse Arrow IPC: convert view types to standard types
@@ -2331,6 +2394,41 @@ impl ClickHouseClient {
 mod tests {
     use super::*;
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+
+    #[test]
+    fn split_range_start_reads_first_sorting_key() {
+        // New-format checkpoint stores [range_start].
+        let split = ClickHouseSourceSplit {
+            sorting_keys: vec!["block_number".to_string(), "id".to_string()],
+            args: vec![ScalarValue::Int64(Some(1000))],
+        };
+        assert_eq!(split.range_start(), Some(1000));
+    }
+
+    #[test]
+    fn split_range_start_is_backwards_compatible_with_full_keyset() {
+        // Checkpoints written before sort-key-range pagination stored the full
+        // last-row keyset. The new code must resume at the first sorting key,
+        // re-reading from there rather than skipping rows.
+        let old_split = ClickHouseSourceSplit {
+            sorting_keys: vec!["block_number".to_string(), "id".to_string()],
+            args: vec![ScalarValue::Int64(Some(1000)), ScalarValue::Int64(Some(50))],
+        };
+        assert_eq!(
+            old_split.range_start(),
+            Some(1000),
+            "old full-keyset checkpoint must resume at the first sorting key"
+        );
+    }
+
+    #[test]
+    fn split_range_start_empty_is_none() {
+        let split = ClickHouseSourceSplit {
+            sorting_keys: vec![],
+            args: vec![],
+        };
+        assert_eq!(split.range_start(), None);
+    }
 
     #[test]
     fn test_schema_normalization() {
@@ -3251,7 +3349,7 @@ mod tests {
                 initial_split_args: initial_split_args.clone(),
                 state_store,
                 datafusion_buffer_size: 16,
-                block_range: 1_000_000,
+                sort_key_range: 1_000_000,
                 table_name: "test_table".to_string(),
                 has_persisted_split: false,
             }),
@@ -3673,6 +3771,20 @@ impl ClickHouseSourceSplit {
     pub fn update_args(&mut self, args: Vec<ScalarValue>) {
         self.args = args;
     }
+
+    /// The first sorting-key value to resume scanning from, or `None` if no cursor
+    /// has been persisted yet.
+    ///
+    /// Only `args[0]` is read. Checkpoints written before sort-key-range pagination
+    /// stored the full last-row keyset `[k0, k1, ...]`; current ones store just
+    /// `[range_start]`. `args[0]` is the first sorting key in both, so an older
+    /// checkpoint resumes at that key and re-reads from there (at-least-once,
+    /// covered by downstream dedup) rather than skipping rows. Keep the persisted
+    /// format (`Vec<ScalarValue>`) and the state-store VERSION stable so existing
+    /// checkpoints stay loadable.
+    pub fn range_start(&self) -> Option<i128> {
+        self.args.first().and_then(scalar_to_i128)
+    }
 }
 
 #[derive(Debug)]
@@ -3682,6 +3794,9 @@ struct ClickHouseSourceStateStore {
 }
 
 impl ClickHouseSourceStateStore {
+    // Bumping this discards existing checkpoints (sources restart from the
+    // beginning). The persisted format stayed compatible across the keyset ->
+    // sort-key-range change (see ClickHouseSourceSplit::range_start), so keep "v1".
     const VERSION: &str = "v1";
 
     pub async fn save_split(&self, split: ClickHouseSourceSplit) -> Result<(), StateBackendError> {

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -1400,7 +1400,7 @@ impl ExecutionPlan for ClickHouseSourceExec {
             let attach_checkpoints = {
                 let buffer_arc = checkpoint_buffer_for_data.clone();
                 move |batch: RecordBatch| -> RecordBatch {
-                    let mut buffer = buffer_arc.lock().unwrap();
+                    let mut buffer = buffer_arc.lock().expect("checkpoint buffer mutex poisoned");
                     if buffer.is_empty() {
                         return batch;
                     }

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -209,7 +209,7 @@ pub(crate) fn parse_replacing_merge_tree_dedup(
     if !engine_name.to_ascii_lowercase().contains("replacing") {
         return None;
     }
-    let close = engine_full.rfind(')')?;
+    let close = matching_close_paren(engine_full, open)?;
     if close <= open {
         return None;
     }
@@ -267,6 +267,44 @@ fn tokenize_engine_args(args: &str) -> Vec<String> {
         tokens.push(current.trim().to_string());
     }
     tokens
+}
+
+/// Index of the `)` that closes the `(` at `open`, respecting single-quoted
+/// string literals (with `''` escapes) and nested parens. A real `engine_full`
+/// is `ReplacingMergeTree(...) ORDER BY (...)` — the trailing ORDER BY /
+/// SETTINGS clauses carry their own parens, so a naive `rfind(')')` grabs the
+/// wrong close and lets the ORDER BY text leak into the parsed column names.
+fn matching_close_paren(engine_full: &str, open: usize) -> Option<usize> {
+    let mut depth = 0i32;
+    let mut in_quote = false;
+    let mut chars = engine_full.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        if i < open {
+            continue;
+        }
+        if in_quote {
+            if c == '\'' {
+                if matches!(chars.peek(), Some(&(_, '\''))) {
+                    chars.next(); // escaped quote
+                } else {
+                    in_quote = false;
+                }
+            }
+            continue;
+        }
+        match c {
+            '\'' => in_quote = true,
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 #[derive(Clone, Debug)]
@@ -3001,6 +3039,20 @@ mod tests {
         .expect("quoted commas must be ignored");
         assert_eq!(d.version_column.as_deref(), Some("v"));
         assert_eq!(d.is_deleted_column.as_deref(), Some("d"));
+    }
+
+    #[test]
+    fn parse_engine_with_trailing_order_by_clause() {
+        // A real `system.tables.engine_full` value appends the ORDER BY (and
+        // possibly SETTINGS) clause, which carries its own parens. The parser
+        // must close on the engine's matching paren, not the last one — or the
+        // ORDER BY text leaks into the parsed column names.
+        let d = parse_replacing_merge_tree_dedup(
+            "ReplacingMergeTree(insert_timestamp, is_deleted) ORDER BY (block_number, id)",
+        )
+        .expect("replacing variant with ORDER BY should parse");
+        assert_eq!(d.version_column.as_deref(), Some("insert_timestamp"));
+        assert_eq!(d.is_deleted_column.as_deref(), Some("is_deleted"));
     }
 
     #[test]

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -1358,6 +1358,7 @@ impl ExecutionPlan for ClickHouseSourceExec {
                     &table_name_for_exec,
                     where_clause_for_exec.as_deref(),
                     Some(range_start),
+                    None,
                     &first_sorting_key_name,
                 )
                 .await
@@ -1509,16 +1510,36 @@ impl ExecutionPlan for ClickHouseSourceExec {
                                 )))).await;
                                 break;
                             }
-                            // Size the next width from whichever limit was hit. A byte
-                            // overflow sizes from the observed byte density so the re-read
-                            // lands just under MAX_PAGE_BYTES in one step; on_complete's
-                            // byte clamp then keeps it there (no thrash). A row overflow
-                            // halves. When both trip, byte is the stricter constraint.
-                            if byte_overflow {
-                                controller.on_byte_overflow(total_page_bytes);
-                            } else {
-                                controller.on_overflow(None);
-                            }
+                            // Probe the exact row count for this range so the next
+                            // width is sized from the TRUE density (count / width) in
+                            // one step. Without it the byte sizer divides the
+                            // LIMIT-capped sample by the full range width, under-
+                            // estimates density, and a dense range shrinks
+                            // geometrically over many discarded multi-GiB re-reads
+                            // before converging. The probe is a primary-key count
+                            // (cheap); a failure is non-fatal — the controller falls
+                            // back to byte/row halving.
+                            let probed_count = match client
+                                .fetch_count(
+                                    &table_name_for_exec,
+                                    where_clause_for_exec.as_deref(),
+                                    Some(range_start),
+                                    Some(upper_bound),
+                                    &first_sorting_key_name,
+                                )
+                                .await
+                            {
+                                Ok(c) => Some(c),
+                                Err(e) => {
+                                    warn!(
+                                        "[{}] count probe on overflow [{}, {}) failed ({}); \
+                                         falling back to halve",
+                                        reference_name, range_start, upper_bound, e
+                                    );
+                                    None
+                                }
+                            };
+                            controller.on_overflow_probed(probed_count, total_page_bytes);
                             info!(
                                 "[{}] range [{}, {}) overflowed page limits \
                                  (page_size={}, {} rows; max_page_bytes={}, {} bytes); width -> {}",
@@ -2111,15 +2132,19 @@ impl ClickHouseClient {
         Ok(max_val)
     }
 
-    /// Count rows matching the source filter at or above `lower_bound` on the
-    /// first sorting key. Used as an up-front density probe to size the first
-    /// pagination range. Carries no ORDER BY, so a matching projection serves it
-    /// cheaply; a slow probe is itself a signal that the filter is scan-bound.
+    /// Count rows matching the source filter in the half-open sort-key range
+    /// `[lower_bound, upper_bound)` on the first sorting key. Used two ways: as
+    /// an up-front density probe to size the first pagination range (no upper
+    /// bound — the whole remaining tail), and on overflow to size the next range
+    /// from the *true* density in one step (both bounds — the overflowing
+    /// range). Carries no ORDER BY, so a matching projection serves it cheaply;
+    /// a slow probe is itself a signal that the filter is scan-bound.
     pub async fn fetch_count(
         &self,
         table_name: &str,
         where_clause: Option<&str>,
         lower_bound: Option<i128>,
+        upper_bound: Option<i128>,
         first_key: &str,
     ) -> streamling_core::error::Result<u64> {
         let mut conditions: Vec<String> = Vec::new();
@@ -2128,6 +2153,9 @@ impl ClickHouseClient {
         }
         if let Some(lb) = lower_bound {
             conditions.push(format!("{} >= {}", first_key, lb));
+        }
+        if let Some(ub) = upper_bound {
+            conditions.push(format!("{} < {}", first_key, ub));
         }
         let where_sql = if conditions.is_empty() {
             String::new()

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -17,6 +17,7 @@ use streamling_core::error::{ResultExt, StreamlingError};
 use streamling_core::functions::byte_reverse::ReverseBytes32Func;
 use streamling_core::streamling_err;
 use streamling_core::types::{i256::I256Type, u256::U256Type};
+use streamling_core::utils::dedup::{TombstoneRule, deduplicate_record_batches_by_version};
 use streamling_core::utils::parse_primary_key_columns;
 
 use crate::util::parallel::parallel_execute;
@@ -114,6 +115,93 @@ fn is_timeout_error(error: &DataFusionError) -> bool {
     let error_msg = error.to_string().to_lowercase();
     error_msg.contains("timeout") || error_msg.contains("timed out")
 }
+/// Version / is_deleted columns inferred from a ReplacingMergeTree-family
+/// `engine_full` string. Either may be `None` (e.g. plain `ReplacingMergeTree()`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReplacingMergeTreeDedup {
+    pub version_column: Option<String>,
+    pub is_deleted_column: Option<String>,
+}
+
+/// Parse the version and is_deleted column names out of a `system.tables.engine_full`
+/// value for a ReplacingMergeTree-family engine.
+///
+/// Example: `SharedReplacingMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}', insert_timestamp, is_deleted)`
+/// The quoted path/replica literals are dropped; the remaining bare identifiers
+/// are, in order, the version column and the is_deleted column. This holds for
+/// every variant (`ReplacingMergeTree`, `ReplicatedReplacingMergeTree`,
+/// `SharedReplacingMergeTree`): the path/replica args are always quoted, while
+/// the version/is_deleted args are always bare column identifiers.
+///
+/// Returns `None` for non-ReplacingMergeTree engines (no version concept).
+pub(crate) fn parse_replacing_merge_tree_dedup(
+    engine_full: &str,
+) -> Option<ReplacingMergeTreeDedup> {
+    let engine_full = engine_full.trim();
+    let open = engine_full.find('(')?;
+    let engine_name = engine_full[..open].trim();
+    if !engine_name.to_ascii_lowercase().contains("replacing") {
+        return None;
+    }
+    let close = engine_full.rfind(')')?;
+    if close <= open {
+        return None;
+    }
+    let args = &engine_full[open + 1..close];
+
+    // Bare identifiers (version, is_deleted), in order: every token that isn't a
+    // quoted string literal.
+    let bare: Vec<String> = tokenize_engine_args(args)
+        .into_iter()
+        .filter(|tok| !tok.starts_with('\''))
+        .map(|tok| tok.trim().to_string())
+        .filter(|tok| !tok.is_empty())
+        .collect();
+
+    let mut iter = bare.into_iter();
+    Some(ReplacingMergeTreeDedup {
+        version_column: iter.next(),
+        is_deleted_column: iter.next(),
+    })
+}
+
+/// Split engine args on top-level commas, preserving single-quoted string
+/// literals (with `''` escapes). Quoted tokens keep their quotes so callers can
+/// distinguish them from bare identifiers.
+fn tokenize_engine_args(args: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut chars = args.chars().peekable();
+    let mut in_quote = false;
+    while let Some(c) = chars.next() {
+        if in_quote {
+            current.push(c);
+            if c == '\'' && matches!(chars.peek(), Some('\'')) {
+                // '' is an escaped quote; stay inside the literal.
+                chars.next();
+                current.push('\'');
+            } else if c == '\'' {
+                in_quote = false;
+            }
+        } else {
+            match c {
+                '\'' => {
+                    in_quote = true;
+                    current.push(c);
+                }
+                ',' => {
+                    tokens.push(current.trim().to_string());
+                    current = String::new();
+                }
+                _ => current.push(c),
+            }
+        }
+    }
+    if !current.trim().is_empty() {
+        tokens.push(current.trim().to_string());
+    }
+    tokens
+}
 
 #[derive(Clone, Debug)]
 pub struct ClickHouseTableProvider {
@@ -135,6 +223,9 @@ struct SourceParams {
     sort_key_range: i64,
     table_name: String,
     has_persisted_split: bool,
+    /// Inferred ReplacingMergeTree version column. When `Some`, each fully-read
+    /// page is coalesced and deduplicated by max version before emission.
+    dedup_version_column: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -281,6 +372,37 @@ impl ClickHouseTableProvider {
             }
         };
 
+        // Infer the ReplacingMergeTree version column from engine_full so the
+        // scan can deduplicate by max version (keyed on the table's ORDER BY),
+        // not by row position. Dedup only engages when the inferred version
+        // column is actually present in the fetched schema; otherwise the scan
+        // emits raw rows as before.
+        let dedup_version_column = match client.fetch_engine_full(&database_name, table_name) {
+            Ok(engine_full) => {
+                let inferred = parse_replacing_merge_tree_dedup(&engine_full)
+                    .and_then(|d| d.version_column)
+                    .filter(|col| schema.field_with_name(col).is_ok());
+                match &inferred {
+                    Some(col) => info!(
+                        "[{}] ReplacingMergeTree version-aware dedup enabled (version_column={})",
+                        reference_name, col
+                    ),
+                    None => debug!(
+                        "[{}] no ReplacingMergeTree version column inferred; emitting raw rows",
+                        reference_name
+                    ),
+                }
+                inferred
+            }
+            Err(e) => {
+                warn!(
+                    "[{}] could not fetch engine_full for dedup inference ({}); version-aware dedup disabled",
+                    reference_name, e
+                );
+                None
+            }
+        };
+
         let source_params = SourceParams {
             query_builder: query_builder.clone(),
             sorting_keys,
@@ -290,6 +412,7 @@ impl ClickHouseTableProvider {
             sort_key_range,
             table_name: table_name.to_string(),
             has_persisted_split,
+            dedup_version_column,
         };
         Ok(ClickHouseTableProvider {
             reference_name: reference_name.clone(),
@@ -1014,6 +1137,11 @@ impl ExecutionPlan for ClickHouseSourceExec {
             args: self.split.args.clone(),
         }));
         let state_store = source_params.state_store.clone();
+        // Version-aware dedup (inferred from engine_full in new_source). The
+        // dedup key is the table's full ORDER BY, so all duplicate versions of a
+        // key share a `block_number` and land in the same page.
+        let dedup_version_column = source_params.dedup_version_column.clone();
+        let dedup_key = source_params.sorting_keys.join(",");
         let empty_batch_schema = schema.clone();
 
         // Shared checkpoint buffer for metadata propagation
@@ -1283,7 +1411,44 @@ impl ExecutionPlan for ClickHouseSourceExec {
                                 receiver_dropped = true;
                             }
                         } else {
-                            for batch in batches.into_iter() {
+                            // When a version column was inferred, coalesce the
+                            // whole page and deduplicate by max version before
+                            // emitting: versions of one ORDER BY key can be split
+                            // across the page's IPC blocks, so per-batch dedup
+                            // would miss them. Keys whose winner is a tombstone
+                            // (_gs_op='d') are dropped (ReplacingMergeTree FINAL).
+                            let emit_batches: Vec<RecordBatch> = match &dedup_version_column {
+                                Some(version_col) => {
+                                    match deduplicate_record_batches_by_version(
+                                        &batches,
+                                        &dedup_key,
+                                        version_col,
+                                        Some(&TombstoneRule {
+                                            column: "_gs_op".to_string(),
+                                            value: "d".to_string(),
+                                        }),
+                                    ) {
+                                        Ok(deduped) if deduped.num_rows() == 0 => {
+                                            vec![RecordBatch::new_empty(empty_batch_schema.clone())]
+                                        }
+                                        Ok(deduped) => vec![deduped],
+                                        Err(e) => {
+                                            let _ = tx
+                                                .send(Err(DataFusionError::from(
+                                                    streamling_err!(
+                                                        "ClickHouse source dedup failed: {}",
+                                                        e
+                                                    ),
+                                                )))
+                                                .await;
+                                            break;
+                                        }
+                                    }
+                                }
+                                None => batches,
+                            };
+
+                            for batch in emit_batches.into_iter() {
                                 let batch = attach_checkpoints(batch);
                                 if tx.send(Ok(batch)).await.is_err() {
                                     receiver_dropped = true;
@@ -1698,6 +1863,32 @@ impl ClickHouseClient {
             .filter(|s| !s.is_empty())
             .collect::<Vec<String>>();
         Ok(sorting_keys)
+    }
+    /// Fetch the full engine declaration string (e.g.
+    /// `SharedReplacingMergeTree('...', '{replica}', insert_timestamp, is_deleted)`)
+    /// from `system.tables`. Used to infer the ReplacingMergeTree version and
+    /// is_deleted columns for source-side dedup.
+    pub fn fetch_engine_full(
+        &self,
+        database_name: &str,
+        table_name: &str,
+    ) -> streamling_core::error::Result<String> {
+        let query = format!(
+            "SELECT engine_full FROM system.tables WHERE database = '{}' AND name = '{}' FORMAT Arrow",
+            database_name, table_name
+        );
+        let response_bytes = block_on(async {
+            let response_result = self.send_query(reqwest::Method::GET, query.as_str()).await;
+            self.process_http_response(response_result, query.as_str(), "engine_full")
+                .await
+        })?;
+        let mut reader = self.create_arrow_reader(response_bytes, &query)?;
+        let batch = reader
+            .next()
+            .ok_or_else(|| streamling_err!("no rows returned for engine_full query"))??;
+        let scalar = ScalarValue::try_from_array(&batch.column(0), 0)
+            .streamling_context("failed to extract engine_full from query result")?;
+        Ok(scalar.to_string())
     }
 
     pub async fn fetch_max_sorting_key(
@@ -2499,6 +2690,59 @@ mod tests {
             args: vec![ScalarValue::Int64(Some(1000))],
         };
         assert_eq!(split.range_start(), Some(1000));
+    }
+
+    #[test]
+    fn parse_shared_replacing_mergetree_full() {
+        let d = parse_replacing_merge_tree_dedup(
+            "SharedReplacingMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}', insert_timestamp, is_deleted)",
+        )
+        .expect("Replacing variant should parse");
+        assert_eq!(d.version_column.as_deref(), Some("insert_timestamp"));
+        assert_eq!(d.is_deleted_column.as_deref(), Some("is_deleted"));
+    }
+
+    #[test]
+    fn parse_replicated_replacing_mergetree() {
+        let d = parse_replacing_merge_tree_dedup(
+            "ReplicatedReplacingMergeTree('/clickhouse/path', 'replica1', version_col)",
+        )
+        .expect("Replicated variant should parse");
+        assert_eq!(d.version_column.as_deref(), Some("version_col"));
+        assert_eq!(d.is_deleted_column, None);
+    }
+
+    #[test]
+    fn parse_plain_replacing_mergetree() {
+        let d = parse_replacing_merge_tree_dedup("ReplacingMergeTree(insert_time)")
+            .expect("plain variant should parse");
+        assert_eq!(d.version_column.as_deref(), Some("insert_time"));
+        assert_eq!(d.is_deleted_column, None);
+    }
+
+    #[test]
+    fn parse_plain_replacing_mergetree_no_args() {
+        let d = parse_replacing_merge_tree_dedup("ReplacingMergeTree()")
+            .expect("no-arg variant should still parse");
+        assert_eq!(d.version_column, None);
+        assert_eq!(d.is_deleted_column, None);
+    }
+
+    #[test]
+    fn parse_non_replacing_engine_returns_none() {
+        assert!(parse_replacing_merge_tree_dedup("MergeTree()").is_none());
+        assert!(parse_replacing_merge_tree_dedup("CollapsingMergeTree(sign)").is_none());
+    }
+
+    #[test]
+    fn parse_engine_with_comma_in_path() {
+        // A zk path with a comma inside the quoted literal must not be split.
+        let d = parse_replacing_merge_tree_dedup(
+            "ReplicatedReplacingMergeTree('/clickhouse/tables/{shard},weird,name', '{replica}', v, d)",
+        )
+        .expect("quoted commas must be ignored");
+        assert_eq!(d.version_column.as_deref(), Some("v"));
+        assert_eq!(d.is_deleted_column.as_deref(), Some("d"));
     }
 
     #[test]
@@ -3787,6 +4031,7 @@ mod tests {
                 sort_key_range: 1_000_000,
                 table_name: "test_table".to_string(),
                 has_persisted_split: false,
+                dedup_version_column: None,
             }),
             sink_params: None,
             metric_metadata_id: "test_metric".to_string(),

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -353,7 +353,7 @@ struct SinkParams {
 
 impl ClickHouseTableProvider {
     const DEFAULT_SORT_KEY_RANGE: i64 = 1_000_000;
-    const DEFAULT_PAGE_SIZE: usize = 2_000_000;
+    const DEFAULT_PAGE_SIZE: usize = 10_000_000;
     const MIN_SORT_KEY_RANGE: i64 = 100;
     const SOURCE_QUERY_TIMEOUT_SECS: u64 = 60;
 
@@ -1416,7 +1416,7 @@ impl ExecutionPlan for ClickHouseSourceExec {
             // Resume from the persisted cursor. Only the first sorting key matters;
             // see ClickHouseSourceSplit::range_start for checkpoint compatibility.
             let range_start = {
-                let guard = split.lock().unwrap();
+                let guard = split.lock().expect("split mutex poisoned");
                 guard.range_start().unwrap_or(0)
             };
             let template = i128_to_scalar_like(0, &max_val);

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -115,6 +115,24 @@ fn is_timeout_error(error: &DataFusionError) -> bool {
     let error_msg = error.to_string().to_lowercase();
     error_msg.contains("timeout") || error_msg.contains("timed out")
 }
+
+/// Drop the column at `drop_idx` and re-tag the batch with `target_schema`.
+/// Strips a dedup-only version column (force-included because the configured
+/// columns omit it) before emission, so the external schema is unchanged.
+fn project_out_column(
+    batch: RecordBatch,
+    drop_idx: usize,
+    target_schema: SchemaRef,
+) -> Result<RecordBatch, DataFusionError> {
+    let kept: Vec<ArrayRef> = batch
+        .columns()
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != drop_idx)
+        .map(|(_, c)| Arc::clone(c))
+        .collect();
+    RecordBatch::try_new(target_schema, kept).map_err(Into::into)
+}
 /// Version / is_deleted columns inferred from a ReplacingMergeTree-family
 /// `engine_full` string. Either may be `None` (e.g. plain `ReplacingMergeTree()`).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -226,6 +244,10 @@ struct SourceParams {
     /// Inferred ReplacingMergeTree version column. When `Some`, each fully-read
     /// page is coalesced and deduplicated by max version before emission.
     dedup_version_column: Option<String>,
+    /// Index of the dedup-only version column within the scan batch, when it
+    /// was force-included (not part of the configured columns). Such a column
+    /// is projected back out before emission so the external schema is unchanged.
+    project_out_version_index: Option<usize>,
 }
 
 #[derive(Clone, Debug)]
@@ -265,15 +287,76 @@ impl ClickHouseTableProvider {
         let sort_key_range_config = config.sort_key_range;
         let client = ClickHouseClient::new(config.connection.clone());
 
-        let columns_copy = columns.clone();
-        let schema = client
-            .fetch_schema(table_name, columns)
-            .streamling_with_context(|| {
-                format!(
-                    "failed to fetch schema from ClickHouse for table '{}'",
-                    table_name
-                )
-            })?;
+        // Infer the ReplacingMergeTree version column from engine_full so the
+        // scan can deduplicate by max version (keyed on the table's ORDER BY),
+        // not by row position.
+        let inferred_version_column: Option<String> = match client
+            .fetch_engine_full(&database_name, table_name)
+        {
+            Ok(engine_full) => {
+                parse_replacing_merge_tree_dedup(&engine_full).and_then(|d| d.version_column)
+            }
+            Err(e) => {
+                warn!(
+                    "[{}] could not fetch engine_full for dedup inference ({}); version-aware dedup disabled",
+                    reference_name, e
+                );
+                None
+            }
+        };
+
+        // The version column is force-included in the scan for dedup even when
+        // the configured columns omit it — a hybrid source projects ClickHouse
+        // to the Kafka schema, which excludes insert_timestamp/is_deleted. It
+        // is projected back out before emission, so the external schema contract
+        // is unchanged. `*` already selects every column, so nothing is added.
+        let user_columns = columns.clone().unwrap_or_else(|| vec!["*".to_string()]);
+        let star_select = user_columns.iter().any(|c| c == "*");
+        let mut scan_columns = user_columns.clone();
+        let mut added_version = false;
+        if let Some(vc) = &inferred_version_column {
+            let already_selected = star_select || user_columns.iter().any(|c| c == vc);
+            if !already_selected {
+                scan_columns.push(vc.clone());
+                added_version = true;
+            }
+        }
+
+        // Fetch the schema the scan will produce. If we appended an inferred
+        // version column that doesn't actually exist, the fetch errors and we
+        // fall back to the configured columns with dedup disabled.
+        let (scan_schema, scan_columns, dedup_version_column, project_out_version_index) =
+            match client.fetch_schema(table_name, Some(scan_columns.clone())) {
+                Ok(s) => {
+                    let dvc = inferred_version_column
+                        .clone()
+                        .filter(|vc| s.field_with_name(vc).is_ok());
+                    let pvi = if added_version {
+                        dvc.as_ref().and_then(|vc| s.index_of(vc).ok())
+                    } else {
+                        None
+                    };
+                    (s, scan_columns, dvc, pvi)
+                }
+                Err(e) => {
+                    warn!(
+                        "[{}] inferred version column '{}' not selectable; dedup disabled ({})",
+                        reference_name,
+                        inferred_version_column.as_deref().unwrap_or("?"),
+                        e
+                    );
+                    let fallback = user_columns.clone();
+                    let s = client
+                        .fetch_schema(table_name, Some(fallback.clone()))
+                        .streamling_with_context(|| {
+                            format!(
+                                "failed to fetch schema from ClickHouse for table '{}'",
+                                table_name
+                            )
+                        })?;
+                    (s, fallback, None, None)
+                }
+            };
         let sorting_keys = client
             .fetch_sorting_keys(&database_name, table_name)
             .streamling_with_context(|| {
@@ -300,7 +383,7 @@ impl ClickHouseTableProvider {
         // Narrow types (Int8, UInt8, Int16, UInt16) would silently overflow in
         // i128_to_scalar_like when computing sort key range boundaries.
         let first_key_name = sorting_keys.first().unwrap();
-        let first_key_type = schema
+        let first_key_type = scan_schema
             .field_with_name(first_key_name)
             .ok()
             .map(|f| f.data_type().clone());
@@ -333,7 +416,7 @@ impl ClickHouseTableProvider {
 
         let mut query_builder = ClickHouseQueryBuilder::of(
             table_name.to_string(),
-            columns_copy.unwrap_or(vec!["*".to_string()]),
+            scan_columns.clone(),
             filter.clone(),
             Some(pagination_config),
         );
@@ -372,36 +455,39 @@ impl ClickHouseTableProvider {
             }
         };
 
-        // Infer the ReplacingMergeTree version column from engine_full so the
-        // scan can deduplicate by max version (keyed on the table's ORDER BY),
-        // not by row position. Dedup only engages when the inferred version
-        // column is actually present in the fetched schema; otherwise the scan
-        // emits raw rows as before.
-        let dedup_version_column = match client.fetch_engine_full(&database_name, table_name) {
-            Ok(engine_full) => {
-                let inferred = parse_replacing_merge_tree_dedup(&engine_full)
-                    .and_then(|d| d.version_column)
-                    .filter(|col| schema.field_with_name(col).is_ok());
-                match &inferred {
-                    Some(col) => info!(
-                        "[{}] ReplacingMergeTree version-aware dedup enabled (version_column={})",
-                        reference_name, col
-                    ),
-                    None => debug!(
-                        "[{}] no ReplacingMergeTree version column inferred; emitting raw rows",
-                        reference_name
-                    ),
-                }
-                inferred
+        // Provider schema exposed downstream: the scan schema with a
+        // dedup-only version column (force-included because the configured
+        // columns omit it) projected back out, so the external contract — e.g.
+        // a hybrid source's Kafka-matching schema — is unchanged.
+        let schema: SchemaRef = match project_out_version_index {
+            Some(idx) => {
+                let fields: Vec<arrow_schema::Field> = scan_schema
+                    .fields()
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| *i != idx)
+                    .map(|(_, f)| f.as_ref().clone())
+                    .collect();
+                Arc::new(arrow_schema::Schema::new_with_metadata(
+                    fields,
+                    scan_schema.metadata().clone(),
+                ))
             }
-            Err(e) => {
-                warn!(
-                    "[{}] could not fetch engine_full for dedup inference ({}); version-aware dedup disabled",
-                    reference_name, e
-                );
-                None
-            }
+            None => scan_schema.clone(),
         };
+
+        match &dedup_version_column {
+            Some(col) => info!(
+                "[{}] ReplacingMergeTree version-aware dedup enabled (version_column={}, force_included={})",
+                reference_name,
+                col,
+                project_out_version_index.is_some()
+            ),
+            None => debug!(
+                "[{}] no ReplacingMergeTree version column inferred; emitting raw rows",
+                reference_name
+            ),
+        }
 
         let source_params = SourceParams {
             query_builder: query_builder.clone(),
@@ -413,6 +499,7 @@ impl ClickHouseTableProvider {
             table_name: table_name.to_string(),
             has_persisted_split,
             dedup_version_column,
+            project_out_version_index,
         };
         Ok(ClickHouseTableProvider {
             reference_name: reference_name.clone(),
@@ -1142,6 +1229,7 @@ impl ExecutionPlan for ClickHouseSourceExec {
         // key share a `block_number` and land in the same page.
         let dedup_version_column = source_params.dedup_version_column.clone();
         let dedup_key = source_params.sorting_keys.join(",");
+        let project_out_version_index = source_params.project_out_version_index;
         let empty_batch_schema = schema.clone();
 
         // Shared checkpoint buffer for metadata propagation
@@ -1417,42 +1505,74 @@ impl ExecutionPlan for ClickHouseSourceExec {
                             // across the page's IPC blocks, so per-batch dedup
                             // would miss them. Keys whose winner is a tombstone
                             // (_gs_op='d') are dropped (ReplacingMergeTree FINAL).
-                            let emit_batches: Vec<RecordBatch> = match &dedup_version_column {
-                                Some(version_col) => {
-                                    match deduplicate_record_batches_by_version(
-                                        &batches,
-                                        &dedup_key,
-                                        version_col,
-                                        Some(&TombstoneRule {
-                                            column: "_gs_op".to_string(),
-                                            value: "d".to_string(),
-                                        }),
-                                    ) {
-                                        Ok(deduped) if deduped.num_rows() == 0 => {
-                                            vec![RecordBatch::new_empty(empty_batch_schema.clone())]
+                            let (mut emit_batches, deduped_to_empty): (Vec<RecordBatch>, bool) =
+                                match &dedup_version_column {
+                                    Some(version_col) => {
+                                        match deduplicate_record_batches_by_version(
+                                            &batches,
+                                            &dedup_key,
+                                            version_col,
+                                            Some(&TombstoneRule {
+                                                column: "_gs_op".to_string(),
+                                                value: "d".to_string(),
+                                            }),
+                                        ) {
+                                            Ok(deduped) if deduped.num_rows() == 0 => {
+                                                (Vec::new(), true)
+                                            }
+                                            Ok(deduped) => (vec![deduped], false),
+                                            Err(e) => {
+                                                let _ = tx
+                                                    .send(Err(DataFusionError::from(
+                                                        streamling_err!(
+                                                            "ClickHouse source dedup failed: {}",
+                                                            e
+                                                        ),
+                                                    )))
+                                                    .await;
+                                                break;
+                                            }
                                         }
-                                        Ok(deduped) => vec![deduped],
+                                    }
+                                    None => (batches, false),
+                                };
+
+                            if deduped_to_empty {
+                                // Every key in this page was tombstoned. Emit one
+                                // empty provider_schema batch so any buffered
+                                // checkpoint messages still flow.
+                                let empty_batch = attach_checkpoints(RecordBatch::new_empty(
+                                    empty_batch_schema.clone(),
+                                ));
+                                if tx.send(Ok(empty_batch)).await.is_err() {
+                                    receiver_dropped = true;
+                                }
+                            } else {
+                                // Strip the dedup-only version column (if it was
+                                // force-included) so the emitted batches match
+                                // the external schema. Projection is total — a
+                                // failure here is unrecoverable for the scan.
+                                if let Some(drop_idx) = project_out_version_index {
+                                    match emit_batches
+                                        .into_iter()
+                                        .map(|b| {
+                                            project_out_column(b, drop_idx, schema.clone())
+                                        })
+                                        .collect::<Result<Vec<_>>>()
+                                    {
+                                        Ok(p) => emit_batches = p,
                                         Err(e) => {
-                                            let _ = tx
-                                                .send(Err(DataFusionError::from(
-                                                    streamling_err!(
-                                                        "ClickHouse source dedup failed: {}",
-                                                        e
-                                                    ),
-                                                )))
-                                                .await;
+                                            let _ = tx.send(Err(e)).await;
                                             break;
                                         }
                                     }
                                 }
-                                None => batches,
-                            };
-
-                            for batch in emit_batches.into_iter() {
-                                let batch = attach_checkpoints(batch);
-                                if tx.send(Ok(batch)).await.is_err() {
-                                    receiver_dropped = true;
-                                    break;
+                                for batch in emit_batches.into_iter() {
+                                    let batch = attach_checkpoints(batch);
+                                    if tx.send(Ok(batch)).await.is_err() {
+                                        receiver_dropped = true;
+                                        break;
+                                    }
                                 }
                             }
                         }
@@ -4032,6 +4152,7 @@ mod tests {
                 table_name: "test_table".to_string(),
                 has_persisted_split: false,
                 dedup_version_column: None,
+                project_out_version_index: None,
             }),
             sink_params: None,
             metric_metadata_id: "test_metric".to_string(),

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -1708,46 +1708,6 @@ impl ExecutionPlan for ClickHouseSourceExec {
             }
             debug!("Checkpointing task completed for {}", reference_name);
 
-            // Flush any checkpoint messages the task buffered after the last data
-            // batch was emitted (attach_checkpoints only drains onto an outgoing
-            // batch; a Marker that arrives during the final pages — or after the
-            // scan loop exits — has no batch to ride). Without this flush that
-            // Marker is dropped when `tx` drops, so the sink never sees the epoch,
-            // never acks, and the coordinator stalls on "missing sinks" — the
-            // production job-mode termination hang. Emit a synthetic empty batch
-            // carrying the buffered markers so they reach the sink (and the
-            // hybrid safety-net) before the stream ends.
-            {
-                // Build the flush batch inside the lock, then send outside it —
-                // holding a std MutexGuard across `.await` makes the spawn future !Send.
-                let enriched = {
-                    let mut buffer = checkpoint_buffer_for_data.lock().unwrap();
-                    if buffer.is_empty() {
-                        None
-                    } else {
-                        debug!(
-                            "Flushing {} buffered checkpoint message(s) on source completion",
-                            buffer.len()
-                        );
-                        let batch = RecordBatch::new_empty(empty_batch_schema.clone());
-                        let mut metadata = batch.schema().metadata().clone();
-                        enrich_batch_metadata_with_checkpoints(&mut metadata, &buffer);
-                        let enriched = enrich_batch_with_metadata(batch, metadata)
-                            .expect("Failed to enrich final flush batch with checkpoint metadata");
-                        buffer.clear();
-                        Some(enriched)
-                    }
-                };
-                if let Some(enriched) = enriched
-                    && tx.send(Ok(enriched)).await.is_err()
-                {
-                    warn!(
-                        "ClickHouseSourceExec: receiver dropped before final checkpoint flush for {}",
-                        reference_name
-                    );
-                }
-            }
-
             // Unsubscribe from checkpoint channel before dropping the receiver
             // to avoid SendError when the coordinator tries to send to this channel
             unsubscribe(CHECKPOINT_COORDINATOR_CHANNEL, checkpoint_subscriber_id);

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -338,20 +338,20 @@ impl ClickHouseTableProvider {
         // Infer the ReplacingMergeTree version column from engine_full so the
         // scan can deduplicate by max version (keyed on the table's ORDER BY),
         // not by row position.
-        let inferred_version_column: Option<String> = match client
-            .fetch_engine_full(&database_name, table_name)
-        {
-            Ok(engine_full) => {
-                parse_replacing_merge_tree_dedup(&engine_full).and_then(|d| d.version_column)
-            }
-            Err(e) => {
-                warn!(
-                    "[{}] could not fetch engine_full for dedup inference ({}); version-aware dedup disabled",
-                    reference_name, e
-                );
-                None
-            }
-        };
+        let (inferred_version_column, inferred_is_deleted_column): (Option<String>, Option<String>) =
+            match client.fetch_engine_full(&database_name, table_name) {
+                Ok(engine_full) => match parse_replacing_merge_tree_dedup(&engine_full) {
+                    Some(d) => (d.version_column, d.is_deleted_column),
+                    None => (None, None),
+                },
+                Err(e) => {
+                    warn!(
+                        "[{}] could not fetch engine_full for dedup inference ({}); version-aware dedup disabled",
+                        reference_name, e
+                    );
+                    (None, None)
+                }
+            };
 
         // The version column is force-included in the scan for dedup even when
         // the configured columns omit it — a hybrid source projects ClickHouse
@@ -374,7 +374,7 @@ impl ClickHouseTableProvider {
         // version column that doesn't actually exist, the fetch errors and we
         // fall back to the configured columns with dedup disabled.
         let (scan_schema, scan_columns, dedup_version_column, project_out_version_index) =
-            match client.fetch_schema(table_name, Some(scan_columns.clone())) {
+            match client.fetch_schema(table_name, Some(scan_columns.clone()), inferred_is_deleted_column.clone()) {
                 Ok(s) => {
                     let dvc = inferred_version_column
                         .clone()
@@ -395,7 +395,7 @@ impl ClickHouseTableProvider {
                     );
                     let fallback = user_columns.clone();
                     let s = client
-                        .fetch_schema(table_name, Some(fallback.clone()))
+                        .fetch_schema(table_name, Some(fallback.clone()), inferred_is_deleted_column.clone())
                         .streamling_with_context(|| {
                             format!(
                                 "failed to fetch schema from ClickHouse for table '{}'",
@@ -468,6 +468,7 @@ impl ClickHouseTableProvider {
             filter.clone(),
             Some(pagination_config),
         );
+        query_builder.set_is_deleted_column(inferred_is_deleted_column.clone());
         let state_store = Arc::new(ClickHouseSourceStateStore {
             reference_name: reference_name.clone(),
             state_backend,
@@ -2049,6 +2050,7 @@ impl ClickHouseClient {
         &self,
         table_name: &str,
         columns: Option<Vec<String>>,
+        is_deleted_column: Option<String>,
     ) -> streamling_core::error::Result<SchemaRef> {
         let mut query_builder = ClickHouseQueryBuilder::of(
             table_name.to_string(),
@@ -2056,6 +2058,7 @@ impl ClickHouseClient {
             None,
             None,
         );
+        query_builder.set_is_deleted_column(is_deleted_column);
 
         let query = format!("{} LIMIT 1 FORMAT Arrow", query_builder.get_query());
         let response_bytes = block_on(async {

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -1501,6 +1501,47 @@ impl ExecutionPlan for ClickHouseSourceExec {
 
             while !controller.is_done() {
                 page_count += 1;
+                // Count-first sizing: probe the exact row count for the range the
+                // cursor covers and shrink the width to fit BEFORE the data read.
+                // The up-front span-average density that sized `initial_width`
+                // misses clustered high-fanout regions — a dense cluster inside a
+                // sparse span would otherwise be read at the span-average width and
+                // materialise `page_size + 1` rows (the OOM) before the reactive
+                // overflow could shrink it. Each iteration shrinks from the exact
+                // count; the cursor never moves during sizing (only `on_complete`
+                // advances it), so range_start is fixed and only the upper bound
+                // shrinks. A probe failure is non-fatal — fall through and let the
+                // reactive overflow below handle it.
+                loop {
+                    let (probe_lo, probe_hi) = controller.current_range();
+                    if controller.at_min_width() {
+                        break;
+                    }
+                    match client
+                        .fetch_count(
+                            &table_name_for_exec,
+                            where_clause_for_exec.as_deref(),
+                            Some(probe_lo),
+                            Some(probe_hi),
+                            &first_sorting_key_name,
+                        )
+                        .await
+                    {
+                        Ok(count) if count > page_size as u64 => {
+                            controller.shrink_to_fit_count(count);
+                            continue;
+                        }
+                        Ok(_) => break,
+                        Err(e) => {
+                            warn!(
+                                "[{}] count-first probe on range [{}, {}) failed ({}); \
+                                 reading at current width and letting the reactive overflow handle it",
+                                reference_name, probe_lo, probe_hi, e
+                            );
+                            break;
+                        }
+                    }
+                }
                 let (range_start, upper_bound) = controller.current_range();
                 query_builder
                     .set_sort_key_range_upper_bound(Some(i128_to_scalar_like(upper_bound, &template)));

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -279,7 +279,7 @@ struct SinkParams {
 
 impl ClickHouseTableProvider {
     const DEFAULT_SORT_KEY_RANGE: i64 = 1_000_000;
-    const DEFAULT_PAGE_SIZE: usize = 10_000_000;
+    const DEFAULT_PAGE_SIZE: usize = 2_000_000;
     const MIN_SORT_KEY_RANGE: i64 = 100;
     const SOURCE_QUERY_TIMEOUT_SECS: u64 = 60;
 

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -1687,6 +1687,46 @@ impl ExecutionPlan for ClickHouseSourceExec {
             }
             debug!("Checkpointing task completed for {}", reference_name);
 
+            // Flush any checkpoint messages the task buffered after the last data
+            // batch was emitted (attach_checkpoints only drains onto an outgoing
+            // batch; a Marker that arrives during the final pages — or after the
+            // scan loop exits — has no batch to ride). Without this flush that
+            // Marker is dropped when `tx` drops, so the sink never sees the epoch,
+            // never acks, and the coordinator stalls on "missing sinks" — the
+            // production job-mode termination hang. Emit a synthetic empty batch
+            // carrying the buffered markers so they reach the sink (and the
+            // hybrid safety-net) before the stream ends.
+            {
+                // Build the flush batch inside the lock, then send outside it —
+                // holding a std MutexGuard across `.await` makes the spawn future !Send.
+                let enriched = {
+                    let mut buffer = checkpoint_buffer_for_data.lock().unwrap();
+                    if buffer.is_empty() {
+                        None
+                    } else {
+                        debug!(
+                            "Flushing {} buffered checkpoint message(s) on source completion",
+                            buffer.len()
+                        );
+                        let batch = RecordBatch::new_empty(empty_batch_schema.clone());
+                        let mut metadata = batch.schema().metadata().clone();
+                        enrich_batch_metadata_with_checkpoints(&mut metadata, &buffer);
+                        let enriched = enrich_batch_with_metadata(batch, metadata)
+                            .expect("Failed to enrich final flush batch with checkpoint metadata");
+                        buffer.clear();
+                        Some(enriched)
+                    }
+                };
+                if let Some(enriched) = enriched
+                    && tx.send(Ok(enriched)).await.is_err()
+                {
+                    warn!(
+                        "ClickHouseSourceExec: receiver dropped before final checkpoint flush for {}",
+                        reference_name
+                    );
+                }
+            }
+
             // Unsubscribe from checkpoint channel before dropping the receiver
             // to avoid SendError when the coordinator tries to send to this channel
             unsubscribe(CHECKPOINT_COORDINATOR_CHANNEL, checkpoint_subscriber_id);

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -338,20 +338,22 @@ impl ClickHouseTableProvider {
         // Infer the ReplacingMergeTree version column from engine_full so the
         // scan can deduplicate by max version (keyed on the table's ORDER BY),
         // not by row position.
-        let (inferred_version_column, inferred_is_deleted_column): (Option<String>, Option<String>) =
-            match client.fetch_engine_full(&database_name, table_name) {
-                Ok(engine_full) => match parse_replacing_merge_tree_dedup(&engine_full) {
-                    Some(d) => (d.version_column, d.is_deleted_column),
-                    None => (None, None),
-                },
-                Err(e) => {
-                    warn!(
-                        "[{}] could not fetch engine_full for dedup inference ({}); version-aware dedup disabled",
-                        reference_name, e
-                    );
-                    (None, None)
-                }
-            };
+        let (inferred_version_column, inferred_is_deleted_column): (
+            Option<String>,
+            Option<String>,
+        ) = match client.fetch_engine_full(&database_name, table_name) {
+            Ok(engine_full) => match parse_replacing_merge_tree_dedup(&engine_full) {
+                Some(d) => (d.version_column, d.is_deleted_column),
+                None => (None, None),
+            },
+            Err(e) => {
+                warn!(
+                    "[{}] could not fetch engine_full for dedup inference ({}); version-aware dedup disabled",
+                    reference_name, e
+                );
+                (None, None)
+            }
+        };
 
         // The version column is force-included in the scan for dedup even when
         // the configured columns omit it — a hybrid source projects ClickHouse
@@ -374,7 +376,11 @@ impl ClickHouseTableProvider {
         // version column that doesn't actually exist, the fetch errors and we
         // fall back to the configured columns with dedup disabled.
         let (scan_schema, scan_columns, dedup_version_column, project_out_version_index) =
-            match client.fetch_schema(table_name, Some(scan_columns.clone()), inferred_is_deleted_column.clone()) {
+            match client.fetch_schema(
+                table_name,
+                Some(scan_columns.clone()),
+                inferred_is_deleted_column.clone(),
+            ) {
                 Ok(s) => {
                     let dvc = inferred_version_column
                         .clone()
@@ -395,7 +401,11 @@ impl ClickHouseTableProvider {
                     );
                     let fallback = user_columns.clone();
                     let s = client
-                        .fetch_schema(table_name, Some(fallback.clone()), inferred_is_deleted_column.clone())
+                        .fetch_schema(
+                            table_name,
+                            Some(fallback.clone()),
+                            inferred_is_deleted_column.clone(),
+                        )
                         .streamling_with_context(|| {
                             format!(
                                 "failed to fetch schema from ClickHouse for table '{}'",

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -324,6 +324,11 @@ struct SourceParams {
     initial_split_args: Vec<ScalarValue>,
     state_store: Arc<ClickHouseSourceStateStore>,
     datafusion_buffer_size: usize,
+    /// Target rows per emitted batch. A page (which dedup coalesces into one
+    /// batch) is split into chunks of this size at the emit point so downstream
+    /// operators see `record_batch_size`-bounded batches, matching the Kafka
+    /// source. Mirrors the global `AppConfig::record_batch_size`.
+    record_batch_size: usize,
     sort_key_range: i64,
     table_name: String,
     has_persisted_split: bool,
@@ -367,6 +372,7 @@ impl ClickHouseTableProvider {
         columns: Option<Vec<String>>,
         state_backend: Arc<dyn StateOperatorBackend<ClickHouseSourceSplit>>,
         datafusion_buffer_size: usize,
+        record_batch_size: usize,
     ) -> Result<Self, DataFusionError> {
         let database_name = config.connection.database.clone();
         let page_size = config.page_size.unwrap_or(Self::DEFAULT_PAGE_SIZE);
@@ -591,6 +597,7 @@ impl ClickHouseTableProvider {
             sorting_keys,
             initial_split_args,
             state_store,
+            record_batch_size,
             datafusion_buffer_size,
             sort_key_range,
             table_name: table_name.to_string(),
@@ -1310,6 +1317,7 @@ impl ExecutionPlan for ClickHouseSourceExec {
             .page_size;
         let default_sort_key_range = source_params.sort_key_range;
         let table_name_for_exec = source_params.table_name.clone();
+        let record_batch_size = source_params.record_batch_size;
         let first_sorting_key_name = self
             .split
             .sorting_keys
@@ -1755,9 +1763,18 @@ impl ExecutionPlan for ClickHouseSourceExec {
                                     }
                                 }
                                 for batch in emit_batches.into_iter() {
-                                    let batch = attach_checkpoints(batch);
-                                    if tx.send(Ok(batch)).await.is_err() {
-                                        receiver_dropped = true;
+                                    for chunk in chunk_record_batch(batch, record_batch_size) {
+                                        // attach_checkpoints drains the buffered messages onto
+                                        // the first chunk it sees (and no-ops once empty), so
+                                        // checkpoint messages still ride exactly one emitted
+                                        // batch — the first chunk of the page.
+                                        let chunk = attach_checkpoints(chunk);
+                                        if tx.send(Ok(chunk)).await.is_err() {
+                                            receiver_dropped = true;
+                                            break;
+                                        }
+                                    }
+                                    if receiver_dropped {
                                         break;
                                     }
                                 }
@@ -1866,6 +1883,29 @@ impl ExecutionPlan for ClickHouseSourceExec {
         info!("ClickHouseSourceExec built successfully");
         Ok(builder.build())
     }
+}
+
+/// Split `batch` into chunks of at most `max_rows` rows. Used at the ClickHouse
+/// source emit point so downstream operators receive `record_batch_size`-bounded
+/// batches regardless of how large a deduped page is — dedup coalesces a whole
+/// page into a single batch, which can dwarf the global `record_batch_size` that
+/// other operators (and the Kafka source) emit at.
+///
+/// `RecordBatch::slice` shares the schema (and all of its metadata) across
+/// chunks, so every chunk carries the page's schema metadata unchanged; any
+/// per-emission metadata (checkpoint messages) is attached by the caller to a
+/// single chunk after this split. A batch that is empty or already within the
+/// limit yields itself as the sole chunk. A `max_rows` of 0 is treated as "no
+/// chunking" so a misconfigured size cannot produce zero-row chunks.
+fn chunk_record_batch(batch: RecordBatch, max_rows: usize) -> Vec<RecordBatch> {
+    let n = batch.num_rows();
+    if max_rows == 0 || n <= max_rows {
+        return vec![batch];
+    }
+    (0..n)
+        .step_by(max_rows)
+        .map(|offset| batch.slice(offset, (n - offset).min(max_rows)))
+        .collect()
 }
 
 impl ClickHouseSourceExec {
@@ -3094,6 +3134,135 @@ mod tests {
         .expect("replacing variant with ORDER BY should parse");
         assert_eq!(d.version_column.as_deref(), Some("insert_timestamp"));
         assert_eq!(d.is_deleted_column.as_deref(), Some("is_deleted"));
+    }
+
+    // ---- emit-time batch chunking (chunk_record_batch) ----
+
+    fn make_int64_batch_with_meta(n: i64, meta: Option<(&str, &str)>) -> RecordBatch {
+        let fields = vec![Field::new("block_number", DataType::Int64, false)];
+        let schema = match meta {
+            Some((k, v)) => Schema::new_with_metadata(
+                fields,
+                std::iter::once((k.to_string(), v.to_string())).collect(),
+            ),
+            None => Schema::new(fields),
+        };
+        let values: Vec<i64> = (0..n).collect();
+        RecordBatch::try_new(
+            std::sync::Arc::new(schema),
+            vec![std::sync::Arc::new(arrow::array::Int64Array::from(values))
+                as arrow::array::ArrayRef],
+        )
+        .expect("valid batch")
+    }
+
+    fn make_int64_batch(n: i64) -> RecordBatch {
+        make_int64_batch_with_meta(n, None)
+    }
+
+    #[test]
+    fn chunk_record_batch_splits_evenly() {
+        let chunks = chunk_record_batch(make_int64_batch(10), 5);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].num_rows(), 5);
+        assert_eq!(chunks[1].num_rows(), 5);
+    }
+
+    #[test]
+    fn chunk_record_batch_splits_with_remainder() {
+        let chunks = chunk_record_batch(make_int64_batch(7), 3);
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(chunks[0].num_rows(), 3);
+        assert_eq!(chunks[1].num_rows(), 3);
+        assert_eq!(chunks[2].num_rows(), 1);
+    }
+
+    #[test]
+    fn chunk_record_batch_preserves_row_order_with_no_loss_or_duplication() {
+        let chunks = chunk_record_batch(make_int64_batch(8), 3);
+        let collected: Vec<i64> = chunks
+            .iter()
+            .flat_map(|c| {
+                c.column(0)
+                    .as_any()
+                    .downcast_ref::<arrow::array::Int64Array>()
+                    .expect("int64 column")
+                    .values()
+                    .iter()
+                    .copied()
+            })
+            .collect();
+        assert_eq!(collected, (0..8).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn chunk_record_batch_under_limit_returns_single_chunk() {
+        let chunks = chunk_record_batch(make_int64_batch(3), 5);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].num_rows(), 3);
+    }
+
+    #[test]
+    fn chunk_record_batch_empty_batch_returns_single_chunk() {
+        let chunks = chunk_record_batch(make_int64_batch(0), 5);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].num_rows(), 0);
+    }
+
+    #[test]
+    fn chunk_record_batch_max_rows_zero_is_a_noop() {
+        // A misconfigured size of 0 must not produce zero-row chunks or loop.
+        let chunks = chunk_record_batch(make_int64_batch(10), 0);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].num_rows(), 10);
+    }
+
+    #[test]
+    fn chunk_record_batch_preserves_schema_metadata_on_every_chunk() {
+        let batch = make_int64_batch_with_meta(7, Some(("schema_version", "42")));
+        let chunks = chunk_record_batch(batch, 3);
+        assert_eq!(chunks.len(), 3);
+        for (i, c) in chunks.iter().enumerate() {
+            assert_eq!(
+                c.schema().metadata().get("schema_version"),
+                Some(&"42".to_string()),
+                "chunk {} lost the schema metadata",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn chunk_record_batch_checkpoint_rides_first_chunk_only() {
+        // Mirrors the emit loop: a page is chunked, then per-emission metadata
+        // (checkpoint messages) is attached to the FIRST chunk only, because
+        // attach_checkpoints drains its buffer on first use and no-ops after.
+        // Chunks are independent RecordBatches, so merging metadata into the
+        // first cannot leak to the rest — this locks that invariant so a future
+        // refactor can't silently duplicate or drop checkpoint messages.
+        let chunks = chunk_record_batch(make_int64_batch(7), 3);
+        assert_eq!(chunks.len(), 3);
+        let first = {
+            let merged: std::collections::HashMap<String, String> =
+                std::iter::once(("checkpoint_epoch".to_string(), "99".to_string())).collect();
+            let schema = Schema::new_with_metadata(
+                vec![Field::new("block_number", DataType::Int64, false)],
+                merged,
+            );
+            RecordBatch::try_new(std::sync::Arc::new(schema), chunks[0].columns().to_vec())
+                .expect("rebuild first chunk with checkpoint metadata")
+        };
+        assert_eq!(
+            first.schema().metadata().get("checkpoint_epoch"),
+            Some(&"99".to_string()),
+            "first chunk carries the checkpoint"
+        );
+        for c in chunks.iter().skip(1) {
+            assert!(
+                c.schema().metadata().get("checkpoint_epoch").is_none(),
+                "a later chunk leaked the checkpoint — chunks must be independent"
+            );
+        }
     }
 
     #[test]
@@ -4379,6 +4548,7 @@ mod tests {
                 initial_split_args: initial_split_args.clone(),
                 state_store,
                 datafusion_buffer_size: 16,
+                record_batch_size: 1000,
                 sort_key_range: 1_000_000,
                 table_name: "test_table".to_string(),
                 has_persisted_split: false,

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -115,6 +115,18 @@ fn is_timeout_error(error: &DataFusionError) -> bool {
     let error_msg = error.to_string().to_lowercase();
     error_msg.contains("timeout") || error_msg.contains("timed out")
 }
+/// Maximum total byte size of a fully-buffered source page.
+///
+/// Arrow's variable-length arrays (`Utf8`/`Binary`) index their data buffer with
+/// `i32` offsets, so a single column cannot hold more than ~2 GiB; building one
+/// — via the IPC reader or `concat_batches` (version dedup) — panics with
+/// "byte array offset overflow" past that point. Pagination bounded pages by row
+/// count (`page_size`) only, so a dense string column blew the limit on a page
+/// that looked fine by rows (observed on `matic_raw_logs` in production). The
+/// widest column is at most the page total, so keeping the page well under
+/// `i32::MAX` guarantees no column can overflow. Half the limit leaves a 2x
+/// margin against offsets/null-bitmap overhead and measurement slack.
+const MAX_PAGE_BYTES: u64 = (i32::MAX as u64) / 2;
 
 /// Drop the column at `drop_idx` and re-tag the batch with `target_schema`.
 /// Strips a dedup-only version column (force-included because the configured
@@ -1366,6 +1378,7 @@ impl ExecutionPlan for ClickHouseSourceExec {
 
             let mut controller = RangeController::new(
                 page_size as u64,
+                MAX_PAGE_BYTES,
                 range_start,
                 max_key,
                 initial_width,
@@ -1443,11 +1456,16 @@ impl ExecutionPlan for ClickHouseSourceExec {
                         // holds parsed batches, bounded by page_size + 1 rows.
                         let mut batches: Vec<RecordBatch> = Vec::new();
                         let mut total_rows_in_page: usize = 0;
+                        // Summed so the byte tripwire can shrink a page that is
+                        // fine by rows but too large for a single Arrow column
+                        // (see MAX_PAGE_BYTES). The widest column <= this total.
+                        let mut total_page_bytes: u64 = 0;
                         let mut stream_failed = false;
                         while let Some(item_result) = stream.next().await {
                             match item_result {
                                 Ok(batch) => {
                                     total_rows_in_page += batch.num_rows();
+                                    total_page_bytes += batch.get_array_memory_size() as u64;
                                     batches.push(batch);
                                 }
                                 Err(e) => {
@@ -1466,24 +1484,46 @@ impl ExecutionPlan for ClickHouseSourceExec {
 
                         trace!("ClickHouseSourceExec: page {} read {} rows (page_size {})", page_count, total_rows_in_page, page_size);
 
-                        // Overflow: the range holds more than page_size rows. Shrink and
-                        // re-read the SAME range. Nothing was emitted, so no duplicates
-                        // and no advance.
-                        if total_rows_in_page > page_size {
+                        // Overflow: the range holds more than `page_size` rows, OR the
+                        // page is too large in bytes for a single Arrow column. Dedup
+                        // coalesces the whole page via `concat_batches`, and a Utf8/
+                        // Binary column panics ("byte array offset overflow") past ~2 GiB
+                        // of i32 offsets — a page that looks fine by rows can still blow
+                        // that limit on a dense string column. Either way: shrink the
+                        // width and re-read the SAME range. Nothing was emitted, so no
+                        // duplicates and no advance.
+                        let row_overflow = total_rows_in_page > page_size;
+                        let byte_overflow = total_page_bytes > MAX_PAGE_BYTES;
+                        if row_overflow || byte_overflow {
                             if controller.at_min_width() {
-                                // A min-width range still overflows: a single key holds more
-                                // than page_size matching rows and cannot be split further.
-                                // Surface it rather than silently skip data.
+                                // A min-width range still overflows: a single sort key
+                                // holds more data than one page can carry and cannot be
+                                // split further. Surface it rather than silently skip
+                                // data — a key exceeding MAX_PAGE_BYTES alone would
+                                // overflow Arrow's per-array limit.
                                 let _ = tx.send(Err(DataFusionError::from(streamling_core::streamling_err!(
-                                    "ClickHouse source: range [{}, {}) at min width still exceeds page_size {} ({} rows); increase page_size",
-                                    range_start, upper_bound, page_size, total_rows_in_page
+                                    "ClickHouse source: range [{}, {}) at min width still exceeds page limits \
+                                     (page_size={}, {} rows; max_page_bytes={}, {} bytes)",
+                                    range_start, upper_bound, page_size, total_rows_in_page,
+                                    MAX_PAGE_BYTES, total_page_bytes
                                 )))).await;
                                 break;
                             }
-                            controller.on_overflow(None);
+                            // Size the next width from whichever limit was hit. A byte
+                            // overflow sizes from the observed byte density so the re-read
+                            // lands just under MAX_PAGE_BYTES in one step; on_complete's
+                            // byte clamp then keeps it there (no thrash). A row overflow
+                            // halves. When both trip, byte is the stricter constraint.
+                            if byte_overflow {
+                                controller.on_byte_overflow(total_page_bytes);
+                            } else {
+                                controller.on_overflow(None);
+                            }
                             info!(
-                                "[{}] range [{}, {}) overflowed page_size {} ({} rows); width -> {}",
-                                reference_name, range_start, upper_bound, page_size, total_rows_in_page, controller.width()
+                                "[{}] range [{}, {}) overflowed page limits \
+                                 (page_size={}, {} rows; max_page_bytes={}, {} bytes); width -> {}",
+                                reference_name, range_start, upper_bound, page_size, total_rows_in_page,
+                                MAX_PAGE_BYTES, total_page_bytes, controller.width()
                             );
                             page_count -= 1;
                             continue;
@@ -1586,7 +1626,7 @@ impl ExecutionPlan for ClickHouseSourceExec {
                         // ends the scan once the cursor passes max_key. On restart we re-read
                         // from the persisted cursor.
                         let page_elapsed = page_start.elapsed();
-                        controller.on_complete(total_rows_in_page, page_elapsed);
+                        controller.on_complete(total_rows_in_page, page_elapsed, total_page_bytes);
                         if let Ok(mut split_guard) = split.lock() {
                             split_guard.update_args(vec![i128_to_scalar_like(controller.range_start(), &template)]);
                         }
@@ -2853,7 +2893,6 @@ mod tests {
         assert!(parse_replacing_merge_tree_dedup("MergeTree()").is_none());
         assert!(parse_replacing_merge_tree_dedup("CollapsingMergeTree(sign)").is_none());
     }
-
     #[test]
     fn parse_engine_with_comma_in_path() {
         // A zk path with a comma inside the quoted literal must not be split.

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -128,6 +128,42 @@ fn is_timeout_error(error: &DataFusionError) -> bool {
 /// margin against offsets/null-bitmap overhead and measurement slack.
 const MAX_PAGE_BYTES: u64 = (i32::MAX as u64) / 2;
 
+/// Drain `buffer` and, if non-empty, build a synthetic empty batch carrying the
+/// checkpoint messages as schema metadata so they reach the sink before the
+/// source stream ends.
+///
+/// `attach_checkpoints` (the inline closure in `execute`) only drains the buffer
+/// onto an outgoing *data* batch. When the scan loop exits, a Marker buffered
+/// after the last data batch has no batch to ride — without this flush it is
+/// dropped when `tx` drops, the sink never ACKs that epoch, and the coordinator
+/// stalls on "missing sinks". On main's keyset pagination the last page was
+/// always an exhausted page that emitted an empty batch (draining the buffer);
+/// the new range pagination's last page has data and skips that drain, so this
+/// explicit flush restores parity.
+///
+/// Extracted as a free function so the drain logic is unit-testable without a
+/// ClickHouse connection or a multi-minute scan. Returns `None` when the buffer
+/// is empty (nothing to flush).
+fn build_checkpoint_flush_batch(
+    buffer: &mut Vec<CheckpointMessage>,
+    schema: SchemaRef,
+) -> Option<RecordBatch> {
+    if buffer.is_empty() {
+        return None;
+    }
+    debug!(
+        "Flushing {} buffered checkpoint message(s) on source completion",
+        buffer.len()
+    );
+    let batch = RecordBatch::new_empty(schema);
+    let mut metadata = batch.schema().metadata().clone();
+    enrich_batch_metadata_with_checkpoints(&mut metadata, buffer);
+    let enriched = enrich_batch_with_metadata(batch, metadata)
+        .expect("Failed to enrich final flush batch with checkpoint metadata");
+    buffer.clear();
+    Some(enriched)
+}
+
 /// Drop the column at `drop_idx` and re-tag the batch with `target_schema`.
 /// Strips a dedup-only version column (force-included because the configured
 /// columns omit it) before emission, so the external schema is unchanged.
@@ -1708,6 +1744,27 @@ impl ExecutionPlan for ClickHouseSourceExec {
             }
             debug!("Checkpointing task completed for {}", reference_name);
 
+            // Flush any checkpoint messages buffered after the last data batch.
+            // attach_checkpoints only drains onto an outgoing data batch; a Marker
+            // that arrived during the final pages (or after the scan loop exited)
+            // has no batch to ride. Without this flush it is dropped when `tx`
+            // drops, the sink never ACKs the epoch, and the coordinator stalls on
+            // "missing sinks" — the production job-mode termination hang.
+            {
+                let flush_batch = build_checkpoint_flush_batch(
+                    &mut checkpoint_buffer_for_data.lock().expect("checkpoint buffer mutex poisoned"),
+                    empty_batch_schema.clone(),
+                );
+                if let Some(batch) = flush_batch
+                    && tx.send(Ok(batch)).await.is_err()
+                {
+                    warn!(
+                        "ClickHouseSourceExec: receiver dropped before final checkpoint flush for {}",
+                        reference_name
+                    );
+                }
+            }
+
             // Unsubscribe from checkpoint channel before dropping the receiver
             // to avoid SendError when the coordinator tries to send to this channel
             unsubscribe(CHECKPOINT_COORDINATOR_CHANNEL, checkpoint_subscriber_id);
@@ -2869,6 +2926,7 @@ impl ClickHouseClient {
 mod tests {
     use super::*;
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use streamling_core::checkpoints::checkpoint_management::CheckpointEpoch;
 
     #[test]
     fn split_range_start_reads_first_sorting_key() {
@@ -4625,6 +4683,47 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn checkpoint_flush_drains_buffered_markers_into_synthetic_batch() {
+        // Regression: after the scan loop exits, a Marker buffered in
+        // checkpoint_buffer has no data batch to ride. build_checkpoint_flush_batch
+        // must drain it into a synthetic empty batch carrying the markers as
+        // schema metadata so the sink ACKs the epoch before the stream ends.
+        // Without it the coordinator stalls on "missing sinks" (the production
+        // job-mode termination hang).
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8, false)]));
+
+        // Empty buffer -> nothing to flush.
+        let mut empty: Vec<CheckpointMessage> = vec![];
+        assert!(build_checkpoint_flush_batch(&mut empty, schema.clone()).is_none());
+        assert!(empty.is_empty(), "empty buffer stays empty");
+
+        // Buffered Marker -> synthetic empty batch carrying it, buffer drained.
+        let mut buffer = vec![CheckpointMessage::Marker {
+            epoch: CheckpointEpoch(42),
+            created_at_ms: 1234,
+        }];
+        let batch = build_checkpoint_flush_batch(&mut buffer, schema.clone())
+            .expect("non-empty buffer must produce a flush batch");
+        assert_eq!(batch.num_rows(), 0, "flush batch is synthetic/empty");
+        assert!(buffer.is_empty(), "buffer drained after flush");
+
+        // The Marker must be recoverable from the batch's schema metadata — that
+        // is how the sink extracts and ACKs it.
+        let extracted = extract_checkpoint_messages(batch.schema().metadata());
+        assert!(
+            !extracted.is_empty(),
+            "flush batch must carry the checkpoint marker in metadata"
+        );
+        assert!(
+            extracted.iter().any(|m| matches!(
+                m,
+                CheckpointMessage::Marker { epoch, .. } if epoch.0 == 42
+            )),
+            "flushed batch must carry epoch 42 marker"
+        );
     }
 }
 

--- a/crates/streamling-connectors/src/table_providers/clickhouse/query_builder.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse/query_builder.rs
@@ -23,7 +23,6 @@ pub struct ClickHouseQueryBuilder {
 }
 
 impl ClickHouseQueryBuilder {
-
     // Helper function to format ScalarValue for SQL with proper quoting
     fn format_scalar_for_sql(value: &ScalarValue) -> String {
         match value {

--- a/crates/streamling-connectors/src/table_providers/clickhouse/query_builder.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse/query_builder.rs
@@ -15,10 +15,14 @@ pub struct ClickHouseQueryBuilder {
     pagination_config: Option<ClickHousePaginationConfig>,
     current_keyset: Option<Vec<ScalarValue>>, // `>=` lower bound on the sorting key
     sort_key_range_upper_bound: Option<ScalarValue>, // Upper bound (exclusive) on first sorting key for sort key range pagination
+    /// Name of the ReplacingMergeTree `is_deleted` flag column, parsed from
+    /// `engine_full`. When `Some`, `_gs_op` is derived from it (so a custom-named
+    /// flag works); when `None` there is no engine-level deletion concept and
+    /// every row is classified 'i'. See `gs_op_field`.
+    is_deleted_column: Option<String>,
 }
 
 impl ClickHouseQueryBuilder {
-    const VIRTUAL_GS_OP_FIELD: &str = "CASE WHEN is_deleted=0 THEN 'i' ELSE 'd' END AS _gs_op";
 
     // Helper function to format ScalarValue for SQL with proper quoting
     fn format_scalar_for_sql(value: &ScalarValue) -> String {
@@ -81,6 +85,7 @@ impl ClickHouseQueryBuilder {
             pagination_config: config,
             current_keyset: None,
             sort_key_range_upper_bound: None,
+            is_deleted_column: None,
         }
     }
 
@@ -93,6 +98,25 @@ impl ClickHouseQueryBuilder {
     pub fn set_sort_key_range_upper_bound(&mut self, value: Option<ScalarValue>) -> &mut Self {
         self.sort_key_range_upper_bound = value;
         self
+    }
+
+    /// Set the ReplacingMergeTree `is_deleted` flag column name (parsed from
+    /// `engine_full`). Drives the virtual `_gs_op` field; see `gs_op_field`.
+    pub fn set_is_deleted_column(&mut self, col: Option<String>) -> &mut Self {
+        self.is_deleted_column = col;
+        self
+    }
+
+    /// The virtual `_gs_op` column: 'i' for a live row, 'd' for a tombstone.
+    /// For a ReplacingMergeTree with an `is_deleted` flag, derive it from that
+    /// flag using the column name parsed from `engine_full` (not a hardcode, so a
+    /// custom-named flag column works). With no `is_deleted` column there is no
+    /// engine-level deletion concept, so every row is classified 'i'.
+    fn gs_op_field(&self) -> String {
+        match &self.is_deleted_column {
+            Some(col) => format!("CASE WHEN {}=0 THEN 'i' ELSE 'd' END AS _gs_op", col),
+            None => "'i' AS _gs_op".to_string(),
+        }
     }
 
     // Rebuild the query with current pagination state
@@ -158,7 +182,7 @@ impl ClickHouseQueryBuilder {
         let final_select = format!(
             "SELECT {},\n{}",
             select_columns.join(",\n"),
-            Self::VIRTUAL_GS_OP_FIELD
+            self.gs_op_field()
         );
 
         // Combine CTE and final SELECT
@@ -402,7 +426,9 @@ mod tests {
     }
 
     #[test]
-    fn test_query_includes_gs_op() {
+    fn test_query_includes_gs_op_default_is_constant_insert() {
+        // No is_deleted column: no engine-level deletion concept, so _gs_op is a
+        // constant 'i' (always present so the output schema contract holds).
         let mut builder = ClickHouseQueryBuilder::of(
             "test_table".to_string(),
             vec!["id".to_string()],
@@ -410,10 +436,23 @@ mod tests {
             None,
         );
         let query = builder.get_query();
-
-        // Should include _gs_op virtual field
         assert!(query.contains("_gs_op"));
-        assert!(query.contains("CASE WHEN is_deleted=0 THEN 'i' ELSE 'd' END AS _gs_op"));
+        assert!(query.contains("'i' AS _gs_op"));
+    }
+
+    #[test]
+    fn test_query_gs_op_from_is_deleted_flag() {
+        // A ReplacingMergeTree is_deleted flag (custom name) drives _gs_op, so a
+        // non-standard flag column works instead of a hardcode.
+        let mut builder = ClickHouseQueryBuilder::of(
+            "test_table".to_string(),
+            vec!["id".to_string()],
+            None,
+            None,
+        );
+        builder.set_is_deleted_column(Some("deleted_flag".to_string()));
+        let query = builder.get_query();
+        assert!(query.contains("CASE WHEN deleted_flag=0 THEN 'i' ELSE 'd' END AS _gs_op"));
     }
 
     #[test]
@@ -424,6 +463,7 @@ mod tests {
             None,
             None,
         );
+        builder.set_is_deleted_column(Some("is_deleted".to_string()));
         let query = builder.get_query();
 
         // Should include id and name columns

--- a/crates/streamling-connectors/src/table_providers/clickhouse/query_builder.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse/query_builder.rs
@@ -13,9 +13,8 @@ pub struct ClickHouseQueryBuilder {
     columns: Vec<String>,
     where_clause: Option<String>,
     pagination_config: Option<ClickHousePaginationConfig>,
-    current_keyset: Option<Vec<ScalarValue>>, // Current pagination state
-    is_start_at: bool, // True if this keyset is from start_at (use >=), false if pagination boundary (use >)
-    block_range_upper_bound: Option<ScalarValue>, // Upper bound (exclusive) on first sorting key for block range pagination
+    current_keyset: Option<Vec<ScalarValue>>, // `>=` lower bound on the sorting key
+    sort_key_range_upper_bound: Option<ScalarValue>, // Upper bound (exclusive) on first sorting key for sort key range pagination
 }
 
 impl ClickHouseQueryBuilder {
@@ -81,41 +80,24 @@ impl ClickHouseQueryBuilder {
             where_clause,
             pagination_config: config,
             current_keyset: None,
-            is_start_at: false,
-            block_range_upper_bound: None,
+            sort_key_range_upper_bound: None,
         }
     }
 
     pub fn start_at_page(&mut self, args: Vec<ScalarValue>) -> &mut Self {
-        // Store the start_at keyset so it survives query rebuilding
+        // Store the keyset; it is applied as a `>=` lower bound on the sorting key.
         self.current_keyset = Some(args);
-        self.is_start_at = true;
         self
     }
 
-    // Convenient method to update pagination state and rebuild query
-    pub fn update_keyset(&mut self, keyset: Vec<ScalarValue>) -> &mut Self {
-        self.current_keyset = Some(keyset);
-        self.is_start_at = false; // This is a pagination boundary, not start_at
-        self.rebuild_query();
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn clear_keyset(&mut self) -> &mut Self {
-        self.current_keyset = None;
-        self.is_start_at = false;
-        self
-    }
-
-    pub fn set_block_range_upper_bound(&mut self, value: Option<ScalarValue>) -> &mut Self {
-        self.block_range_upper_bound = value;
+    pub fn set_sort_key_range_upper_bound(&mut self, value: Option<ScalarValue>) -> &mut Self {
+        self.sort_key_range_upper_bound = value;
         self
     }
 
     // Rebuild the query with current pagination state
     fn rebuild_query(&mut self) {
-        // Build the CTE with SELECT * FROM table WHERE ... ORDER BY ...
+        // Build the CTE with SELECT * FROM table WHERE ... (no ORDER BY; see below)
         let mut cte_query = format!("SELECT * FROM {}", self.table_name);
 
         // Add original where clause if it exists
@@ -128,9 +110,9 @@ impl ClickHouseQueryBuilder {
         let has_where = self.where_clause.is_some();
         let mut added_conditions = has_where;
 
-        // Add block range upper bound on the first sorting key
+        // Add sort key range upper bound on the first sorting key
         if let (Some(pagination_config), Some(upper_bound)) =
-            (&self.pagination_config, &self.block_range_upper_bound)
+            (&self.pagination_config, &self.sort_key_range_upper_bound)
             && let Some(first_key) = pagination_config.sorting_keys.first()
         {
             let bound_clause = format!(
@@ -147,7 +129,8 @@ impl ClickHouseQueryBuilder {
         if let (Some(pagination_config), Some(keyset)) =
             (&self.pagination_config, &self.current_keyset)
         {
-            let operator = if self.is_start_at { ">=" } else { ">" };
+            // The keyset is always a `>=` lower bound (set via start_at_page).
+            let operator = ">=";
             let conditions =
                 Self::build_keyset_conditions(&pagination_config.sorting_keys, keyset, operator);
             if !conditions.is_empty() {
@@ -156,13 +139,12 @@ impl ClickHouseQueryBuilder {
             }
         }
 
-        // Add ORDER BY clause to CTE
-        if let Some(pagination_config) = &self.pagination_config {
-            let sorting_keys_str = pagination_config.sorting_keys.join(",");
-            if !sorting_keys_str.trim().is_empty() {
-                cte_query = format!("{} ORDER BY {}", cte_query, sorting_keys_str);
-            }
-        }
+        // NB: deliberately NO `ORDER BY` here. Pagination is driven by disjoint
+        // half-open `block_number` ranges (the keyset/sort-key-range WHERE bounds
+        // above), so determinism comes from the predicate, not row order. An
+        // `ORDER BY` on the sorting key would force read-in-order on the main
+        // table and make ClickHouse skip a matching projection (read-in-order is
+        // not supported on projections), so it is intentionally omitted.
 
         // Build the final SELECT statement that selects columns from the CTE
         // Remove _gs_op if present since we create our own virtual column
@@ -195,6 +177,11 @@ impl ClickHouseQueryBuilder {
     // Get pagination config (for accessing page_size)
     pub fn pagination_config(&self) -> Option<&ClickHousePaginationConfig> {
         self.pagination_config.as_ref()
+    }
+
+    // The user-supplied filter, used to build the matching count probe.
+    pub fn where_clause(&self) -> Option<&str> {
+        self.where_clause.as_deref()
     }
 }
 
@@ -252,7 +239,10 @@ mod tests {
         // Should have CTE structure
         assert!(query.contains("WITH t AS"));
         assert!(query.contains("SELECT * FROM test_table"));
-        assert!(query.contains("ORDER BY id,timestamp"));
+        assert!(
+            !query.contains("ORDER BY"),
+            "CTE must not emit ORDER BY: {query}"
+        );
         assert!(query.contains("SELECT id,\nname"));
         assert!(query.contains("_gs_op"));
         assert!(query.contains("FROM t"));
@@ -275,7 +265,10 @@ mod tests {
         assert!(query.contains("WITH t AS"));
         assert!(query.contains("SELECT * FROM test_table"));
         assert!(query.contains("WHERE (status = 'active')"));
-        assert!(query.contains("ORDER BY id"));
+        assert!(
+            !query.contains("ORDER BY"),
+            "CTE must not emit ORDER BY: {query}"
+        );
     }
 
     #[test]
@@ -295,26 +288,10 @@ mod tests {
 
         // Should use >= for start_at
         assert!(query.contains("id >= 100"));
-        assert!(query.contains("ORDER BY id"));
-    }
-
-    #[test]
-    fn test_query_with_pagination_keyset() {
-        let pagination_config = ClickHousePaginationConfig {
-            sorting_keys: vec!["id".to_string()],
-            page_size: 1000,
-        };
-        let mut builder = ClickHouseQueryBuilder::of(
-            "test_table".to_string(),
-            vec!["id".to_string(), "name".to_string()],
-            None,
-            Some(pagination_config),
+        assert!(
+            !query.contains("ORDER BY"),
+            "CTE must not emit ORDER BY: {query}"
         );
-        builder.update_keyset(vec![ScalarValue::Int64(Some(100))]);
-        let query = builder.get_query();
-
-        // Should use > for pagination boundary
-        assert!(query.contains("id > 100"));
     }
 
     #[test]
@@ -338,7 +315,10 @@ mod tests {
         // Should have proper tuple comparison unwinding
         assert!(query.contains("block_number >= 1000"));
         assert!(query.contains("block_number = 1000 AND id >= 50"));
-        assert!(query.contains("ORDER BY block_number,id"));
+        assert!(
+            !query.contains("ORDER BY"),
+            "CTE must not emit ORDER BY: {query}"
+        );
     }
 
     #[test]
@@ -502,70 +482,16 @@ mod tests {
         assert!(query.starts_with("WITH t AS"));
         assert!(query.contains("SELECT * FROM matic_raw_logs"));
         assert!(query.contains("WHERE (address = '0x4bfb41d5b3570defd03c39a9a4d8de6bd8b8982e')"));
-        assert!(query.contains("ORDER BY id"));
+        assert!(
+            !query.contains("ORDER BY"),
+            "CTE must not emit ORDER BY: {query}"
+        );
         assert!(query.contains("SELECT id,\nblock_number,\nblock_hash"));
         assert!(query.contains("FROM t"));
     }
 
     #[test]
-    fn test_pagination_flow() {
-        let pagination_config = ClickHousePaginationConfig {
-            sorting_keys: vec!["block_number".to_string(), "id".to_string()],
-            page_size: 1000,
-        };
-        let mut builder = ClickHouseQueryBuilder::of(
-            "transactions".to_string(),
-            vec![
-                "block_number".to_string(),
-                "id".to_string(),
-                "hash".to_string(),
-            ],
-            Some("status = 'confirmed'".to_string()),
-            Some(pagination_config),
-        );
-
-        // First page: no keyset, should return all matching rows
-        let first_page_query = builder.get_query().to_string();
-        assert!(first_page_query.contains("SELECT * FROM transactions"));
-        assert!(first_page_query.contains("WHERE (status = 'confirmed')"));
-        assert!(first_page_query.contains("ORDER BY block_number,id"));
-        assert!(!first_page_query.contains("block_number >"));
-        assert!(!first_page_query.contains("block_number >="));
-
-        // Simulate reading first page and getting last row: block_number=1000, id=50
-        builder.update_keyset(vec![
-            ScalarValue::Int64(Some(1000)),
-            ScalarValue::Int64(Some(50)),
-        ]);
-        let second_page_query = builder.get_query().to_string();
-
-        // Second page: should use > (not >=) for pagination boundary
-        assert!(second_page_query.contains("WHERE (status = 'confirmed')"));
-        assert!(second_page_query.contains("AND"));
-        // Should have proper tuple comparison unwinding
-        assert!(second_page_query.contains("block_number > 1000"));
-        assert!(second_page_query.contains("block_number = 1000 AND id > 50"));
-        assert!(second_page_query.contains("ORDER BY block_number,id"));
-
-        // Simulate reading second page and getting last row: block_number=1000, id=150
-        builder.update_keyset(vec![
-            ScalarValue::Int64(Some(1000)),
-            ScalarValue::Int64(Some(150)),
-        ]);
-        let third_page_query = builder.get_query().to_string();
-
-        // Third page: should continue with > operator
-        assert!(third_page_query.contains("block_number > 1000"));
-        assert!(third_page_query.contains("block_number = 1000 AND id > 150"));
-
-        // Verify all queries have proper CTE structure
-        assert!(first_page_query.starts_with("WITH t AS"));
-        assert!(second_page_query.starts_with("WITH t AS"));
-        assert!(third_page_query.starts_with("WITH t AS"));
-    }
-
-    #[test]
-    fn test_block_range_upper_bound_only() {
+    fn test_sort_key_range_upper_bound_only() {
         let pagination_config = ClickHousePaginationConfig {
             sorting_keys: vec!["block_number".to_string(), "id".to_string()],
             page_size: 1000,
@@ -576,15 +502,18 @@ mod tests {
             None,
             Some(pagination_config),
         );
-        builder.set_block_range_upper_bound(Some(ScalarValue::Int64(Some(1_000_000))));
+        builder.set_sort_key_range_upper_bound(Some(ScalarValue::Int64(Some(1_000_000))));
         let query = builder.get_query();
 
         assert!(query.contains("block_number < 1000000"));
-        assert!(query.contains("ORDER BY block_number,id"));
+        assert!(
+            !query.contains("ORDER BY"),
+            "CTE must not emit ORDER BY: {query}"
+        );
     }
 
     #[test]
-    fn test_block_range_with_where_clause() {
+    fn test_sort_key_range_with_where_clause() {
         let pagination_config = ClickHousePaginationConfig {
             sorting_keys: vec!["block_number".to_string()],
             page_size: 1000,
@@ -595,7 +524,7 @@ mod tests {
             Some("address = '0x1234'".to_string()),
             Some(pagination_config),
         );
-        builder.set_block_range_upper_bound(Some(ScalarValue::Int64(Some(2_000_000))));
+        builder.set_sort_key_range_upper_bound(Some(ScalarValue::Int64(Some(2_000_000))));
         let query = builder.get_query();
 
         assert!(query.contains("WHERE (address = '0x1234')"));
@@ -603,32 +532,7 @@ mod tests {
     }
 
     #[test]
-    fn test_block_range_with_keyset() {
-        let pagination_config = ClickHousePaginationConfig {
-            sorting_keys: vec!["block_number".to_string(), "id".to_string()],
-            page_size: 1000,
-        };
-        let mut builder = ClickHouseQueryBuilder::of(
-            "test_table".to_string(),
-            vec!["block_number".to_string(), "id".to_string()],
-            None,
-            Some(pagination_config),
-        );
-        builder.set_block_range_upper_bound(Some(ScalarValue::Int64(Some(1_000_000))));
-        builder.update_keyset(vec![
-            ScalarValue::Int64(Some(500_000)),
-            ScalarValue::Int64(Some(42)),
-        ]);
-        let query = builder.get_query();
-
-        // Both block range upper bound and keyset conditions should be present
-        assert!(query.contains("block_number < 1000000"));
-        assert!(query.contains("block_number > 500000"));
-        assert!(query.contains("block_number = 500000 AND id > 42"));
-    }
-
-    #[test]
-    fn test_block_range_with_where_and_keyset() {
+    fn test_sort_key_range_with_where_and_keyset() {
         let pagination_config = ClickHousePaginationConfig {
             sorting_keys: vec!["block_number".to_string(), "id".to_string()],
             page_size: 1000,
@@ -639,132 +543,18 @@ mod tests {
             Some("address = '0xdead'".to_string()),
             Some(pagination_config),
         );
-        builder.set_block_range_upper_bound(Some(ScalarValue::Int64(Some(3_000_000))));
+        builder.set_sort_key_range_upper_bound(Some(ScalarValue::Int64(Some(3_000_000))));
         builder.start_at_page(vec![
             ScalarValue::Int64(Some(1_000_000)),
             ScalarValue::Int64(Some(0)),
         ]);
         let query = builder.get_query();
 
-        // All three conditions: filter, block range, and keyset
+        // All three conditions: filter, sort key range, and keyset
         assert!(query.contains("WHERE (address = '0xdead')"));
         assert!(query.contains("block_number < 3000000"));
         assert!(query.contains("block_number >= 1000000"));
         assert!(query.contains("block_number = 1000000 AND id >= 0"));
-    }
-
-    #[test]
-    fn test_clear_keyset() {
-        let pagination_config = ClickHousePaginationConfig {
-            sorting_keys: vec!["block_number".to_string()],
-            page_size: 1000,
-        };
-        let mut builder = ClickHouseQueryBuilder::of(
-            "test_table".to_string(),
-            vec!["block_number".to_string()],
-            None,
-            Some(pagination_config),
-        );
-
-        builder.update_keyset(vec![ScalarValue::Int64(Some(500))]);
-        let query_with_keyset = builder.get_query().to_string();
-        assert!(query_with_keyset.contains("block_number > 500"));
-
-        builder.clear_keyset();
-        let query_without_keyset = builder.get_query().to_string();
-        assert!(!query_without_keyset.contains("block_number >"));
-        assert!(!query_without_keyset.contains("block_number >="));
-    }
-
-    #[test]
-    fn test_block_range_pagination_flow() {
-        let pagination_config = ClickHousePaginationConfig {
-            sorting_keys: vec!["block_number".to_string(), "id".to_string()],
-            page_size: 1000,
-        };
-        let mut builder = ClickHouseQueryBuilder::of(
-            "traces".to_string(),
-            vec![
-                "block_number".to_string(),
-                "id".to_string(),
-                "data".to_string(),
-            ],
-            Some("error = '0x01'".to_string()),
-            Some(pagination_config),
-        );
-
-        // Range 1: [0, 1M) - first page, no keyset
-        builder.set_block_range_upper_bound(Some(ScalarValue::Int64(Some(1_000_000))));
-        let q1 = builder.get_query().to_string();
-        assert!(q1.contains("block_number < 1000000"));
-        assert!(!q1.contains("block_number >"));
-
-        // Within range 1: keyset pagination after first page
-        builder.update_keyset(vec![
-            ScalarValue::Int64(Some(500_000)),
-            ScalarValue::Int64(Some(99)),
-        ]);
-        let q2 = builder.get_query().to_string();
-        assert!(q2.contains("block_number < 1000000"));
-        assert!(q2.contains("block_number > 500000"));
-
-        // Advance to range 2: [1M, 2M) - start_at new range, new upper bound
-        builder.set_block_range_upper_bound(Some(ScalarValue::Int64(Some(2_000_000))));
-        builder.start_at_page(vec![ScalarValue::Int64(Some(1_000_000))]);
-        let q3 = builder.get_query().to_string();
-        assert!(q3.contains("block_number < 2000000"));
-        assert!(q3.contains("block_number >= 1000000"));
-        assert!(!q3.contains("block_number > 500000"));
-
-        // All queries maintain CTE structure
-        assert!(q1.starts_with("WITH t AS"));
-        assert!(q2.starts_with("WITH t AS"));
-        assert!(q3.starts_with("WITH t AS"));
-    }
-
-    #[test]
-    fn test_timeout_retry_resets_keyset() {
-        let pagination_config = ClickHousePaginationConfig {
-            sorting_keys: vec!["block_number".to_string(), "id".to_string()],
-            page_size: 1000,
-        };
-        let mut builder = ClickHouseQueryBuilder::of(
-            "traces".to_string(),
-            vec!["block_number".to_string(), "id".to_string()],
-            None,
-            Some(pagination_config),
-        );
-
-        // Scanning range [0, 1000) — keyset advanced to block_number=800
-        builder.set_block_range_upper_bound(Some(ScalarValue::Int64(Some(1000))));
-        builder.update_keyset(vec![
-            ScalarValue::Int64(Some(800)),
-            ScalarValue::Int64(Some(42)),
-        ]);
-        let q1 = builder.get_query().to_string();
-        assert!(q1.contains("block_number < 1000"));
-        assert!(q1.contains("block_number > 800"));
-
-        // Timeout! Shrink range to [0, 500) and reset keyset to range_start=0.
-        // Without the reset, the query would have block_number > 800 AND block_number < 500.
-        builder.set_block_range_upper_bound(Some(ScalarValue::Int64(Some(500))));
-        builder.start_at_page(vec![ScalarValue::Int64(Some(0))]);
-        let q2 = builder.get_query().to_string();
-        assert!(
-            q2.contains("block_number < 500"),
-            "upper bound should be 500, got: {}",
-            q2
-        );
-        assert!(
-            q2.contains("block_number >= 0"),
-            "should restart from range_start, got: {}",
-            q2
-        );
-        assert!(
-            !q2.contains("block_number > 800"),
-            "stale keyset must be cleared, got: {}",
-            q2
-        );
     }
 
     #[test]
@@ -781,9 +571,9 @@ mod tests {
             Some("address IN ('0x1234')".to_string()),
             Some(pagination_config),
         );
-        builder.set_block_range_upper_bound(Some(ScalarValue::Int64(Some(1_000_000))));
+        builder.set_sort_key_range_upper_bound(Some(ScalarValue::Int64(Some(1_000_000))));
         // Simulate an empty keyset being set (e.g. checkpoint with no args)
-        builder.update_keyset(vec![]);
+        builder.start_at_page(vec![]);
         let query = builder.get_query();
 
         assert!(
@@ -794,13 +584,13 @@ mod tests {
             !query.contains("WHERE ()"),
             "query must not contain 'WHERE ()': {query}"
         );
-        // The filter and block range upper bound should still be present
+        // The filter and sort key range upper bound should still be present
         assert!(query.contains("WHERE (address IN ('0x1234'))"));
         assert!(query.contains("AND (block_number < 1000000)"));
     }
 
     #[test]
-    fn test_recovery_uses_enlarged_block_range() {
+    fn test_recovery_uses_enlarged_sort_key_range() {
         let pagination_config = ClickHousePaginationConfig {
             sorting_keys: vec!["block_number".to_string(), "id".to_string()],
             page_size: 1000,
@@ -812,20 +602,20 @@ mod tests {
             Some(pagination_config),
         );
 
-        // Simulate: block_range was halved to 500 after timeout, range [0, 500) exhausted.
-        // Advancing to next range: recover block_range to 1000 first, THEN set upper bound.
-        let mut block_range: i128 = 500;
-        let default_block_range: i128 = 1000;
+        // Simulate: sort_key_range was halved to 500 after timeout, range [0, 500) exhausted.
+        // Advancing to next range: recover sort_key_range to 1000 first, THEN set upper bound.
+        let mut sort_key_range: i128 = 500;
+        let default_sort_key_range: i128 = 1000;
         let next_start: i128 = 500;
 
         // Recovery happens before setting upper bound
-        if block_range < default_block_range {
-            block_range = (block_range * 2).min(default_block_range);
+        if sort_key_range < default_sort_key_range {
+            sort_key_range = (sort_key_range * 2).min(default_sort_key_range);
         }
-        assert_eq!(block_range, 1000);
+        assert_eq!(sort_key_range, 1000);
 
-        builder.set_block_range_upper_bound(Some(ScalarValue::Int64(Some(
-            (next_start + block_range) as i64,
+        builder.set_sort_key_range_upper_bound(Some(ScalarValue::Int64(Some(
+            (next_start + sort_key_range) as i64,
         ))));
         builder.start_at_page(vec![ScalarValue::Int64(Some(next_start as i64))]);
         let query = builder.get_query().to_string();
@@ -833,7 +623,7 @@ mod tests {
         // The range should be [500, 1500), not [500, 1000) which would skip [1000, 1500)
         assert!(
             query.contains("block_number < 1500"),
-            "upper bound should use recovered block_range, got: {}",
+            "upper bound should use recovered sort_key_range, got: {}",
             query
         );
         assert!(query.contains("block_number >= 500"));

--- a/crates/streamling-connectors/src/table_providers/clickhouse/range_controller.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse/range_controller.rs
@@ -1,0 +1,427 @@
+use std::time::Duration;
+
+/// Adaptive sort-key-range pagination with an owned cursor.
+///
+/// The connector paginates by half-open ranges `[range_start, range_start + width)`
+/// on the first sorting key, with no `ORDER BY`, so determinism comes from the
+/// predicate (not row order) and a matching projection can be selected. This type
+/// owns both the cursor (`range_start`) and the adaptive `width`, so the
+/// advance-vs-reread decision — the part that determines whether data can be lost —
+/// is unit-testable in isolation.
+///
+/// Invariant: a range is only advanced past on `on_complete` (a fully-read page).
+/// `on_overflow` and `on_timeout` shrink `width` WITHOUT advancing, so the same
+/// range is re-read. Emitted ranges therefore tile the key space with no gaps.
+///
+/// Two signals drive width:
+/// - **rows** — the tripwire. A page is read with `LIMIT page_size + 1`; `page_size + 1`
+///   rows means the range overflowed (`on_overflow`), else it was fully consumed.
+/// - **elapsed** — the time guard. A page slower than `soft_time_budget` shrinks the
+///   width even if the row count looked fine, catching the scan-bound case.
+#[derive(Debug, Clone)]
+pub struct RangeController {
+    page_size: u64,
+    width: i128,
+    max_width: i128,
+    soft_time_budget: Duration,
+    range_start: i128,
+    max_key: i128,
+}
+
+impl RangeController {
+    /// Largest per-step growth multiplier. Bounds how fast width expands so a
+    /// near-empty page can't explode the range in one step.
+    const GROW_CEILING: f64 = 4.0;
+
+    /// Smallest range width: one key. A range must cover at least one key, or it
+    /// reads nothing, "completes", advances by zero, and the scan stalls forever.
+    /// This floor is what guarantees forward progress. It is deliberately 1 (not
+    /// higher): a larger floor could make a dense region unfittable into `page_size`
+    /// and falsely report it as unsplittable.
+    const MIN_WIDTH: i128 = 1;
+
+    pub fn new(
+        page_size: u64,
+        range_start: i128,
+        max_key: i128,
+        initial_width: i128,
+        max_width: i128,
+        soft_time_budget: Duration,
+    ) -> Self {
+        Self {
+            page_size,
+            width: initial_width.clamp(Self::MIN_WIDTH, max_width),
+            max_width,
+            soft_time_budget,
+            range_start,
+            max_key,
+        }
+    }
+
+    /// Start of the range to read next. This is the checkpoint cursor.
+    pub fn range_start(&self) -> i128 {
+        self.range_start
+    }
+
+    /// The half-open range to read next: `[range_start, range_start + width)`.
+    pub fn current_range(&self) -> (i128, i128) {
+        (self.range_start, self.range_start + self.width)
+    }
+
+    pub fn width(&self) -> i128 {
+        self.width
+    }
+
+    /// True once the cursor has advanced past the last key — the scan is finished.
+    pub fn is_done(&self) -> bool {
+        self.range_start > self.max_key
+    }
+
+    /// True when width is at its floor and can't shrink further. If a page still
+    /// overflows here, a single key holds more than `page_size` rows and the caller
+    /// must surface it rather than lose data.
+    pub fn at_min_width(&self) -> bool {
+        self.width <= Self::MIN_WIDTH
+    }
+
+    /// A page was fully consumed (rows <= page_size). Advances the cursor past the
+    /// completed range, then sizes the next range: grow toward `page_size` rows, or
+    /// shrink if the page was slow.
+    pub fn on_complete(&mut self, rows: usize, elapsed: Duration) {
+        // Advance past the range just read, using the width that produced it. This
+        // is the ONLY method that advances the cursor — overflow and timeout re-read.
+        self.range_start += self.width;
+
+        // Row-based multiplier: scale toward `page_size` rows per page, capped at
+        // GROW_CEILING. A completed page has rows <= page_size, so this is >= 1.0
+        // (never shrinks on rows alone — that's the tripwire's and time guard's job).
+        let rows = rows.max(1) as f64;
+        let row_mult = (self.page_size as f64 / rows).min(Self::GROW_CEILING);
+        let mut candidate = self.width as f64 * row_mult;
+
+        // Time guard: a page slower than the soft budget is transfer- or scan-bound,
+        // so shrink proportionally regardless of row headroom. This stops an
+        // empty-but-slow (sparse, no projection) page from growing into a timeout.
+        if elapsed > self.soft_time_budget {
+            let time_mult = self.soft_time_budget.as_secs_f64() / elapsed.as_secs_f64();
+            candidate = candidate.min(self.width as f64 * time_mult);
+        }
+
+        self.width = (candidate as i128).clamp(Self::MIN_WIDTH, self.max_width);
+    }
+
+    /// A page overflowed the tripwire (rows == page_size + 1). Shrinks width so the
+    /// SAME range is re-read. Does NOT advance the cursor. With a probed exact
+    /// `count`, resizes in one step; otherwise halves.
+    pub fn on_overflow(&mut self, probed_count: Option<u64>) {
+        let candidate = match probed_count {
+            Some(count) if count > 0 => {
+                (self.width as f64 * (self.page_size as f64 / count as f64)) as i128
+            }
+            _ => self.width / 2,
+        };
+        self.width = candidate.clamp(Self::MIN_WIDTH, self.max_width);
+    }
+
+    /// A page timed out. Shrinks width and re-reads the SAME range. Does NOT advance
+    /// the cursor, so no rows are skipped.
+    pub fn on_timeout(&mut self) {
+        self.on_overflow(None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // page_size 1000, cursor 0, far-off max_key, width 1000, max 1_000_000, 30s
+    fn controller() -> RangeController {
+        RangeController::new(
+            1000,
+            0,
+            1_000_000_000,
+            1000,
+            1_000_000,
+            Duration::from_secs(30),
+        )
+    }
+
+    // ---- width adaptation ----
+
+    #[test]
+    fn page_at_target_keeps_width_stable() {
+        let mut c = controller();
+        c.on_complete(1000, Duration::from_secs(1));
+        assert_eq!(
+            c.width(),
+            1000,
+            "a page exactly at page_size should hold width"
+        );
+    }
+
+    #[test]
+    fn sparse_page_grows_width_capped_at_ceiling() {
+        let mut c = controller();
+        c.on_complete(100, Duration::from_secs(1));
+        assert_eq!(c.width(), 4000, "growth is capped at 4x per step");
+    }
+
+    #[test]
+    fn empty_fast_page_grows_at_ceiling() {
+        let mut c = controller();
+        c.on_complete(0, Duration::from_secs(1));
+        assert_eq!(c.width(), 4000, "an empty fast page grows at the ceiling");
+    }
+
+    #[test]
+    fn empty_slow_page_does_not_grow() {
+        let mut c = controller();
+        // Empty but 60s against a 30s budget: scan-bound. Time guard overrides the
+        // grow-on-empty and shrinks instead (width * 30/60 = 500).
+        c.on_complete(0, Duration::from_secs(60));
+        assert_eq!(
+            c.width(),
+            500,
+            "an empty but slow page is scan-bound and must shrink"
+        );
+    }
+
+    #[test]
+    fn slow_page_shrinks_even_with_row_headroom() {
+        let mut c = controller();
+        c.on_complete(500, Duration::from_secs(60));
+        assert_eq!(c.width(), 500, "the time guard wins over row-based growth");
+    }
+
+    #[test]
+    fn overflow_with_probed_count_resizes_in_one_step() {
+        let mut c = controller();
+        c.on_overflow(Some(4000));
+        assert_eq!(c.width(), 250, "a probed count resizes precisely");
+    }
+
+    #[test]
+    fn overflow_without_count_halves() {
+        let mut c = controller();
+        c.on_overflow(None);
+        assert_eq!(c.width(), 500, "no probe -> halve");
+    }
+
+    #[test]
+    fn shrink_floors_at_one_to_guarantee_progress() {
+        // Width must never reach 0, or an empty range would stall the scan. Even an
+        // aggressive shrink (probed count far above page_size) floors at 1.
+        let mut c =
+            RangeController::new(1000, 0, 1_000_000, 100, 1_000_000, Duration::from_secs(30));
+        c.on_overflow(Some(1_000_000));
+        assert_eq!(
+            c.width(),
+            1,
+            "shrink floors at 1 so the cursor always advances"
+        );
+        assert!(c.at_min_width(), "width 1 is the minimum");
+    }
+
+    #[test]
+    fn growth_is_clamped_to_max_width() {
+        let mut c = RangeController::new(
+            1000,
+            0,
+            1_000_000_000,
+            500_000,
+            1_000_000,
+            Duration::from_secs(30),
+        );
+        c.on_complete(0, Duration::from_secs(1));
+        assert_eq!(c.width(), 1_000_000, "growth never exceeds max_width");
+    }
+
+    // ---- cursor / advance semantics (data-loss critical) ----
+
+    #[test]
+    fn complete_advances_cursor_by_the_width_just_used() {
+        let mut c =
+            RangeController::new(1000, 100, 1_000_000_000, 50, 4096, Duration::from_secs(30));
+        assert_eq!(c.current_range(), (100, 150));
+        c.on_complete(50, Duration::from_secs(1));
+        assert_eq!(
+            c.range_start(),
+            150,
+            "cursor advances by the width that was read"
+        );
+    }
+
+    #[test]
+    fn overflow_does_not_advance_cursor() {
+        let mut c = RangeController::new(20, 100, 1_000_000_000, 80, 4096, Duration::from_secs(30));
+        c.on_overflow(None);
+        assert_eq!(
+            c.range_start(),
+            100,
+            "overflow must re-read the same range, not advance"
+        );
+        assert_eq!(c.width(), 40, "overflow shrinks width");
+    }
+
+    #[test]
+    fn timeout_does_not_advance_cursor_and_shrinks() {
+        let mut c = RangeController::new(20, 100, 1_000_000_000, 80, 4096, Duration::from_secs(30));
+        c.on_timeout();
+        assert_eq!(c.range_start(), 100, "timeout must NOT advance the cursor");
+        assert!(c.width() < 80, "timeout shrinks the width");
+    }
+
+    #[test]
+    fn is_done_only_after_cursor_passes_max_key() {
+        let mut c = RangeController::new(1000, 0, 100, 100, 4096, Duration::from_secs(30));
+        assert!(!c.is_done());
+        c.on_complete(100, Duration::from_secs(1)); // advance 0 -> 100
+        assert!(
+            !c.is_done(),
+            "range_start == max_key is not done (max_key row still in range)"
+        );
+        c.on_complete(100, Duration::from_secs(1)); // advance past max_key
+        assert!(c.is_done(), "range_start past max_key is done");
+    }
+
+    // Synthetic distribution: 1 row per key, except a dense burst in [300,400) at
+    // 8 rows/key. With a small page_size this forces overflow + shrink inside the
+    // burst and growth back out — without ever exceeding page_size for a single key
+    // (so it stays coverable).
+    fn rows_in_range(start: i128, end: i128) -> usize {
+        let mut rows = 0usize;
+        for k in start..end {
+            rows += if (300..400).contains(&k) { 8 } else { 1 };
+        }
+        rows
+    }
+
+    /// CASE 1 (page size exceeds) + CASE 3 (scale down then back up): drive a full
+    /// scan through a dense burst. Assert the emitted ranges tile the whole key
+    /// space with no gaps and every row is emitted exactly once.
+    #[test]
+    fn no_data_loss_through_dense_burst_with_overflow_and_rescale() {
+        let max_key = 1000i128;
+        let page_size = 20u64;
+        let mut c = RangeController::new(page_size, 0, max_key, 20, 4096, Duration::from_secs(30));
+
+        let mut emitted: Vec<(i128, i128)> = Vec::new();
+        let mut saw_overflow = false;
+        let mut min_width_in_burst = i128::MAX;
+        let mut max_width_after_burst = 0i128;
+        let mut guard = 0;
+
+        while !c.is_done() {
+            guard += 1;
+            assert!(guard < 1_000_000, "controller failed to terminate");
+            let (start, end_raw) = c.current_range();
+            let end = end_raw.min(max_key + 1);
+            let rows = rows_in_range(start, end);
+
+            if rows as u64 > page_size {
+                assert!(
+                    !c.at_min_width(),
+                    "coverable density must never stick at min width"
+                );
+                saw_overflow = true;
+                min_width_in_burst = min_width_in_burst.min(c.width());
+                c.on_overflow(None);
+            } else {
+                emitted.push((start, end));
+                c.on_complete(rows, Duration::from_millis(1));
+                if start >= 400 {
+                    max_width_after_burst = max_width_after_burst.max(c.width());
+                }
+            }
+        }
+
+        // No gaps, no overlaps: emitted ranges tile [0, max_key + 1) contiguously.
+        assert_eq!(emitted.first().unwrap().0, 0, "scan must start at key 0");
+        for w in emitted.windows(2) {
+            assert_eq!(
+                w[0].1, w[1].0,
+                "gap or overlap between {:?} and {:?}",
+                w[0], w[1]
+            );
+        }
+        assert!(
+            emitted.last().unwrap().1 > max_key,
+            "scan must cover past max_key"
+        );
+
+        // Every row emitted exactly once.
+        let total = rows_in_range(0, max_key + 1);
+        let got: usize = emitted.iter().map(|(s, e)| rows_in_range(*s, *e)).sum();
+        assert_eq!(
+            got, total,
+            "all rows must be emitted exactly once (no loss, no dup)"
+        );
+
+        // We actually scaled down in the burst and back up afterward.
+        assert!(saw_overflow, "dense burst should have triggered overflow");
+        assert!(
+            max_width_after_burst > min_width_in_burst,
+            "width should recover after the burst (down {} -> up {})",
+            min_width_in_burst,
+            max_width_after_burst
+        );
+    }
+
+    /// CASE 2 (timeout): every 3rd page times out. Timeouts must re-read without
+    /// advancing, so the scan still covers every key with no gaps.
+    #[test]
+    fn no_data_loss_with_injected_timeouts() {
+        let max_key = 500i128;
+        let page_size = 20u64;
+        let mut c = RangeController::new(page_size, 0, max_key, 30, 4096, Duration::from_secs(30));
+
+        let mut emitted: Vec<(i128, i128)> = Vec::new();
+        let mut step = 0;
+        let mut guard = 0;
+        let mut saw_timeout = false;
+
+        while !c.is_done() {
+            guard += 1;
+            assert!(guard < 1_000_000, "controller failed to terminate");
+            let (start, end_raw) = c.current_range();
+            let end = end_raw.min(max_key + 1);
+            step += 1;
+
+            // Inject a timeout on every 3rd page (while there's width to shrink).
+            if step % 3 == 0 && c.width() > 1 {
+                saw_timeout = true;
+                c.on_timeout();
+                continue;
+            }
+
+            let rows = rows_in_range(start, end);
+            if rows as u64 > page_size {
+                assert!(
+                    !c.at_min_width(),
+                    "coverable density must never stick at min width"
+                );
+                c.on_overflow(None);
+            } else {
+                emitted.push((start, end));
+                c.on_complete(rows, Duration::from_millis(1));
+            }
+        }
+
+        assert!(saw_timeout, "test should have injected timeouts");
+        assert_eq!(emitted.first().unwrap().0, 0, "scan must start at key 0");
+        for w in emitted.windows(2) {
+            assert_eq!(
+                w[0].1, w[1].0,
+                "gap or overlap between {:?} and {:?}",
+                w[0], w[1]
+            );
+        }
+        assert!(
+            emitted.last().unwrap().1 > max_key,
+            "scan must cover past max_key"
+        );
+        let total = rows_in_range(0, max_key + 1);
+        let got: usize = emitted.iter().map(|(s, e)| rows_in_range(*s, *e)).sum();
+        assert_eq!(got, total, "no rows lost despite timeouts");
+    }
+}

--- a/crates/streamling-connectors/src/table_providers/clickhouse/range_controller.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse/range_controller.rs
@@ -55,6 +55,15 @@ impl RangeController {
     /// page can't creep back up to the limit and re-overflow.
     const BYTE_TARGET_RATIO: f64 = 0.9;
 
+    /// Fraction of `page_size` that a probed one-step resize targets for rows.
+    /// Symmetric with `BYTE_TARGET_RATIO`: sizing a shrunk range to land at
+    /// *exactly* `page_size` rows leaves no margin, so a range whose true count
+    /// sits just over the tripwire re-reads at almost the same width, hits
+    /// `page_size + 1` again, and creeps down a row at a time. Targeting 90%
+    /// guarantees each overflow shrinks the width meaningfully, at the cost of
+    /// ~10% per-page headroom in a steady dense region.
+    const ROW_TARGET_RATIO: f64 = 0.9;
+
     /// Smallest range width: one key. A range must cover at least one key, or it
     /// reads nothing, "completes", advances by zero, and the scan stalls forever.
     /// This floor is what guarantees forward progress. It is deliberately 1 (not
@@ -180,6 +189,56 @@ impl RangeController {
             self.width / 2
         };
         self.width = candidate.clamp(Self::MIN_WIDTH, self.max_width);
+    }
+
+    /// A page overflowed the row tripwire and/or the byte guard, and the caller
+    /// probed the exact `count` for the range just read. Size the next width to
+    /// satisfy BOTH limits in one step using the *true* density (`count /
+    /// width`) — not the LIMIT-capped row sample that biases `on_byte_overflow`.
+    ///
+    /// `observed_bytes` is the byte size of the rows actually materialised (≤
+    /// `page_size + 1`). Divided by the smaller of `count` and `page_size + 1`
+    /// it gives bytes-per-row; multiplied by the true row density it predicts
+    /// the byte density of the *whole* range, so the byte limit is respected
+    /// even though only a prefix of the rows was read.
+    ///
+    /// This is what makes a dense region converge in one re-read instead of
+    /// shrinking geometrically over many discarded pages: a wide range whose
+    /// first `page_size + 1` rows overflow still has its full `count` probed,
+    /// so the next width lands under both limits immediately. A probe failure
+    /// (`None`) falls back to the byte/row shrink so a transient count-query
+    /// error cannot stall the scan. Does NOT advance the cursor — the same
+    /// range is re-read.
+    pub fn on_overflow_probed(&mut self, count: Option<u64>, observed_bytes: u64) {
+        let Some(count) = count.filter(|&c| c > 0) else {
+            if observed_bytes > self.max_page_bytes {
+                self.on_byte_overflow(observed_bytes);
+            } else {
+                self.on_overflow(None);
+            }
+            return;
+        };
+        let count = count as f64;
+        // Bytes-per-row from the sampled rows we actually materialised. The
+        // sample is at most page_size + 1 rows even when the range holds more.
+        let sampled_rows = count.min(self.page_size as f64 + 1.0);
+        let bytes_per_row = if observed_bytes > 0 {
+            observed_bytes as f64 / sampled_rows
+        } else {
+            0.0
+        };
+        // Row-safe width: scale so the next range holds ~ROW_TARGET_RATIO * page_size.
+        let row_safe = self.width as f64 * (Self::ROW_TARGET_RATIO * self.page_size as f64 / count);
+        // Byte-safe width: scale so the next range holds ~BYTE_TARGET_RATIO * max.
+        // bytes_per_width = (count / width) * bytes_per_row = true row density × size.
+        let byte_safe = if bytes_per_row > 0.0 && self.width > 0 {
+            let bytes_per_width = (count / self.width as f64) * bytes_per_row;
+            (Self::BYTE_TARGET_RATIO * self.max_page_bytes as f64) / bytes_per_width
+        } else {
+            row_safe
+        };
+        let candidate = row_safe.min(byte_safe);
+        self.width = (candidate as i128).clamp(Self::MIN_WIDTH, self.max_width);
     }
 
     /// A page timed out. Shrinks width and re-reads the SAME range. Does NOT advance
@@ -610,6 +669,130 @@ mod tests {
         // row_mult = 100_000/10 capped at 4 -> 1000*4 = 4000; byte_ceiling =
         // 1000/(10/1000) = 100_000; min = 4000, clamped to max_width 100_000.
         assert_eq!(c.width(), 4000, "byte-light page grows normally");
+    }
+
+    // ---- probed one-step overflow sizing (true density) ----
+
+    #[test]
+    fn probed_overflow_converges_dense_range_in_one_step() {
+        // The production pathology: a wide range whose first page_size+1 rows
+        // overflow on bytes. The LIMIT-capped sample under-estimates density, so
+        // the old byte sizer shrank geometrically over many re-reads. With a
+        // probed count the true density sizes the next width under the byte limit
+        // at once. byte_controller: page_size 100_000, max 1000 bytes, width 1000.
+        //   count 50_000 (true); observed 4000 bytes for all 50_000 rows.
+        //   bytes_per_row = 4000/50_000 = 0.08
+        //   bytes_per_width = (50_000/1000)*0.08 = 4.0
+        //   byte_safe = 0.9*1000/4 = 225; row_safe = 1000*0.9*100_000/50_000 = 1800
+        //   -> 225 (byte binds), one step.
+        let mut c = byte_controller();
+        c.on_overflow_probed(Some(50_000), 4000);
+        assert_eq!(c.width(), 225, "one-step resize to the byte-safe width");
+        assert_eq!(
+            c.range_start(),
+            0,
+            "probed overflow must NOT advance the cursor (re-read the same range)"
+        );
+    }
+
+    #[test]
+    fn probed_overflow_byte_only_matches_byte_sizer() {
+        // count <= page_size (rows fit, bytes trip): reduces to on_byte_overflow.
+        let mut a = byte_controller();
+        let mut b = byte_controller();
+        a.on_overflow_probed(Some(100), 2500);
+        b.on_byte_overflow(2500);
+        assert_eq!(a.width(), b.width());
+        assert_eq!(a.width(), 360);
+    }
+
+    #[test]
+    fn probed_overflow_row_only_targets_ninety_percent() {
+        // No byte concern (observed 0): row constraint binds, sized to 90% of the
+        // row-safe width (10% margin vs on_overflow's exact page_size target).
+        let mut c = controller(); // page_size 1000, width 1000
+        c.on_overflow_probed(Some(4000), 0);
+        assert_eq!(c.width(), 225, "0.9 * (1000*1000/4000) = 225");
+    }
+
+    #[test]
+    fn probed_overflow_none_falls_back_to_byte_or_halve() {
+        // A failed/absent probe must not change behavior vs the un-probed path.
+        let mut over = byte_controller(); // max_page_bytes 1000
+        over.on_overflow_probed(None, 2500); // bytes over limit -> byte sizer
+        assert_eq!(over.width(), 360);
+
+        let mut under = controller(); // max_page_bytes u64::MAX, width 1000
+        under.on_overflow_probed(None, 0); // bytes under limit -> halve
+        assert_eq!(under.width(), 500);
+    }
+
+    #[test]
+    fn probed_overflow_floors_at_one() {
+        // A single key holding vast bytes/rows: even the true density can't fit,
+        // so width floors at MIN_WIDTH and the caller surfaces it.
+        let mut c = byte_controller();
+        c.on_overflow_probed(Some(u64::MAX), u64::MAX);
+        assert_eq!(c.width(), 1);
+        assert!(c.at_min_width());
+    }
+
+    /// No-data-loss check for the probed path: drive a full scan through the dense
+    /// burst, sizing overflows from the true count (as the driver now does). The
+    /// emitted ranges must still tile the key space with no gaps or duplicates.
+    #[test]
+    fn no_data_loss_with_probed_overflow_sizing() {
+        let max_key = 1000i128;
+        let page_size = 20u64;
+        let mut c = RangeController::new(
+            page_size,
+            u64::MAX,
+            0,
+            max_key,
+            20,
+            4096,
+            Duration::from_secs(30),
+        );
+
+        let mut emitted: Vec<(i128, i128)> = Vec::new();
+        let mut guard = 0;
+        while !c.is_done() {
+            guard += 1;
+            assert!(guard < 1_000_000, "controller failed to terminate");
+            let (start, end_raw) = c.current_range();
+            let end = end_raw.min(max_key + 1);
+            let rows = rows_in_range(start, end);
+            if rows as u64 > page_size {
+                assert!(
+                    !c.at_min_width(),
+                    "coverable density must never stick at min width"
+                );
+                // The driver probes the true count here.
+                c.on_overflow_probed(Some(rows as u64), 0);
+            } else {
+                emitted.push((start, end));
+                c.on_complete(rows, Duration::from_millis(1), 0);
+            }
+        }
+
+        assert_eq!(emitted.first().unwrap().0, 0, "scan must start at key 0");
+        for w in emitted.windows(2) {
+            assert_eq!(
+                w[0].1, w[1].0,
+                "gap or overlap between {:?} and {:?}",
+                w[0], w[1]
+            );
+        }
+        assert!(
+            emitted.last().unwrap().1 > max_key,
+            "scan must cover past max_key"
+        );
+        let total = rows_in_range(0, max_key + 1);
+        let got: usize = emitted.iter().map(|(s, e)| rows_in_range(*s, *e)).sum();
+        assert_eq!(
+            got, total,
+            "all rows emitted exactly once (no loss, no dup)"
+        );
     }
 
     /// A full scan through a byte-dense burst. Models bytes-per-key (1 outside

--- a/crates/streamling-connectors/src/table_providers/clickhouse/range_controller.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse/range_controller.rs
@@ -241,6 +241,30 @@ impl RangeController {
         self.width = (candidate as i128).clamp(Self::MIN_WIDTH, self.max_width);
     }
 
+    /// Count-first sizing: shrink the current range's width so it holds ≤ ~`page_size`
+    /// rows, given an exact `count` for the range the cursor currently covers. Called
+    /// BEFORE the data read so a clustered high-fanout region is shrunk to fit without
+    /// first materialising an oversized page — the up-front span-average density that
+    /// sized `initial_width` misses dense clusters, which is the OOM path.
+    ///
+    /// Row-based only (no bytes are known before the read); the reactive byte
+    /// tripwire remains the backstop for variable-width columns. Does NOT advance the
+    /// cursor — the caller re-probes the shrunk range until it fits or
+    /// [`at_min_width`] is reached. Returns `true` when `count` already fits
+    /// (`count <= page_size`), `false` after shrinking (caller should re-probe).
+    pub fn shrink_to_fit_count(&mut self, count: u64) -> bool {
+        if count <= self.page_size {
+            return true;
+        }
+        // Mirror on_overflow_probed's row sizing: target ROW_TARGET_RATIO of
+        // page_size so a range whose density sits right at the boundary doesn't
+        // re-overflow on the immediately following read.
+        let candidate =
+            self.width as f64 * (Self::ROW_TARGET_RATIO * self.page_size as f64 / count as f64);
+        self.width = (candidate as i128).clamp(Self::MIN_WIDTH, self.max_width);
+        false
+    }
+
     /// A page timed out. Shrinks width and re-reads the SAME range. Does NOT advance
     /// the cursor, so no rows are skipped.
     pub fn on_timeout(&mut self) {
@@ -346,6 +370,52 @@ mod tests {
             "shrink floors at 1 so the cursor always advances"
         );
         assert!(c.at_min_width(), "width 1 is the minimum");
+    }
+
+    #[test]
+    fn shrink_to_fit_count_is_noop_when_already_fits() {
+        let mut c = controller(); // page_size 1000, width 1000
+        assert!(c.shrink_to_fit_count(800), "a range that fits reports true");
+        assert_eq!(c.width(), 1000, "a fitting range is not shrunk");
+    }
+
+    #[test]
+    fn shrink_to_fit_count_sizes_from_exact_density() {
+        // width 1000 holds 4000 rows (4x page_size). Targeting 0.9*page_size rows
+        // lands at width 1000 * (900 / 4000) = 225.
+        let mut c = controller();
+        assert!(
+            !c.shrink_to_fit_count(4000),
+            "a shrunk range reports false so the caller re-probes"
+        );
+        assert_eq!(c.width(), 225);
+    }
+
+    #[test]
+    fn shrink_to_fit_count_floors_at_min_width() {
+        // A single key dwarfing page_size can't shrink below MIN_WIDTH (1).
+        let mut c = RangeController::new(
+            1000,
+            u64::MAX,
+            0,
+            1_000_000,
+            100,
+            1_000_000,
+            Duration::from_secs(30),
+        );
+        assert!(!c.shrink_to_fit_count(u64::MAX));
+        assert_eq!(c.width(), 1);
+        assert!(c.at_min_width());
+    }
+
+    #[test]
+    fn shrink_to_fit_count_does_not_advance_cursor() {
+        let mut c = controller(); // cursor 0
+        c.shrink_to_fit_count(4000);
+        assert_eq!(c.range_start(), 0, "sizing never advances the cursor");
+        let (start, upper) = c.current_range();
+        assert_eq!(start, 0);
+        assert_eq!(upper, 225, "upper bound reflects the shrunk width");
     }
 
     #[test]

--- a/crates/streamling-connectors/src/table_providers/clickhouse/range_controller.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse/range_controller.rs
@@ -44,6 +44,17 @@ impl RangeController {
     /// near-empty page can't explode the range in one step.
     const GROW_CEILING: f64 = 4.0;
 
+    /// Fraction of `max_page_bytes` that byte sizing targets. A re-read covers a
+    /// different (shrunk) sub-range whose byte density differs from the page that
+    /// overflowed, so sizing to land at *exactly* the limit asymptotes — each read
+    /// lands a hair over and shrinks by one (observed on `matic_raw_logs`: 6
+    /// discarded ~1 GiB reads to converge). Targeting 90% leaves headroom for that
+    /// density variance so the re-read lands under the limit in one step; even when
+    /// variance exceeds it, convergence is geometric (each step shrinks >10%), not
+    /// a unit creep. `on_complete`'s byte clamp uses the same target so a completed
+    /// page can't creep back up to the limit and re-overflow.
+    const BYTE_TARGET_RATIO: f64 = 0.9;
+
     /// Smallest range width: one key. A range must cover at least one key, or it
     /// reads nothing, "completes", advances by zero, and the scan stalls forever.
     /// This floor is what guarantees forward progress. It is deliberately 1 (not
@@ -128,10 +139,13 @@ impl RangeController {
         // using the byte density just observed (bytes per unit width). `self.width`
         // here is still the completing page's width, so bytes/width is the density
         // of the region just scanned. A byte-light page leaves headroom to grow;
-        // a byte-heavy page pins width near its current value.
+        // a byte-heavy page pins width near its current value. Target
+        // BYTE_TARGET_RATIO of the limit so a page completing right at the cap
+        // can't let the next one creep over and re-overflow.
         if bytes > 0 && self.width > 0 {
             let bytes_per_width = bytes as f64 / self.width as f64;
-            let byte_ceiling = self.max_page_bytes as f64 / bytes_per_width;
+            let byte_ceiling =
+                (self.max_page_bytes as f64 * Self::BYTE_TARGET_RATIO) / bytes_per_width;
             candidate = candidate.min(byte_ceiling);
         }
 
@@ -152,13 +166,16 @@ impl RangeController {
     }
 
     /// A page overflowed the byte guard (bytes > max_page_bytes) while fitting by
-    /// rows. Sizes the next width from the observed byte density so the re-read
-    /// lands just under `max_page_bytes` in one step — halving could take several
-    /// discarded reads to converge, and `on_complete`'s byte clamp then keeps it
-    /// there. Does NOT advance the cursor, so the same range is re-read.
+    /// rows. Sizes the next width from the observed byte density, targeting
+    /// `BYTE_TARGET_RATIO` of `max_page_bytes` (not the limit itself) so the re-read
+    /// — which covers a different, shrunk sub-range with different density — lands
+    /// under the limit in one step rather than asymptoting a unit at a time.
+    /// `on_complete`'s byte clamp then keeps it there. Does NOT advance the cursor,
+    /// so the same range is re-read.
     pub fn on_byte_overflow(&mut self, observed_bytes: u64) {
+        let target = self.max_page_bytes as f64 * Self::BYTE_TARGET_RATIO;
         let candidate = if observed_bytes > 0 {
-            (self.width as f64 * (self.max_page_bytes as f64 / observed_bytes as f64)) as i128
+            (self.width as f64 * (target / observed_bytes as f64)) as i128
         } else {
             self.width / 2
         };
@@ -535,13 +552,13 @@ mod tests {
     #[test]
     fn byte_overflow_sizes_from_observed_density_in_one_step() {
         let mut c = byte_controller();
-        // width 1000, observed 2500 bytes vs a 1000 limit -> next width 400,
-        // landing just under the limit in a single re-read (not a halve chain).
+        // width 1000, observed 2500 bytes vs a 1000 limit, target 90% -> next
+        // width 360, landing under the limit with headroom in a single re-read.
         c.on_byte_overflow(2500);
         assert_eq!(
             c.width(),
-            400,
-            "byte overflow resizes by max/observed ratio"
+            360,
+            "byte overflow resizes by (0.9*max)/observed ratio"
         );
         assert_eq!(
             c.range_start(),
@@ -568,14 +585,18 @@ mod tests {
         // between overflow and re-read forever. With the clamp, width stays put.
         let mut c = byte_controller();
         // width 1000: rows 100 (row-sparse), bytes 2000 (byte-dense -> overflow).
+        // Target 90% of the 1000 limit -> shrinks to 450 (not 500).
         c.on_byte_overflow(2000);
-        assert_eq!(c.width(), 500, "shrunk to the byte-safe width");
-        // Re-read at 500: bytes ~1000 (at the limit, not over), rows ~50 -> complete.
+        assert_eq!(c.width(), 450, "shrunk to 90% of the byte-safe width");
+        // Re-read at 450: bytes ~1000 (at the limit, not over), rows ~50 -> complete.
+        // The byte clamp caps growth at 90% of the limit, so width does NOT snap
+        // back toward the row multiplier's 1800 target.
         c.on_complete(50, Duration::from_millis(1), 1000);
-        assert_eq!(
-            c.width(),
-            500,
-            "on_complete must NOT grow width back into a byte overflow"
+        assert!(
+            c.width() <= 450,
+            "on_complete must NOT grow width back into a byte overflow \
+             (clamped to {}, would be ~1800 without it)",
+            c.width()
         );
     }
 

--- a/crates/streamling-connectors/src/table_providers/clickhouse/range_controller.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse/range_controller.rs
@@ -164,7 +164,7 @@ impl RangeController {
     /// A page overflowed the row tripwire (rows == page_size + 1). Shrinks width so
     /// the SAME range is re-read. Does NOT advance the cursor. With a probed exact
     /// `count`, resizes in one step; otherwise halves.
-    pub fn on_overflow(&mut self, probed_count: Option<u64>) {
+    fn on_overflow(&mut self, probed_count: Option<u64>) {
         let candidate = match probed_count {
             Some(count) if count > 0 => {
                 (self.width as f64 * (self.page_size as f64 / count as f64)) as i128
@@ -181,7 +181,7 @@ impl RangeController {
     /// under the limit in one step rather than asymptoting a unit at a time.
     /// `on_complete`'s byte clamp then keeps it there. Does NOT advance the cursor,
     /// so the same range is re-read.
-    pub fn on_byte_overflow(&mut self, observed_bytes: u64) {
+    fn on_byte_overflow(&mut self, observed_bytes: u64) {
         let target = self.max_page_bytes as f64 * Self::BYTE_TARGET_RATIO;
         let candidate = if observed_bytes > 0 {
             (self.width as f64 * (target / observed_bytes as f64)) as i128

--- a/crates/streamling-connectors/src/table_providers/clickhouse/range_controller.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse/range_controller.rs
@@ -13,14 +13,25 @@ use std::time::Duration;
 /// `on_overflow` and `on_timeout` shrink `width` WITHOUT advancing, so the same
 /// range is re-read. Emitted ranges therefore tile the key space with no gaps.
 ///
-/// Two signals drive width:
+/// Three signals drive width:
 /// - **rows** — the tripwire. A page is read with `LIMIT page_size + 1`; `page_size + 1`
 ///   rows means the range overflowed (`on_overflow`), else it was fully consumed.
 /// - **elapsed** — the time guard. A page slower than `soft_time_budget` shrinks the
 ///   width even if the row count looked fine, catching the scan-bound case.
+/// - **bytes** — the array guard. A page over `max_page_bytes` (`on_byte_overflow`)
+///   would build a single Arrow column past the ~2 GiB `i32` offset limit, so it is
+///   re-read smaller. `on_complete` also clamps growth by observed byte density, or a
+///   byte-dense region would let the row multiplier snap width straight back into a
+///   byte overflow and thrash forever.
 #[derive(Debug, Clone)]
 pub struct RangeController {
     page_size: u64,
+    /// Upper bound on a page's total byte size. Guards Arrow's `i32` per-array
+    /// limit (~2 GiB): the widest column is at most the page total, so a page
+    /// kept under this never builds a column that overflows `concat_batches` or
+    /// the IPC reader. Drives `on_byte_overflow` and the byte clamp in
+    /// `on_complete`.
+    max_page_bytes: u64,
     width: i128,
     max_width: i128,
     soft_time_budget: Duration,
@@ -42,6 +53,7 @@ impl RangeController {
 
     pub fn new(
         page_size: u64,
+        max_page_bytes: u64,
         range_start: i128,
         max_key: i128,
         initial_width: i128,
@@ -50,6 +62,7 @@ impl RangeController {
     ) -> Self {
         Self {
             page_size,
+            max_page_bytes,
             width: initial_width.clamp(Self::MIN_WIDTH, max_width),
             max_width,
             soft_time_budget,
@@ -84,10 +97,14 @@ impl RangeController {
         self.width <= Self::MIN_WIDTH
     }
 
-    /// A page was fully consumed (rows <= page_size). Advances the cursor past the
-    /// completed range, then sizes the next range: grow toward `page_size` rows, or
-    /// shrink if the page was slow.
-    pub fn on_complete(&mut self, rows: usize, elapsed: Duration) {
+    /// A page was fully consumed (rows <= page_size, bytes <= max_page_bytes).
+    /// Advances the cursor past the completed range, then sizes the next range:
+    /// grow toward `page_size` rows, shrink if the page was slow, and — crucially
+    /// — never grow past the byte density just observed. That byte clamp is what
+    /// stops a byte-dense region from thrashing: without it the row multiplier
+    /// (rows are few when bytes are large) would snap width straight back over
+    /// `max_page_bytes`, re-trigger overflow, and re-read forever.
+    pub fn on_complete(&mut self, rows: usize, elapsed: Duration, bytes: u64) {
         // Advance past the range just read, using the width that produced it. This
         // is the ONLY method that advances the cursor — overflow and timeout re-read.
         self.range_start += self.width;
@@ -107,11 +124,22 @@ impl RangeController {
             candidate = candidate.min(self.width as f64 * time_mult);
         }
 
+        // Byte guard: cap growth so the next page stays under `max_page_bytes`,
+        // using the byte density just observed (bytes per unit width). `self.width`
+        // here is still the completing page's width, so bytes/width is the density
+        // of the region just scanned. A byte-light page leaves headroom to grow;
+        // a byte-heavy page pins width near its current value.
+        if bytes > 0 && self.width > 0 {
+            let bytes_per_width = bytes as f64 / self.width as f64;
+            let byte_ceiling = self.max_page_bytes as f64 / bytes_per_width;
+            candidate = candidate.min(byte_ceiling);
+        }
+
         self.width = (candidate as i128).clamp(Self::MIN_WIDTH, self.max_width);
     }
 
-    /// A page overflowed the tripwire (rows == page_size + 1). Shrinks width so the
-    /// SAME range is re-read. Does NOT advance the cursor. With a probed exact
+    /// A page overflowed the row tripwire (rows == page_size + 1). Shrinks width so
+    /// the SAME range is re-read. Does NOT advance the cursor. With a probed exact
     /// `count`, resizes in one step; otherwise halves.
     pub fn on_overflow(&mut self, probed_count: Option<u64>) {
         let candidate = match probed_count {
@@ -119,6 +147,20 @@ impl RangeController {
                 (self.width as f64 * (self.page_size as f64 / count as f64)) as i128
             }
             _ => self.width / 2,
+        };
+        self.width = candidate.clamp(Self::MIN_WIDTH, self.max_width);
+    }
+
+    /// A page overflowed the byte guard (bytes > max_page_bytes) while fitting by
+    /// rows. Sizes the next width from the observed byte density so the re-read
+    /// lands just under `max_page_bytes` in one step — halving could take several
+    /// discarded reads to converge, and `on_complete`'s byte clamp then keeps it
+    /// there. Does NOT advance the cursor, so the same range is re-read.
+    pub fn on_byte_overflow(&mut self, observed_bytes: u64) {
+        let candidate = if observed_bytes > 0 {
+            (self.width as f64 * (self.max_page_bytes as f64 / observed_bytes as f64)) as i128
+        } else {
+            self.width / 2
         };
         self.width = candidate.clamp(Self::MIN_WIDTH, self.max_width);
     }
@@ -138,6 +180,7 @@ mod tests {
     fn controller() -> RangeController {
         RangeController::new(
             1000,
+            u64::MAX,
             0,
             1_000_000_000,
             1000,
@@ -151,7 +194,7 @@ mod tests {
     #[test]
     fn page_at_target_keeps_width_stable() {
         let mut c = controller();
-        c.on_complete(1000, Duration::from_secs(1));
+        c.on_complete(1000, Duration::from_secs(1), 0);
         assert_eq!(
             c.width(),
             1000,
@@ -162,14 +205,14 @@ mod tests {
     #[test]
     fn sparse_page_grows_width_capped_at_ceiling() {
         let mut c = controller();
-        c.on_complete(100, Duration::from_secs(1));
+        c.on_complete(100, Duration::from_secs(1), 0);
         assert_eq!(c.width(), 4000, "growth is capped at 4x per step");
     }
 
     #[test]
     fn empty_fast_page_grows_at_ceiling() {
         let mut c = controller();
-        c.on_complete(0, Duration::from_secs(1));
+        c.on_complete(0, Duration::from_secs(1), 0);
         assert_eq!(c.width(), 4000, "an empty fast page grows at the ceiling");
     }
 
@@ -178,7 +221,7 @@ mod tests {
         let mut c = controller();
         // Empty but 60s against a 30s budget: scan-bound. Time guard overrides the
         // grow-on-empty and shrinks instead (width * 30/60 = 500).
-        c.on_complete(0, Duration::from_secs(60));
+        c.on_complete(0, Duration::from_secs(60), 0);
         assert_eq!(
             c.width(),
             500,
@@ -189,7 +232,7 @@ mod tests {
     #[test]
     fn slow_page_shrinks_even_with_row_headroom() {
         let mut c = controller();
-        c.on_complete(500, Duration::from_secs(60));
+        c.on_complete(500, Duration::from_secs(60), 0);
         assert_eq!(c.width(), 500, "the time guard wins over row-based growth");
     }
 
@@ -211,8 +254,15 @@ mod tests {
     fn shrink_floors_at_one_to_guarantee_progress() {
         // Width must never reach 0, or an empty range would stall the scan. Even an
         // aggressive shrink (probed count far above page_size) floors at 1.
-        let mut c =
-            RangeController::new(1000, 0, 1_000_000, 100, 1_000_000, Duration::from_secs(30));
+        let mut c = RangeController::new(
+            1000,
+            u64::MAX,
+            0,
+            1_000_000,
+            100,
+            1_000_000,
+            Duration::from_secs(30),
+        );
         c.on_overflow(Some(1_000_000));
         assert_eq!(
             c.width(),
@@ -226,13 +276,14 @@ mod tests {
     fn growth_is_clamped_to_max_width() {
         let mut c = RangeController::new(
             1000,
+            u64::MAX,
             0,
             1_000_000_000,
             500_000,
             1_000_000,
             Duration::from_secs(30),
         );
-        c.on_complete(0, Duration::from_secs(1));
+        c.on_complete(0, Duration::from_secs(1), 0);
         assert_eq!(c.width(), 1_000_000, "growth never exceeds max_width");
     }
 
@@ -240,10 +291,17 @@ mod tests {
 
     #[test]
     fn complete_advances_cursor_by_the_width_just_used() {
-        let mut c =
-            RangeController::new(1000, 100, 1_000_000_000, 50, 4096, Duration::from_secs(30));
+        let mut c = RangeController::new(
+            1000,
+            u64::MAX,
+            100,
+            1_000_000_000,
+            50,
+            4096,
+            Duration::from_secs(30),
+        );
         assert_eq!(c.current_range(), (100, 150));
-        c.on_complete(50, Duration::from_secs(1));
+        c.on_complete(50, Duration::from_secs(1), 0);
         assert_eq!(
             c.range_start(),
             150,
@@ -253,7 +311,15 @@ mod tests {
 
     #[test]
     fn overflow_does_not_advance_cursor() {
-        let mut c = RangeController::new(20, 100, 1_000_000_000, 80, 4096, Duration::from_secs(30));
+        let mut c = RangeController::new(
+            20,
+            u64::MAX,
+            100,
+            1_000_000_000,
+            80,
+            4096,
+            Duration::from_secs(30),
+        );
         c.on_overflow(None);
         assert_eq!(
             c.range_start(),
@@ -265,7 +331,15 @@ mod tests {
 
     #[test]
     fn timeout_does_not_advance_cursor_and_shrinks() {
-        let mut c = RangeController::new(20, 100, 1_000_000_000, 80, 4096, Duration::from_secs(30));
+        let mut c = RangeController::new(
+            20,
+            u64::MAX,
+            100,
+            1_000_000_000,
+            80,
+            4096,
+            Duration::from_secs(30),
+        );
         c.on_timeout();
         assert_eq!(c.range_start(), 100, "timeout must NOT advance the cursor");
         assert!(c.width() < 80, "timeout shrinks the width");
@@ -273,14 +347,15 @@ mod tests {
 
     #[test]
     fn is_done_only_after_cursor_passes_max_key() {
-        let mut c = RangeController::new(1000, 0, 100, 100, 4096, Duration::from_secs(30));
+        let mut c =
+            RangeController::new(1000, u64::MAX, 0, 100, 100, 4096, Duration::from_secs(30));
         assert!(!c.is_done());
-        c.on_complete(100, Duration::from_secs(1)); // advance 0 -> 100
+        c.on_complete(100, Duration::from_secs(1), 0); // advance 0 -> 100
         assert!(
             !c.is_done(),
             "range_start == max_key is not done (max_key row still in range)"
         );
-        c.on_complete(100, Duration::from_secs(1)); // advance past max_key
+        c.on_complete(100, Duration::from_secs(1), 0); // advance past max_key
         assert!(c.is_done(), "range_start past max_key is done");
     }
 
@@ -303,7 +378,15 @@ mod tests {
     fn no_data_loss_through_dense_burst_with_overflow_and_rescale() {
         let max_key = 1000i128;
         let page_size = 20u64;
-        let mut c = RangeController::new(page_size, 0, max_key, 20, 4096, Duration::from_secs(30));
+        let mut c = RangeController::new(
+            page_size,
+            u64::MAX,
+            0,
+            max_key,
+            20,
+            4096,
+            Duration::from_secs(30),
+        );
 
         let mut emitted: Vec<(i128, i128)> = Vec::new();
         let mut saw_overflow = false;
@@ -328,7 +411,7 @@ mod tests {
                 c.on_overflow(None);
             } else {
                 emitted.push((start, end));
-                c.on_complete(rows, Duration::from_millis(1));
+                c.on_complete(rows, Duration::from_millis(1), 0);
                 if start >= 400 {
                     max_width_after_burst = max_width_after_burst.max(c.width());
                 }
@@ -373,7 +456,15 @@ mod tests {
     fn no_data_loss_with_injected_timeouts() {
         let max_key = 500i128;
         let page_size = 20u64;
-        let mut c = RangeController::new(page_size, 0, max_key, 30, 4096, Duration::from_secs(30));
+        let mut c = RangeController::new(
+            page_size,
+            u64::MAX,
+            0,
+            max_key,
+            30,
+            4096,
+            Duration::from_secs(30),
+        );
 
         let mut emitted: Vec<(i128, i128)> = Vec::new();
         let mut step = 0;
@@ -403,7 +494,7 @@ mod tests {
                 c.on_overflow(None);
             } else {
                 emitted.push((start, end));
-                c.on_complete(rows, Duration::from_millis(1));
+                c.on_complete(rows, Duration::from_millis(1), 0);
             }
         }
 
@@ -423,5 +514,179 @@ mod tests {
         let total = rows_in_range(0, max_key + 1);
         let got: usize = emitted.iter().map(|(s, e)| rows_in_range(*s, *e)).sum();
         assert_eq!(got, total, "no rows lost despite timeouts");
+    }
+
+    // ---- byte tripwire (Arrow ~2 GiB per-array guard) ----
+
+    /// A controller configured with a tiny byte limit, used to exercise the byte
+    /// signals in isolation (page_size is set huge so rows never trip).
+    fn byte_controller() -> RangeController {
+        RangeController::new(
+            100_000,
+            1_000,
+            0,
+            1_000_000_000,
+            1000,
+            100_000,
+            Duration::from_secs(30),
+        )
+    }
+
+    #[test]
+    fn byte_overflow_sizes_from_observed_density_in_one_step() {
+        let mut c = byte_controller();
+        // width 1000, observed 2500 bytes vs a 1000 limit -> next width 400,
+        // landing just under the limit in a single re-read (not a halve chain).
+        c.on_byte_overflow(2500);
+        assert_eq!(
+            c.width(),
+            400,
+            "byte overflow resizes by max/observed ratio"
+        );
+        assert_eq!(
+            c.range_start(),
+            0,
+            "byte overflow must NOT advance the cursor (re-read the same range)"
+        );
+    }
+
+    #[test]
+    fn byte_overflow_floors_at_one() {
+        let mut c = byte_controller();
+        // Observed bytes dwarf the limit: resize floors at MIN_WIDTH so the
+        // cursor still advances one key at a time.
+        c.on_byte_overflow(u64::MAX);
+        assert_eq!(c.width(), 1);
+        assert!(c.at_min_width());
+    }
+
+    #[test]
+    fn on_complete_byte_clamp_prevents_thrash() {
+        // Regression: a byte-dense but row-sparse region. Without the byte clamp
+        // in on_complete, the row multiplier (page_size/rows, capped at 4x) would
+        // snap width straight back past the byte limit every cycle, thrashing
+        // between overflow and re-read forever. With the clamp, width stays put.
+        let mut c = byte_controller();
+        // width 1000: rows 100 (row-sparse), bytes 2000 (byte-dense -> overflow).
+        c.on_byte_overflow(2000);
+        assert_eq!(c.width(), 500, "shrunk to the byte-safe width");
+        // Re-read at 500: bytes ~1000 (at the limit, not over), rows ~50 -> complete.
+        c.on_complete(50, Duration::from_millis(1), 1000);
+        assert_eq!(
+            c.width(),
+            500,
+            "on_complete must NOT grow width back into a byte overflow"
+        );
+    }
+
+    #[test]
+    fn on_complete_grows_when_byte_headroom_allows() {
+        // A byte-light page leaves headroom: growth is capped by the byte ceiling
+        // (which is well above the row target), so the row multiplier wins and
+        // width grows — the byte guard must not over-restrict sparse data.
+        let mut c = byte_controller();
+        c.on_complete(10, Duration::from_millis(1), 10);
+        // row_mult = 100_000/10 capped at 4 -> 1000*4 = 4000; byte_ceiling =
+        // 1000/(10/1000) = 100_000; min = 4000, clamped to max_width 100_000.
+        assert_eq!(c.width(), 4000, "byte-light page grows normally");
+    }
+
+    /// A full scan through a byte-dense burst. Models bytes-per-key (1 outside
+    /// [300,400), 100 inside) against a 1000-byte limit with rows never
+    /// overflowing. The controller must shrink inside the burst, recover after
+    /// it, and tile the whole key space with no gaps or duplicates — proving the
+    /// byte tripwire never loses data and converges instead of thrashing.
+    fn bytes_in_range(start: i128, end: i128) -> u64 {
+        (start..end)
+            .map(|k| {
+                if (300..400).contains(&k) {
+                    100u64
+                } else {
+                    1u64
+                }
+            })
+            .sum()
+    }
+
+    #[test]
+    fn no_data_loss_through_byte_dense_burst() {
+        let max_key = 1000i128;
+        let page_size = 100_000u64;
+        let max_page_bytes = 1000u64;
+        let mut c = RangeController::new(
+            page_size,
+            max_page_bytes,
+            0,
+            max_key,
+            500,
+            100_000,
+            Duration::from_secs(30),
+        );
+
+        let mut emitted: Vec<(i128, i128)> = Vec::new();
+        let mut saw_byte_overflow = false;
+        let mut min_width_in_burst = i128::MAX;
+        let mut max_width_after_burst = 0i128;
+        let mut guard = 0;
+
+        while !c.is_done() {
+            guard += 1;
+            assert!(guard < 1_000_000, "controller failed to terminate");
+            let (start, end_raw) = c.current_range();
+            let end = end_raw.min(max_key + 1);
+            let rows = (end - start) as usize; // 1 row/key
+            let bytes = bytes_in_range(start, end);
+
+            if bytes > max_page_bytes {
+                assert!(
+                    !c.at_min_width(),
+                    "coverable byte density must never stick at min width"
+                );
+                saw_byte_overflow = true;
+                if (300..400).contains(&start) || start >= 290 {
+                    min_width_in_burst = min_width_in_burst.min(c.width());
+                }
+                c.on_byte_overflow(bytes);
+            } else {
+                emitted.push((start, end));
+                c.on_complete(rows, Duration::from_millis(1), bytes);
+                if start >= 400 {
+                    max_width_after_burst = max_width_after_burst.max(c.width());
+                }
+            }
+        }
+
+        // No gaps, no overlaps: emitted ranges tile [0, max_key + 1) contiguously.
+        assert_eq!(emitted.first().unwrap().0, 0, "scan must start at key 0");
+        for w in emitted.windows(2) {
+            assert_eq!(
+                w[0].1, w[1].0,
+                "gap or overlap between {:?} and {:?}",
+                w[0], w[1]
+            );
+        }
+        assert!(
+            emitted.last().unwrap().1 > max_key,
+            "scan must cover past max_key"
+        );
+
+        // Every key emitted exactly once.
+        let total_keys = (max_key + 1) as usize;
+        let got: usize = emitted.iter().map(|(s, e)| (*e - *s) as usize).sum();
+        assert_eq!(
+            got, total_keys,
+            "all keys emitted exactly once (no loss, no dup)"
+        );
+
+        assert!(
+            saw_byte_overflow,
+            "byte-dense burst should trigger byte overflow"
+        );
+        assert!(
+            max_width_after_burst > min_width_in_burst,
+            "width should recover after the burst (down {} -> up {})",
+            min_width_in_burst,
+            max_width_after_burst
+        );
     }
 }

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -782,8 +782,16 @@ impl HybridTableProvider {
         );
 
         if state.current_phase == self.config.bounded_sources.len()
+            && !self.config.job_mode
             && let Some(offset_provider) = &self.config.offset_provider
         {
+            // Only fetch/seed offsets when actually transitioning to the
+            // unbounded phase. In job_mode the unbounded phase never runs, so
+            // this ClickHouse max-offset query + Kafka seed is wasted work and a
+            // stall/hang vector under load (it blocks advance_to_next_phase,
+            // which the hybrid execute loop must return from before it can break
+            // and end the source stream). Skip it; the bounded source's own
+            // cursor is already persisted via its checkpoint Finalizer.
             let offsets = offset_provider.get_offsets().await?;
             state.unbounded_offsets = Some(offsets.clone());
 
@@ -2875,6 +2883,64 @@ mod tests {
         assert_eq!(
             state.current_phase, 0,
             "should fall back to phase 0 when offset provider returns empty map"
+        );
+    }
+    #[tokio::test(flavor = "multi_thread")]
+    async fn job_mode_advancing_past_bounded_skips_offset_provider() {
+        // Regression: in job_mode, advancing to the unbounded transition must
+        // NOT call offset_provider.get_offsets(). That ClickHouse max-offset
+        // query + Kafka seed is for an unbounded phase job_mode never runs, and
+        // blocking on it stalls advance_to_next_phase — which the hybrid execute
+        // loop must return from before it can break and end the source stream
+        // (the production job-mode termination hang).
+        let state_config = StateBackendConfig {
+            backend_type: streamling_config::StateBackendType::InMemory,
+            postgres: None,
+            sqlite: None,
+        };
+        let factory = streamling_state::StateBackendFactories::new(state_config)
+            .expect("Failed to create state backend factory");
+        let backend: Arc<dyn StateOperatorBackend<HybridSourceState>> =
+            factory.create::<HybridSourceState>("job_mode_skip_offsets_test");
+
+        let config = HybridSourceConfig {
+            bounded_sources: vec![
+                Arc::new(MockTableProvider::new("bounded1".to_string())) as Arc<dyn TableProvider>
+            ],
+            unbounded_source: Arc::new(MockTableProvider::new("unbounded".to_string()))
+                as Arc<dyn TableProvider>,
+            // Returns Err if ever called. job_mode must skip it, so advance
+            // succeeds; without the skip, advance would propagate the error.
+            offset_provider: Some(Arc::new(FailingOffsetProvider)),
+            job_mode: true,
+        };
+
+        let provider = HybridTableProvider::new(
+            "test_job_mode_skip_offsets".to_string(),
+            config,
+            create_test_schema(),
+            backend,
+            SESSION_MANAGER.clone(),
+        )
+        .unwrap();
+
+        provider.load_state().await.unwrap();
+        // Advance past the single bounded phase (0 -> 1 == bounded_sources.len()),
+        // the unbounded transition. In job_mode it must skip the offset provider.
+        let result = provider.advance_to_next_phase().await;
+        assert!(
+            result.is_ok(),
+            "job_mode advance should skip the offset provider, got: {:?}",
+            result
+        );
+        let state = provider.state.read().await;
+        assert_eq!(
+            state.current_phase, 1,
+            "phase bookkeeping still advances; only the offset work is skipped"
+        );
+        assert!(
+            state.unbounded_offsets.is_none(),
+            "offsets must not be fetched in job_mode"
         );
     }
 

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1363,7 +1363,7 @@ impl ClickHouseSchemaAdapter {
         table_name: &str,
         target_schema: &SchemaRef,
     ) -> Result<Vec<String>, DataFusionError> {
-        let table_schema = self.client.fetch_schema(table_name, None).map_err(|e| {
+        let table_schema = self.client.fetch_schema(table_name, None, None).map_err(|e| {
             streamling_err!(
                 "failed to fetch schema from ClickHouse for table '{}': {}",
                 table_name,

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1363,13 +1363,16 @@ impl ClickHouseSchemaAdapter {
         table_name: &str,
         target_schema: &SchemaRef,
     ) -> Result<Vec<String>, DataFusionError> {
-        let table_schema = self.client.fetch_schema(table_name, None, None).map_err(|e| {
-            streamling_err!(
-                "failed to fetch schema from ClickHouse for table '{}': {}",
-                table_name,
-                e
-            )
-        })?;
+        let table_schema = self
+            .client
+            .fetch_schema(table_name, None, None)
+            .map_err(|e| {
+                streamling_err!(
+                    "failed to fetch schema from ClickHouse for table '{}': {}",
+                    table_name,
+                    e
+                )
+            })?;
         let table_fields: HashMap<&str, Arc<Field>> = table_schema
             .fields()
             .iter()

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -332,6 +332,7 @@ impl HybridTableProvider {
                         columns,
                         state_backend_factory.create(application_id.as_str()),
                         app_config.internal_buffer_size as usize,
+                        app_config.record_batch_size as usize,
                     )?);
                     debug!(
                         "Clickhouse schema for bounded source: {:?}",

--- a/crates/streamling-e2e/tests/clickhouse_source.rs
+++ b/crates/streamling-e2e/tests/clickhouse_source.rs
@@ -375,6 +375,129 @@ sinks:
     );
 }
 
+/// Count-first pagination: a sort-key span whose *average* density fits a page
+/// but contains a DENSE cluster (several rows per key) must be sized from the
+/// exact per-range count BEFORE the data read, not from the span average. The
+/// up-front probe sizes the initial width from whole-span density and would
+/// otherwise walk a wide range straight into the cluster, materialising more
+/// than `page_size` rows before the reactive overflow could shrink it. With
+/// count-first sizing each range is probed and shrunk to fit first; this test
+/// verifies the orchestration (probe, shrink, re-probe, converge) delivers
+/// every row through a real dense cluster without loss or stall.
+#[tokio::test]
+async fn test_clickhouse_source_count_first_shrinks_dense_cluster() {
+    init_tracing();
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+
+    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE count_first_cluster_test (
+                block_number UInt64,
+                id UInt64,
+                data String,
+                is_deleted UInt8
+            ) ENGINE = MergeTree() ORDER BY (block_number, id)",
+        )
+        .await
+        .expect("Failed to create table");
+
+    // Sparse [0,40): one row per key. Dense cluster [40,50): five rows per key
+    // (fanout 5, kept under page_size so no single key hits the unsplittable
+    // floor). Sparse [50,90): one row per key. Total = 40 + 50 + 40 = 130.
+    let mut values: Vec<String> = Vec::new();
+    for i in 0..40u64 {
+        values.push(format!("({}, {}, 'sparse_{}', 0)", i, i, i));
+    }
+    for blk in 40..50u64 {
+        for j in 0..5u64 {
+            let id = blk * 10 + j;
+            values.push(format!("({}, {}, 'dense_{}', 0)", blk, id, id));
+        }
+    }
+    for i in 50..90u64 {
+        values.push(format!("({}, {}, 'sparse_{}', 0)", i, i, i));
+    }
+    let total_records = values.len() as i64;
+
+    for chunk in values.chunks(200) {
+        let insert_query = format!(
+            "INSERT INTO count_first_cluster_test (block_number, id, data, is_deleted) VALUES {}",
+            chunk.join(", ")
+        );
+        clickhouse
+            .execute(&insert_query)
+            .await
+            .expect("Failed to insert data");
+    }
+
+    let pipeline = r#"
+sources:
+  ch_source:
+    type: clickhouse
+    table_name: count_first_cluster_test
+    primary_key: id
+
+transforms: {}
+
+sinks:
+  pg_sink:
+    type: postgres
+    from: ch_source
+    table: count_first_cluster_results
+    schema: public
+    primary_key: id
+    on_conflict: update
+"#;
+
+    // page_size 30 < the cluster's 50 rows across [40,50), so any multi-key range
+    // overlapping the cluster overflows by rows and must be shrunk from its exact
+    // count before reading.
+    let status = ctx
+        .run_pipeline_with_opts(
+            pipeline,
+            PipelineOpts::new()
+                .env("STREAMLING__CLICKHOUSE_SOURCE__PAGE_SIZE", "30")
+                .env("STREAMLING__CLICKHOUSE_SOURCE__SORT_KEY_RANGE", "50")
+                .record_limit(total_records as u64)
+                .timeout(std::time::Duration::from_secs(60)),
+        )
+        .await
+        .expect("Streamling execution failed");
+
+    assert!(status.success(), "Streamling should exit successfully");
+
+    let count = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.count_first_cluster_results")
+        .await
+        .expect("Failed to query count");
+    assert_eq!(
+        count, total_records,
+        "every row, including the dense cluster, must be delivered after count-first sizing"
+    );
+
+    // The cluster [40,50) carries 50 rows across 10 keys; confirming all 50
+    // arrived proves the count-first loop shrank each overlapping range to fit
+    // rather than skipping the overflow.
+    let cluster_rows = ctx
+        .postgres
+        .count(
+            "SELECT COUNT(*) FROM public.count_first_cluster_results \
+             WHERE block_number >= 40 AND block_number < 50",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        cluster_rows, 50,
+        "dense cluster [40,50) must deliver all 50 rows (5 per key x 10 keys)"
+    );
+}
+
 // ============================================================================
 // Scenario 4: Checkpoint flow across sparse sort key ranges
 // ============================================================================

--- a/crates/streamling-e2e/tests/clickhouse_source.rs
+++ b/crates/streamling-e2e/tests/clickhouse_source.rs
@@ -24,7 +24,7 @@ async fn test_clickhouse_source_boundary() {
 
     let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
 
-    // Create source table — first sorting key must be numeric for block range pagination
+    // Create source table — first sorting key must be numeric for sort key range pagination
     clickhouse
         .execute(
             "CREATE TABLE boundary_test (
@@ -155,7 +155,7 @@ async fn test_clickhouse_source_keyset_pagination() {
 
     let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
 
-    // Create table with compound sorting key — first sorting key must be numeric for block range pagination
+    // Create table with compound sorting key — first sorting key must be numeric for sort key range pagination
     clickhouse
         .execute(
             "CREATE TABLE keyset_test (
@@ -258,14 +258,14 @@ sinks:
 }
 
 // ============================================================================
-// Scenario 3: Block range with inner keyset pagination
+// Scenario 3: Sort key range with inner keyset pagination
 // ============================================================================
 
-/// Test that when a single block range contains more rows than page_size,
-/// inner keyset pagination correctly pages through them before advancing
-/// to the next block range.
+/// Test that when a sort key range contains more rows than page_size, the source
+/// shrinks the range until each page fits and still delivers every row across
+/// all ranges.
 #[tokio::test]
-async fn test_clickhouse_source_block_range_exceeds_page_size() {
+async fn test_clickhouse_source_sort_key_range_exceeds_page_size() {
     init_tracing();
 
     let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
@@ -276,7 +276,7 @@ async fn test_clickhouse_source_block_range_exceeds_page_size() {
 
     clickhouse
         .execute(
-            "CREATE TABLE block_range_paging_test (
+            "CREATE TABLE sort_key_range_paging_test (
                 block_number UInt64,
                 id UInt64,
                 data String,
@@ -287,8 +287,8 @@ async fn test_clickhouse_source_block_range_exceeds_page_size() {
         .expect("Failed to create table");
 
     // Insert 500 rows: block_number 0..499, each with a unique id.
-    // With block_range=100, we get 5 block ranges: [0,100), [100,200), ...
-    // With page_size=30, each block range (100 rows) needs ~4 keyset pages.
+    // page_size=30 forces the adaptive controller to shrink ranges below the
+    // dense regions until each page fits; all 500 rows must still arrive.
     let total_records: u64 = 500;
     let mut values = Vec::new();
     for i in 0..total_records {
@@ -297,7 +297,7 @@ async fn test_clickhouse_source_block_range_exceeds_page_size() {
 
     for chunk in values.chunks(200) {
         let insert_query = format!(
-            "INSERT INTO block_range_paging_test (block_number, id, data, is_deleted) VALUES {}",
+            "INSERT INTO sort_key_range_paging_test (block_number, id, data, is_deleted) VALUES {}",
             chunk.join(", ")
         );
         clickhouse
@@ -310,7 +310,7 @@ async fn test_clickhouse_source_block_range_exceeds_page_size() {
 sources:
   ch_source:
     type: clickhouse
-    table_name: block_range_paging_test
+    table_name: sort_key_range_paging_test
     primary_key: id
 
 transforms: {}
@@ -319,7 +319,7 @@ sinks:
   pg_sink:
     type: postgres
     from: ch_source
-    table: block_range_paging_results
+    table: sort_key_range_paging_results
     schema: public
     primary_key: id
     on_conflict: update
@@ -330,7 +330,7 @@ sinks:
             pipeline,
             PipelineOpts::new()
                 .env("STREAMLING__CLICKHOUSE_SOURCE__PAGE_SIZE", "30")
-                .env("STREAMLING__CLICKHOUSE_SOURCE__BLOCK_RANGE", "100")
+                .env("STREAMLING__CLICKHOUSE_SOURCE__SORT_KEY_RANGE", "100")
                 .record_limit(total_records)
                 .timeout(std::time::Duration::from_secs(60)),
         )
@@ -341,49 +341,51 @@ sinks:
 
     let count = ctx
         .postgres
-        .count("SELECT COUNT(*) FROM public.block_range_paging_results")
+        .count("SELECT COUNT(*) FROM public.sort_key_range_paging_results")
         .await
         .expect("Failed to query count");
 
     assert_eq!(
         count, total_records as i64,
-        "Should have processed all {} records across multiple block ranges with inner keyset pagination",
+        "Should have processed all {} records across multiple sort key ranges with inner keyset pagination",
         total_records
     );
 
-    // Verify rows from different block ranges made it through
+    // Verify rows from different sort key ranges made it through
     let first_range = ctx
         .postgres
-        .count("SELECT COUNT(*) FROM public.block_range_paging_results WHERE block_number < 100")
+        .count("SELECT COUNT(*) FROM public.sort_key_range_paging_results WHERE block_number < 100")
         .await
         .unwrap();
     assert_eq!(
         first_range, 100,
-        "First block range [0,100) should have 100 rows"
+        "First sort key range [0,100) should have 100 rows"
     );
 
     let last_range = ctx
         .postgres
-        .count("SELECT COUNT(*) FROM public.block_range_paging_results WHERE block_number >= 400")
+        .count(
+            "SELECT COUNT(*) FROM public.sort_key_range_paging_results WHERE block_number >= 400",
+        )
         .await
         .unwrap();
     assert_eq!(
         last_range, 100,
-        "Last block range [400,500) should have 100 rows"
+        "Last sort key range [400,500) should have 100 rows"
     );
 }
 
 // ============================================================================
-// Scenario 4: Checkpoint flow across sparse block ranges
+// Scenario 4: Checkpoint flow across sparse sort key ranges
 // ============================================================================
 
-/// Test that checkpoints flow correctly when block range pagination scans
+/// Test that checkpoints flow correctly when sort key range pagination scans
 /// through a mix of populated and empty ranges. Verifies:
 /// 1. Pipeline 1 processes the first cluster and checkpoints its position
 /// 2. Pipeline 2 resumes from the checkpoint and processes the second cluster
 ///    without re-reading the first cluster
 ///
-/// Data layout with block_range=100:
+/// Data layout with sort_key_range=100:
 ///   [0,100)   → 50 rows (cluster 1)
 ///   [100,500) → empty (4 empty ranges)
 ///   [500,600) → 50 rows (cluster 2)
@@ -451,7 +453,7 @@ sinks:
 "#;
 
     // Run 1: process only the first 50 records (cluster 1).
-    // With block_range=100 and page_size=30 the source will also scan
+    // With sort_key_range=100 and page_size=30 the source will also scan
     // empty ranges [100,200)…[400,500) before reaching cluster 2,
     // but record_limit will stop it after 50 records.
     let status_1 = ctx
@@ -481,7 +483,7 @@ sinks:
                 .env("STREAMLING__CHECKPOINT_INTERVAL_SEC", "1")
                 .env("STREAMLING__RECORD_BATCH_SIZE", "10")
                 .env("STREAMLING__CLICKHOUSE_SOURCE__PAGE_SIZE", "30")
-                .env("STREAMLING__CLICKHOUSE_SOURCE__BLOCK_RANGE", "100"),
+                .env("STREAMLING__CLICKHOUSE_SOURCE__SORT_KEY_RANGE", "100"),
         )
         .await
         .expect("Pipeline run 1 failed");
@@ -558,7 +560,7 @@ sinks:
                 .env("STREAMLING__CHECKPOINT_INTERVAL_SEC", "1")
                 .env("STREAMLING__RECORD_BATCH_SIZE", "10")
                 .env("STREAMLING__CLICKHOUSE_SOURCE__PAGE_SIZE", "30")
-                .env("STREAMLING__CLICKHOUSE_SOURCE__BLOCK_RANGE", "100"),
+                .env("STREAMLING__CLICKHOUSE_SOURCE__SORT_KEY_RANGE", "100"),
         )
         .await
         .expect("Pipeline run 2 failed");

--- a/crates/streamling-e2e/tests/clickhouse_source.rs
+++ b/crates/streamling-e2e/tests/clickhouse_source.rs
@@ -898,3 +898,97 @@ sinks:
         cols
     );
 }
+
+/// Regression: when a live row and a delete share the SAME `insert_timestamp`
+/// (a tied version), the source-side version dedup must let the delete win so
+/// the key is dropped — the row's final state is deleted. The scan has no
+/// ORDER BY, so the previous tiebreak (later position wins) was
+/// order-dependent: a live row scanned after the delete survived and the
+/// deletion was silently lost, leaving a stale live row in the sink.
+#[tokio::test]
+async fn test_clickhouse_source_tied_version_delete_drops_key() {
+    init_tracing();
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE tied_version_dedup_test (
+                block_number UInt64,
+                id String,
+                payload String,
+                insert_timestamp DateTime,
+                is_deleted UInt8
+            ) ENGINE = ReplacingMergeTree(insert_timestamp, is_deleted)
+            ORDER BY (block_number, id)",
+        )
+        .await
+        .expect("Failed to create source table");
+
+    // Two keys; for each, a live row and a delete at the SAME version, in
+    // opposite orders so the regression is caught regardless of scan order.
+    //   (1, 'a') — live first, then delete.
+    //   (2, 'b') — delete first, then live.
+    // Both must drop the key: the delete supersedes the live row on a tie.
+    //
+    // `optimize_on_insert = 0` stops ClickHouse from collapsing the tied live
+    // + delete rows at INSERT time — its default dedups them per the engine
+    // before the source scan ever sees both, which hides exactly this bug.
+    // One part, no insert-time collapse, no background-merge race: the scan
+    // reads all four raw rows and the source-side dedup resolves the tie.
+    clickhouse
+        .execute(
+            "INSERT INTO tied_version_dedup_test SETTINGS optimize_on_insert = 0 VALUES
+                (1, 'a', 'a_alive', toDateTime(1000), 0),
+                (1, 'a', 'a_alive', toDateTime(1000), 1),
+                (2, 'b', 'b_alive', toDateTime(1000), 1),
+                (2, 'b', 'b_alive', toDateTime(1000), 0)",
+        )
+        .await
+        .expect("Failed to insert source data");
+
+    let pipeline = r#"
+sources:
+  ch_source:
+    type: clickhouse
+    table_name: tied_version_dedup_test
+    columns: "block_number,id,payload"
+    primary_key: id
+
+transforms: {}
+
+sinks:
+  pg_sink:
+    type: postgres
+    from: ch_source
+    table: tied_version_dedup_results
+    schema: public
+    primary_key: id
+    on_conflict: update
+"#;
+
+    let status = ctx
+        .run_pipeline_with_opts(
+            pipeline,
+            PipelineOpts::new()
+                .record_limit(4)
+                .timeout(std::time::Duration::from_secs(60)),
+        )
+        .await
+        .expect("Streamling execution failed");
+    assert!(status.success(), "pipeline should exit successfully");
+
+    // Both keys are deleted at their (tied) max version -> FINAL drops them.
+    let total = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.tied_version_dedup_results")
+        .await
+        .expect("count query failed");
+    assert_eq!(
+        total, 0,
+        "tied live+delete rows must both be dropped (delete wins the tie)"
+    );
+}

--- a/crates/streamling-e2e/tests/clickhouse_source.rs
+++ b/crates/streamling-e2e/tests/clickhouse_source.rs
@@ -601,3 +601,177 @@ sinks:
         );
     }
 }
+
+// ============================================================================
+// Scenario 5: Version-aware dedup activates when columns omit the version col
+// ============================================================================
+
+/// Regression: source-side ReplacingMergeTree dedup must activate even when
+/// the configured `columns` omit the inferred version column. This is the
+/// hybrid-source path — `ClickHouseSchemaAdapter::get_columns` projects
+/// ClickHouse to the unbounded source's (Kafka) target schema, which excludes
+/// ClickHouse housekeeping columns like `insert_timestamp` and `is_deleted`.
+///
+/// The fix force-includes the inferred version column in the internal scan
+/// and projects it back out before emission, so:
+///   1. dedup picks the max-`insert_timestamp` row per ORDER BY key,
+///   2. tombstone winners (`is_deleted=1`) drop the key entirely (FINAL),
+///   3. the external schema stays exactly the configured columns (no leaked
+///      `insert_timestamp` in the postgres sink table).
+#[tokio::test]
+async fn test_clickhouse_source_replacing_dedup_when_version_column_not_selected() {
+    init_tracing();
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE replacing_dedup_test (
+                block_number UInt64,
+                id String,
+                payload String,
+                insert_timestamp DateTime,
+                is_deleted UInt8
+            ) ENGINE = ReplacingMergeTree(insert_timestamp, is_deleted)
+            ORDER BY (block_number, id)",
+        )
+        .await
+        .expect("Failed to create source table");
+
+    // 5 distinct (block_number, id) keys, 9 raw rows. Each scenario probes a
+    // different dedup property; together they catch the activation regression
+    // regardless of ClickHouse part-read order.
+    //
+    //   (1, 'a')  — single version, sanity (must arrive once).
+    //   (2, 'b')  — newer insert_timestamp inserted second; dedup picks 'b_new'.
+    //   (3, 'c')  — newer insert_timestamp inserted FIRST; position-based dedup
+    //               would pick the wrong row, version-aware picks 'c_new'.
+    //   (4, 'd')  — tombstone has the max insert_timestamp → whole key dropped.
+    //   (5, 'e')  — tombstone is older than the live row → key kept as 'e_alive'.
+    clickhouse
+        .execute(
+            "INSERT INTO replacing_dedup_test VALUES
+                (1, 'a', 'a1',        toDateTime(1000), 0),
+                (2, 'b', 'b_old',     toDateTime(1000), 0),
+                (2, 'b', 'b_new',     toDateTime(2000), 0),
+                (3, 'c', 'c_new',     toDateTime(2000), 0),
+                (3, 'c', 'c_old',     toDateTime(1000), 0),
+                (4, 'd', 'd_alive',   toDateTime(1000), 0),
+                (4, 'd', 'd_deleted', toDateTime(2000), 1),
+                (5, 'e', 'e_alive',   toDateTime(2000), 0),
+                (5, 'e', 'e_deleted', toDateTime(1000), 1)",
+        )
+        .await
+        .expect("Failed to insert source data");
+
+    // The pipeline's `columns` deliberately OMIT `insert_timestamp` and
+    // `is_deleted` — replaying the hybrid-source projection that previously
+    // silently disabled dedup. (Comma-separated, no spaces: the topology
+    // parser splits on ',' without trimming.)
+    let pipeline = r#"
+sources:
+  ch_source:
+    type: clickhouse
+    table_name: replacing_dedup_test
+    columns: "block_number,id,payload"
+    primary_key: id
+
+transforms: {}
+
+sinks:
+  pg_sink:
+    type: postgres
+    from: ch_source
+    table: replacing_dedup_results
+    schema: public
+    primary_key: id
+    on_conflict: update
+"#;
+
+    let status = ctx
+        .run_pipeline_with_opts(
+            pipeline,
+            // Upper bound: 9 raw rows would be emitted without dedup. Bounded
+            // source completes naturally; the limit is a safety net.
+            PipelineOpts::new()
+                .record_limit(9)
+                .timeout(std::time::Duration::from_secs(60)),
+        )
+        .await
+        .expect("Streamling execution failed");
+    assert!(status.success(), "pipeline should exit successfully");
+
+    // (a) FINAL row count: 5 keys − 1 tombstoned key ('d') = 4.
+    let total = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.replacing_dedup_results")
+        .await
+        .expect("count query failed");
+    assert_eq!(
+        total, 4,
+        "ReplacingMergeTree FINAL semantics: 5 keys minus 1 tombstoned = 4"
+    );
+
+    // (b) Position-vs-version: 'c_new' has the higher `insert_timestamp` but
+    // was inserted FIRST, so a position-based or non-deduped reader would
+    // either pick 'c_old' or vary by scan order. Version-aware dedup picks
+    // 'c_new' deterministically.
+    let c_new = ctx
+        .postgres
+        .count(
+            "SELECT COUNT(*) FROM public.replacing_dedup_results \
+             WHERE id = 'c' AND payload = 'c_new'",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        c_new, 1,
+        "max insert_timestamp must win for id='c' (got != 'c_new')"
+    );
+
+    // (c) Tombstone winner: key 'd' must be entirely absent.
+    let d = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.replacing_dedup_results WHERE id = 'd'")
+        .await
+        .unwrap();
+    assert_eq!(d, 0, "tombstoned key 'd' must be dropped (FINAL)");
+
+    // (d) Tombstone non-winner: 'e' survives as alive — an older delete must
+    // not displace a newer live row.
+    let e_alive = ctx
+        .postgres
+        .count(
+            "SELECT COUNT(*) FROM public.replacing_dedup_results \
+             WHERE id = 'e' AND payload = 'e_alive'",
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        e_alive, 1,
+        "older tombstone must not delete a newer live row for id='e'"
+    );
+
+    // (e) External schema contract: the force-included version column is
+    // projected out before emission, so the postgres table only carries the
+    // configured columns (plus any standard sink columns) — never
+    // `insert_timestamp` or `is_deleted`.
+    let cols = ctx
+        .postgres
+        .get_column_names("replacing_dedup_results")
+        .await
+        .unwrap();
+    assert!(
+        !cols.iter().any(|c| c == "insert_timestamp"),
+        "insert_timestamp must be projected out before emission (got columns: {:?})",
+        cols
+    );
+    assert!(
+        !cols.iter().any(|c| c == "is_deleted"),
+        "is_deleted must not leak into the external schema (got columns: {:?})",
+        cols
+    );
+}

--- a/crates/streamling-e2e/tests/hybrid_source.rs
+++ b/crates/streamling-e2e/tests/hybrid_source.rs
@@ -571,6 +571,309 @@ sinks:
 }
 
 // ============================================================================
+// Scenario 3b: Job mode checkpoint epoch finalization (no "missing sinks")
+// ============================================================================
+
+/// Regression: in job mode the bounded ClickHouse source must flush buffered
+/// checkpoint Markers before its stream ends. Otherwise the sink never ACKs the
+/// in-flight epoch and the coordinator stalls on "missing sinks" — and, under
+/// load, the process hangs because the source's final `tx.send(...).await` (the
+/// synthetic marker flush) backpressures against a sink that never finishes.
+///
+/// The existing 3-row test finishes before the checkpoint interval fires, so it
+/// never exercises a Marker arriving mid-scan. This test uses enough rows + a
+/// 1s checkpoint interval to force a Marker during the scan, then asserts:
+///   1. The process exits 0 (no hang).
+///   2. No "missing sinks" / "still waiting for finalization" warnings (markers
+///      flowed and epochs finalized).
+///   3. All bounded records reached the sink.
+#[tokio::test]
+async fn test_job_mode_checkpoint_epoch_finalizes() {
+    init_tracing();
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+
+    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE job_mode_checkpoint_test (
+                block Int64,
+                id String,
+                data String,
+                timestamp Int64,
+                is_deleted UInt8
+            ) ENGINE = MergeTree()
+            ORDER BY (block, id)",
+        )
+        .await
+        .expect("Failed to create ClickHouse table");
+
+    // Enough rows that the scan spans the 1s checkpoint interval. With
+    // batch_size 1 and a print sink, 200 rows is well over a second of work
+    // and guarantees at least one Marker fires mid-scan.
+    let mut values = String::from("INSERT INTO job_mode_checkpoint_test VALUES ");
+    for i in 1..=200u32 {
+        if i > 1 {
+            values.push(',');
+        }
+        values.push_str(&format!("({}, 'row_{}', 'data_{}', {}, 0)", i, i, i, i));
+    }
+    clickhouse
+        .execute(&values)
+        .await
+        .expect("Failed to insert ClickHouse data");
+    // Register the Kafka schema + produce records so the hybrid source's
+    // unbounded phase can initialize (schema registry fetch). Job mode never
+    // consumes them, but the Kafka consumer is still set up at source creation.
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+    ctx.kafka
+        .produce_avro_records(&[TestRecord {
+            block: 999,
+            id: "kafka_unused".to_string(),
+            data: "unused".to_string(),
+            timestamp: 9999,
+        }])
+        .await
+        .expect("Failed to produce Kafka records");
+
+    // Offset table (hybrid source probes it on transition; skipped in job mode
+    // but the config must still parse).
+    clickhouse
+        .execute(
+            "CREATE TABLE kafka_offsets_job_mode_cp (
+                topic String,
+                partition Int32,
+                offset UInt32
+            ) ENGINE = MergeTree()
+            ORDER BY (topic, partition)",
+        )
+        .await
+        .expect("Failed to create offset table");
+
+    let pipeline = format!(
+        r#"
+sources:
+  hybrid_source:
+    type: hybrid
+    bounded_sources:
+      - source_type: clickhouse
+        table_name: job_mode_checkpoint_test
+        columns: block,id,data,timestamp
+    unbounded_source:
+      source_type: kafka
+      topic: {kafka_topic}
+      start_at: earliest
+    offset_table:
+      topic_name: {kafka_topic}
+      table_name: kafka_offsets_job_mode_cp
+    primary_key: id
+
+transforms: {{}}
+
+sinks:
+  pg_sink:
+    type: postgres
+    from: hybrid_source
+    table: job_mode_checkpoint_results
+    schema: public
+    primary_key: id
+    on_conflict: update
+    batch_size: 1
+"#,
+        kafka_topic = ctx.kafka_topic,
+    );
+
+    let output = ctx
+        .run_pipeline_raw(
+            &pipeline,
+            PipelineOpts::new()
+                .env("STREAMLING__JOB_MODE", "true")
+                .env("STREAMLING__CHECKPOINT_INTERVAL_SEC", "1")
+                .env("STREAMLING__RECORD_BATCH_SIZE", "1")
+                .timeout(std::time::Duration::from_secs(180)),
+        )
+        .await
+        .expect("Pipeline execution failed");
+
+    // 1. Process must exit successfully (no hang → no timeout).
+    assert!(
+        output.status.success(),
+        "Job mode pipeline should terminate successfully; stderr:\n{}",
+        output.stderr
+    );
+
+    // 2. No marker-loss symptoms: the coordinator must not stall on a missing
+    //    ACK. "missing sinks" or "still waiting for finalization" means a Marker
+    //    never reached the sink — the regression.
+    assert!(
+        !output.stderr.contains("missing sinks"),
+        "Checkpoint marker was lost: coordinator reports missing sinks.\nstderr:\n{}",
+        output.stderr
+    );
+    assert!(
+        !output.stderr.contains("still waiting for finalization"),
+        "Checkpoint epoch never finalized: marker lost before sink ACK.\nstderr:\n{}",
+        output.stderr
+    );
+
+    // 3. All bounded records reached the sink.
+    let total_count = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.job_mode_checkpoint_results")
+        .await
+        .expect("Failed to query count");
+    assert_eq!(
+        total_count, 200,
+        "Should have all 200 bounded records in the sink, got {}",
+        total_count
+    );
+}
+
+/// Regression: a larger bounded scan that requires multiple pages must still
+/// terminate cleanly in job mode. The page_size + 1 tripwire + dedup coalescing
+/// can interact with the checkpoint Marker delivery on the final page; this
+/// catches a hang or marker loss on a multi-page bounded scan.
+#[tokio::test]
+async fn test_job_mode_multi_page_scan_terminates() {
+    init_tracing();
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+
+    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE job_mode_multi_page_test (
+                block Int64,
+                id String,
+                data String,
+                timestamp Int64,
+                is_deleted UInt8
+            ) ENGINE = MergeTree()
+            ORDER BY (block, id)",
+        )
+        .await
+        .expect("Failed to create ClickHouse table");
+
+    // 3000 rows with a tiny sort_key_range forces multiple pages (each page is
+    // bounded by the range width), exercising the pagination→completion→flush
+    // path repeatedly. batch_size 1 keeps the sink slow so a Marker fires.
+    let mut values = String::from("INSERT INTO job_mode_multi_page_test VALUES ");
+    for i in 1..=3000u32 {
+        if i > 1 {
+            values.push(',');
+        }
+        values.push_str(&format!("({}, 'row_{}', 'data_{}', {}, 0)", i, i, i, i));
+    }
+    clickhouse
+        .execute(&values)
+        .await
+        .expect("Failed to insert ClickHouse data");
+    // Register Kafka schema + produce a record so the hybrid unbounded phase
+    // initializes (job mode never consumes it).
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+    ctx.kafka
+        .produce_avro_records(&[TestRecord {
+            block: 999,
+            id: "kafka_unused".to_string(),
+            data: "unused".to_string(),
+            timestamp: 9999,
+        }])
+        .await
+        .expect("Failed to produce Kafka records");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE kafka_offsets_multi_page (
+                topic String,
+                partition Int32,
+                offset UInt32
+            ) ENGINE = MergeTree()
+            ORDER BY (topic, partition)",
+        )
+        .await
+        .expect("Failed to create offset table");
+
+    let pipeline = format!(
+        r#"
+sources:
+  hybrid_source:
+    type: hybrid
+    bounded_sources:
+      - source_type: clickhouse
+        table_name: job_mode_multi_page_test
+        columns: block,id,data,timestamp
+    unbounded_source:
+      source_type: kafka
+      topic: {kafka_topic}
+      start_at: earliest
+    offset_table:
+      topic_name: {kafka_topic}
+      table_name: kafka_offsets_multi_page
+    primary_key: id
+
+transforms: {{}}
+
+sinks:
+  pg_sink:
+    type: postgres
+    from: hybrid_source
+    table: job_mode_multi_page_results
+    schema: public
+    primary_key: id
+    on_conflict: update
+    batch_size: 1
+"#,
+        kafka_topic = ctx.kafka_topic,
+    );
+
+    let output = ctx
+        .run_pipeline_raw(
+            &pipeline,
+            PipelineOpts::new()
+                .env("STREAMLING__JOB_MODE", "true")
+                .env("STREAMLING__CHECKPOINT_INTERVAL_SEC", "1")
+                .env("STREAMLING__RECORD_BATCH_SIZE", "1")
+                .timeout(std::time::Duration::from_secs(180)),
+        )
+        .await
+        .expect("Pipeline execution failed");
+
+    assert!(
+        output.status.success(),
+        "Multi-page job mode pipeline should terminate successfully; stderr:\n{}",
+        output.stderr
+    );
+    assert!(
+        !output.stderr.contains("missing sinks"),
+        "Marker lost on multi-page scan: missing sinks.\nstderr:\n{}",
+        output.stderr
+    );
+
+    let total_count = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.job_mode_multi_page_results")
+        .await
+        .expect("Failed to query count");
+    assert_eq!(
+        total_count, 3000,
+        "Should have all 3000 bounded records, got {}",
+        total_count
+    );
+}
+
+// ============================================================================
 // Scenario 4: Hybrid resume from high savepoint/checkpoint
 // ============================================================================
 

--- a/crates/streamling-e2e/tests/hybrid_source.rs
+++ b/crates/streamling-e2e/tests/hybrid_source.rs
@@ -576,9 +576,9 @@ sinks:
 
 /// Regression test for hybrid bounded ClickHouse resume:
 /// when resuming from a high saved split, execution must start from that
-/// cursor (not from block range origin 0).
+/// cursor (not from sort key range origin 0).
 ///
-/// This uses a high `start_at` and a small `block_range` so any reset to 0
+/// This uses a high `start_at` and a small `sort_key_range` so any reset to 0
 /// would require scanning a very large number of empty ranges and likely time out.
 #[tokio::test]
 async fn test_hybrid_clickhouse_resume_from_high_saved_split() {
@@ -618,7 +618,7 @@ async fn test_hybrid_clickhouse_resume_from_high_saved_split() {
         })
         .collect();
 
-    // High range is intentionally far from zero. With block_range=100, a reset to 0
+    // High range is intentionally far from zero. With sort_key_range=100, a reset to 0
     // would require scanning many empty ranges before reaching this cursor.
     let high_start = 5_000_000i64;
     let high_rows = 20_000i64;
@@ -740,7 +740,7 @@ sinks:
                 )
                 .env("STREAMLING__RECORD_BATCH_SIZE", "1")
                 .env("STREAMLING__CLICKHOUSE_SOURCE__PAGE_SIZE", "1")
-                .env("STREAMLING__CLICKHOUSE_SOURCE__BLOCK_RANGE", "100")
+                .env("STREAMLING__CLICKHOUSE_SOURCE__SORT_KEY_RANGE", "100")
                 .env("STREAMLING__JOB_MODE", "true"),
         )
         .await
@@ -857,7 +857,7 @@ sinks:
                 .env("STREAMLING__CHECKPOINT_INTERVAL_SEC", "1")
                 .env("STREAMLING__RECORD_BATCH_SIZE", "1")
                 .env("STREAMLING__CLICKHOUSE_SOURCE__PAGE_SIZE", "20")
-                .env("STREAMLING__CLICKHOUSE_SOURCE__BLOCK_RANGE", "100")
+                .env("STREAMLING__CLICKHOUSE_SOURCE__SORT_KEY_RANGE", "100")
                 .env("STREAMLING__JOB_MODE", "true"),
         )
         .await

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -654,6 +654,7 @@ impl Streamling {
                         columns,
                         state_backend_factory.create(app_config.state_backend_namespace()),
                         app_config.internal_buffer_size.as_usize(),
+                        app_config.record_batch_size as usize,
                     )?);
                     let extracted_pk = clickhouse_source_provider.get_extracted_primary_key();
 


### PR DESCRIPTION
## Why

The ClickHouse source query ordered its scan by the sorting key, which forces read-in-order on the main table and makes ClickHouse skip any matching `PROJECTION` (read-in-order is unsupported on projections). On a 1M-row table with an `address` projection, the `ORDER BY` query read **62 marks** and used no projection; the same query without `ORDER BY` used the projection and read **2 marks**.

We had the `ORDER BY` to ensure consistent pagination, and to allow for pagination inside of each sorting key range (block_number). ie block_number 5 might have 10k items, which would have overflowed.

However, our default page size is 10m. it's unlikely that our top-level sorting key has that many items. In case where memory is an issue, we should be redoing the sorting key to be more granular.

## What

- **Drop the `ORDER BY`** from the source query. Pagination is now driven by disjoint half-open ranges on the first sorting key, so determinism comes from the predicate, not row order.
- **`RangeController`** (new) owns the range cursor and adapts the range width:
  - `LIMIT page_size + 1` tripwire — an overflowing range is discarded and re-read smaller, with no duplicates (the response is buffered before emit).
  - up-front `count()` probe sizes the first range from observed density.
  - soft time budget shrinks the range before the hard query timeout fires.
  - only a completed page advances the cursor; overflow and timeout re-read the same range.
- **Checkpoint cursor** is the range start — restart re-reads at most the in-flight range (at-least-once, covered by existing sink dedup).
- **Breaking:** config `block_range` renamed to `sort_key_range` (`STREAMLING__CLICKHOUSE_SOURCE__SORT_KEY_RANGE`).

## Testing

- **Unit** (`range_controller`): emitted ranges tile the key space with no gaps and every row exactly once, under overflow, injected timeouts, and width down/up rescaling. 232 connectors unit tests pass.
- **e2e** (`clickhouse_source`, real ClickHouse): boundary, keyset, multi-range overflow, and checkpoint-across-sparse-ranges all pass (4/4).
- Verified on a real table + projection that the no-`ORDER BY` query selects the projection (2 marks vs 62 with `ORDER BY`).

---

## Version-aware source deduplication (added)

The no-`ORDER BY` scan emits raw physical rows, which for `ReplacingMergeTree` tables means duplicate versions of each `ORDER BY` key reach downstream in scan order — and the existing position-based dedup (last row wins) picks the wrong winner. This change dedupes **at the source**, by max version, before emission.

- **Infer the version column** from `system.tables.engine_full` (`parse_replacing_merge_tree_dedup`). Tokenizing is quote-aware, so commas inside the `'/clickhouse/...'` path literal don't split; the quoted path/replica args are dropped, leaving the bare `version` and `is_deleted` identifiers. Handles `Shared` / `Replicated` / plain `ReplacingMergeTree`; returns nothing for non-Replacing engines.
- **Per-page dedup by max version** (`deduplicate_record_batches_by_version`). Each fully-read page is coalesced and collapsed by `max(insert_timestamp)` keyed on the table's full `ORDER BY`. All versions of a key share the first sorting key, so they always land in one page — per-page coalescing is complete and correct (no cross-batch state needed). Ties break by position (ReplacingMergeTree merge order).
- **Tombstones (`FINAL` semantics):** keys whose max-version row is a delete (`_gs_op='d'`) are dropped entirely. To propagate deletes downstream instead, omit the tombstone rule (one line).
- Reuses the existing hash + real-PK-equality collision handling (STRM-5990). Tombstone match is type-safe via a literal array + `make_comparator` (no per-row `ScalarValue` allocation).

### Force-include the version column (activation fix)

Initially dedup was gated on the inferred version column being present in the fetched schema. That silently disabled it for the **hybrid source** path: `ClickHouseSchemaAdapter::get_columns` projects ClickHouse to the unbounded source's (Kafka) target schema, which excludes ClickHouse housekeeping columns like `insert_timestamp` and `is_deleted` — so the inferred version column wasn't selectable, and the bounded backfill emitted raw, undeduped rows. Same trap for any direct source with explicit `columns`.

Fix: decouple the **internal scan schema** from the **external provider schema**.

- `new_source` appends the inferred version column to the scan column list when the configured columns omit it (`*` already selects every column, so nothing is added). On the rare invalid-version fetch_schema failure we fall back to the configured columns with dedup disabled.
- `SourceParams.project_out_version_index: Option<usize>` records the column to strip — set only when we force-included it.
- `execute()` projects that column out of every emitted batch via `project_out_column`, so the stream's external schema (and the hybrid union's schema contract) is unchanged.

The inference log now reports whether force-inclusion was needed, and the disabled-case log distinguishes "version column not selectable" (invalid inference) from "no Replacing engine."

### Testing (dedup)

- **Unit** — 6 version-aware dedup tests (max-version-wins-not-position, tie→later, tombstone-winner-drops-key, tombstone-non-winner-kept, missing-version-errors, cross-batch): `streamling-common` `utils::dedup` — 30 pass.
- **Unit** — 6 engine-parser tests: `streamling-connectors` lib — 241 pass.
- **e2e regression** — `test_clickhouse_source_replacing_dedup_when_version_column_not_selected` (`clickhouse_source.rs`): creates a `ReplacingMergeTree(insert_timestamp, is_deleted)` table, inserts 9 raw rows across 5 keys covering five dedup scenarios (single version, latest-wins, **position-vs-version trap**, tombstone-winner-dropped, tombstone-non-winner-kept), runs the pipeline with **`columns: "block_number,id,payload"` deliberately omitting the version column**, and asserts: row count = 4 (FINAL); `'c_new'` wins the position-vs-version case; key `'d'` is absent; key `'e'` survives as `'e_alive'`; postgres table has neither `insert_timestamp` nor `is_deleted`. Compiles + lints clean here; must be run locally via `just e2e-test test_clickhouse_source_replacing_dedup_when_version_column_not_selected` (the in-CI cluster's pods are unhealthy in this worktree).
- `just fix && just lint` clean.

### Note

Coalescing the full page adds one in-memory copy of the page (the raw page is already buffered pre-emit, so peak is ~2× page data). Tune `page_size` down on duplicate-dense tables if memory-bound; correctness is unaffected — `RangeController` still rescans on overflow.
