### PR TITLE
Finalize a terminal checkpoint before bounded sources complete (job mode)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6575,6 +6575,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "sqlx",
  "streamling-common",
  "streamling-config",

--- a/README.md
+++ b/README.md
@@ -11,23 +11,36 @@
 
 ```
 
-Streamling is a data processing runtime for data processing scenarios. Ingest from sources (event streams, database changelogs, API polling) and process them through multi-stage topologies with checkpointed at-least-once delivery.
+Streamling is a columnar streaming runtime built for writing your own operators. Everything in a pipeline is the same thing underneath: a DataFusion operator passing Apache Arrow `RecordBatch`es. A Kafka source, a SQL filter, sandboxed TypeScript, an HTTP enrichment, and a plugin you wrote yourself all run on one data plane, so they compose freely and inherit the same guarantees.
 
-Plugins can implement any source, transform, or sink. The runtime enforces backpressure, checkpointing, and data safety across the full pipeline. Built-in connectors for kafka, postgres, clickhouse, and more are included for common data flows.
+You write plugins for what's specific to your domain: polling a partner API, enriching from Postgres, pushing to your warehouse. Reuse them across pipelines by id. A plugin runs at native speed, and the runtime gives it the same guarantees the built-in connectors get: backpressure, checkpoint-coordinated at-least-once delivery, schema validation, and upsert (`_gs_op`) propagation.
+
+Built-in connectors for Kafka, Postgres, ClickHouse, and webhooks cover the common movement patterns, so you only write code for the parts that are yours.
 
 Built with Rust, Apache Arrow, and Apache DataFusion. Install with one command (see [Quick start](#quick-start)) or read more at [streamling.dev](https://streamling.dev).
+
+## Plugins vs. the runtime
+
+The division of labor: you own the logic, the runtime owns correctness.
+
+| You implement in plugins                  | The runtime enforces                                            |
+| ----------------------------------------- | --------------------------------------------------------------- |
+| Custom sources, transforms, sinks         | Checkpoint protocol across the full topology                    |
+| Arbitrary connection and processing logic | At-least-once delivery (sources commit only after sink flush)   |
+| Domain-specific schemas and options       | Schema and `primary_key` validation before startup              |
+| External API calls, decoding, enrichment  | Backpressure, graceful shutdown, retriable error classification |
+| State via the plugin state backend        | Upsert semantics (`_gs_op`) through to sinks                    |
 
 ## When to use Streamling
 
 **Streamling is a good fit when you need to:**
 
-- Run **ongoing data processes** over continuous ordered inputs: event streams, database changelogs, polled APIs, or any plugin source that emits data over time
-- Build **multi-stage data flows** combining plugins, SQL, WASM, HTTP enrichment, [dynamic tables](#dynamic-tables), and custom sinks; the runtime handles orchestration and consistency
-- Get **at-least-once delivery** with checkpoint-coordinated commit ordering: sources don't advance until sinks have durably flushed
-- Extend the runtime with **Rust plugins** or **WASM transforms**: plugins run arbitrary logic against any system; the runtime still enforces checkpointing, schema validation, and delivery guarantees
-- Use **built-in connectors as conveniences**: Kafka, Postgres, ClickHouse, and webhooks cover common data movement patterns without writing plugins
-- Run **bounded batch jobs**: read a finite dataset from a bounded source (e.g. a ClickHouse table), process it, write results, and exit
-- Handle **upserts** (INSERT/UPDATE/DELETE via `_gs_op`) into Postgres or ClickHouse
+- **Write your own operators and reuse them**: implement a source, transform, or sink once in Rust (or a transform in WASM/TypeScript), then drop it into any pipeline by id. The runtime enforces checkpointing, schema validation, and delivery guarantees around your code
+- **Run ongoing data processes** over continuous ordered inputs: event streams, database changelogs, polled APIs, or any plugin source that emits data over time
+- **Build multi-stage flows on one columnar data plane**: plugins, SQL, WASM, HTTP enrichment, and [dynamic tables](#dynamic-tables) chained in a single topology, all exchanging Arrow `RecordBatch`es
+- **Get at-least-once delivery** with checkpoint-coordinated commit ordering: sources don't advance until sinks have durably flushed
+- **Use built-in connectors as conveniences**: Kafka, Postgres, ClickHouse, and webhooks for common data movement, no plugin required
+- **Run bounded batch jobs** and handle upserts (INSERT/UPDATE/DELETE via `_gs_op`) into Postgres or ClickHouse
 
 Use Streamling when you need a streaming engine to process continuously arriving data in order through a defined pipeline, not a distributed shuffle or windowed aggregation engine.
 
@@ -93,16 +106,6 @@ sinks:
 ```
 
 Your plugins own the I/O and business logic; the runtime owns execution, backpressure, checkpointing, and recovery.
-
-### Plugins vs. the runtime
-
-| You implement in plugins                  | The runtime enforces                                            |
-| ----------------------------------------- | --------------------------------------------------------------- |
-| Custom sources, transforms, sinks         | Checkpoint protocol across the full topology                    |
-| Arbitrary connection and processing logic | At-least-once delivery (sources commit only after sink flush)   |
-| Domain-specific schemas and options       | Schema and `primary_key` validation before startup              |
-| External API calls, decoding, enrichment  | Backpressure, graceful shutdown, retriable error classification |
-| State via the plugin state backend        | Upsert semantics (`_gs_op`) through to sinks                    |
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -1061,6 +1061,38 @@ Finally, the print sink sends the checkpoint ack back to the coordinator. Once t
 number of acks (just 1 in this case, since there is only one sink), it finalizes the epoch and sends the finalizer
 message to the Kafka source. The source then commits the offsets.
 
+### Bounded sources and the terminal checkpoint
+
+Most sources are unbounded (Kafka), so the flow above runs on a timer for as long as the pipeline lives. A bounded
+source is different: it has a definite end. The hybrid source in job mode is the current example. It reads its bounded
+phases and then completes instead of switching to its unbounded phase.
+
+This is a problem for the flow above. Checkpoint markers ride inline on data batches, and an epoch finalizes only once
+every sink acks it. When a bounded source reaches its last batch, the timer may not have emitted a marker after that
+batch, so the final rows can complete without ever being covered by a finalized checkpoint. There is also no later
+batch to carry a marker through the graph once the source has stopped producing.
+
+**Every bounded source must follow this contract when it completes:**
+
+1. Call `CheckpointControl::begin_terminal_checkpoint()` to mint the terminal epoch. This stops the timer producer and
+   registers the epoch so the coordinator waits for it.
+2. Emit that epoch as a `Marker` on a final batch (a synthetic empty batch is fine), after the last real data. Emitting
+   it after the data keeps the marker ordered behind everything so the checkpoint covers a consistent cut.
+3. Then end the stream.
+
+The runtime gates teardown on this. After the sinks drain, it waits (`CheckpointControl::await_terminal_finalized`) for
+the terminal epoch to finalize before it stops the coordinator and terminates plugins. The sinks flush and ack the
+terminal marker as their last batch, the coordinator finalizes the epoch, and the Finalizer reaches any component that
+commits on it while that component is still alive. The wait is bounded by a timeout so a sink that dies without acking
+cannot hang shutdown.
+
+When several sources feed one pipeline and complete at different times, a sink whose only upstream has finished stops
+acking. The coordinator drops such a sink from its expected-ack set (`CheckpointControl::sink_completed`, signalled by
+the runtime as each sink drains) so the remaining epochs, including the terminal one, can still finalize. Without this a
+single finished branch would block finalization for every other branch.
+
+The hybrid source's job-mode termination path is the reference implementation.
+
 ## State Backends
 
 Streamling supports multiple state backend implementations for persisting operator state.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 ```
 
-Streamling is a columnar streaming runtime built for writing your own operators. Everything in a pipeline is the same thing underneath: a DataFusion operator passing Apache Arrow `RecordBatch`es. A Kafka source, a SQL filter, sandboxed TypeScript, an HTTP enrichment, and a plugin you wrote yourself all run on one data plane, so they compose freely and inherit the same guarantees.
+Streamling is a columnar streaming runtime easily extendable with your own operators. Everything in a pipeline is the same thing underneath: a DataFusion operator passing Apache Arrow `RecordBatch`es. A Kafka source, a SQL filter, sandboxed TypeScript, an HTTP enrichment, and a plugin you wrote yourself all run on one data plane, so they compose freely and inherit the same guarantees.
 
-You write plugins for what's specific to your domain: polling a partner API, enriching from Postgres, pushing to your warehouse. Reuse them across pipelines by id. A plugin runs at native speed, and the runtime gives it the same guarantees the built-in connectors get: backpressure, checkpoint-coordinated at-least-once delivery, schema validation, and upsert (`_gs_op`) propagation.
+You can write plugins for what's specific to your domain: polling a partner API, enriching from Postgres, pushing to your warehouse. Reuse them across pipelines by id. A plugin runs at native speed, and the runtime gives it the same guarantees the built-in connectors get: backpressure, checkpoint-coordinated at-least-once delivery, schema validation, and upsert (`_gs_op`) propagation.
 
 Built-in connectors for Kafka, Postgres, ClickHouse, and webhooks cover the common movement patterns, so you only write code for the parts that are yours.
 

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -20,8 +20,8 @@ use serde::{Deserialize, Serialize};
 use streamling_config::AppConfig;
 use streamling_core::checkpoints::channels::{subscribe_with_id, unsubscribe};
 use streamling_core::checkpoints::checkpoint_management::{
-    CHECKPOINT_COORDINATOR_CHANNEL, CheckpointMessage, enrich_batch_metadata_with_checkpoints,
-    extract_checkpoint_messages,
+    CHECKPOINT_COORDINATOR_CHANNEL, CheckpointControl, CheckpointMessage,
+    enrich_batch_metadata_with_checkpoints, extract_checkpoint_messages, now_ms,
 };
 use streamling_core::data::COLUMN_NAME_OP;
 use streamling_core::error::ResultExt;
@@ -144,6 +144,11 @@ pub struct HybridTableProvider {
     pub state: Arc<RwLock<HybridSourceState>>,
     reference_name: String,
     session_manager: SessionManager,
+    /// Control handle for the checkpoint coordinator. When set and `job_mode`
+    /// is on, the source begins a terminal checkpoint and emits its marker
+    /// inline after the last bounded batch (see the job-mode termination path
+    /// in `execute`). `None` outside a running pipeline (e.g. in tests).
+    checkpoint_control: Option<CheckpointControl>,
 }
 impl Debug for HybridTableProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -213,9 +218,18 @@ impl HybridTableProvider {
             state: Arc::new(RwLock::new(initial_state)),
             reference_name,
             session_manager,
+            checkpoint_control: None,
         };
 
         Ok(provider)
+    }
+
+    /// Attach the checkpoint control handle so this source can begin the
+    /// terminal checkpoint when it completes in job mode. Builder-style so the
+    /// provider can be configured before being wrapped in an `Arc`.
+    pub fn with_checkpoint_control(mut self, control: CheckpointControl) -> Self {
+        self.checkpoint_control = Some(control);
+        self
     }
 
     pub fn new_from_topology(
@@ -1146,6 +1160,32 @@ impl ExecutionPlan for HybridSourceExec {
                                     "Job mode: all {} bounded phase(s) complete, terminating hybrid source",
                                     provider.config.bounded_sources.len()
                                 );
+
+                                // Emit a terminal checkpoint marker inline,
+                                // after all bounded data, so the sinks flush and
+                                // ack a final epoch covering everything before
+                                // the pipeline tears down. The coordinator gates
+                                // shutdown on this epoch finalizing
+                                // (`await_terminal_finalized`). Reuses the
+                                // synthetic-batch flush path so the marker rides
+                                // the data stream and keeps a consistent cut.
+                                if let Some(control) = &provider.checkpoint_control {
+                                    let terminal = control.begin_terminal_checkpoint();
+                                    pending_for_main.lock().unwrap().push(
+                                        CheckpointMessage::Marker {
+                                            epoch: terminal,
+                                            created_at_ms: now_ms(),
+                                        },
+                                    );
+                                    flush_pending_to_synth_batch(
+                                        &pending_for_main,
+                                        &schema_for_synth,
+                                        &tx,
+                                        &reference_name_for_spawn,
+                                    )
+                                    .await;
+                                }
+
                                 provider.shutdown();
                                 break 'outer;
                             }
@@ -2431,6 +2471,63 @@ mod tests {
         assert!(
             state.completed_phases.iter().all(|&c| c),
             "All bounded phases should be marked complete"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_hybrid_source_emits_terminal_marker_in_job_mode() {
+        use streamling_core::checkpoints::checkpoint_management::CheckpointCoordinator;
+
+        // With a control handle attached, a completing job-mode source must
+        // emit a terminal checkpoint marker on a final (synthetic) batch so the
+        // sinks can flush and ack a checkpoint covering all bounded data before
+        // the pipeline tears down.
+        let coordinator = CheckpointCoordinator::new();
+        let control = coordinator.control();
+
+        let bounded_sources: Vec<Arc<dyn TableProvider>> =
+            vec![Arc::new(FiniteMockTableProvider::new())];
+        let unbounded_source: Arc<dyn TableProvider> = Arc::new(FiniteMockTableProvider::new());
+
+        let config = HybridSourceConfig {
+            bounded_sources,
+            unbounded_source,
+            offset_provider: None,
+            job_mode: true,
+        };
+
+        let state_backend =
+            create_state_backend("test_hybrid_source_emits_terminal_marker_in_job_mode").await;
+        let hybrid_provider = HybridTableProvider::new(
+            "test_terminal_marker".to_string(),
+            config,
+            create_test_schema(),
+            state_backend,
+            SESSION_MANAGER.clone(),
+        )
+        .unwrap()
+        .with_checkpoint_control(control);
+
+        let session_state = SESSION_MANAGER.session_state();
+        let plan = hybrid_provider
+            .scan(&session_state, None, &[], None)
+            .await
+            .expect("scan should succeed");
+
+        let context = Arc::new(TaskContext::default());
+        let stream = plan.execute(0, context).expect("execute should succeed");
+        let batches: Vec<_> = stream.collect().await;
+
+        let emitted_markers: Vec<_> = batches
+            .iter()
+            .filter_map(|b| b.as_ref().ok())
+            .flat_map(|b| extract_checkpoint_messages(b.schema().metadata()))
+            .filter(|m| matches!(m, CheckpointMessage::Marker { .. }))
+            .collect();
+
+        assert!(
+            !emitted_markers.is_empty(),
+            "job-mode source should emit a terminal checkpoint marker on completion"
         );
     }
 

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -2512,7 +2512,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_hybrid_source_terminal_checkpoint_round_trip() {
-        use streamling_core::checkpoints::channels::send;
         use streamling_core::checkpoints::checkpoint_management::CheckpointCoordinator;
 
         // A completing job-mode source emits the terminal Marker, waits for the
@@ -2544,7 +2543,7 @@ mod tests {
             SESSION_MANAGER.clone(),
         )
         .unwrap()
-        .with_checkpoint_control(control);
+        .with_checkpoint_control(control.clone());
 
         let session_state = SESSION_MANAGER.session_state();
         let plan = hybrid_provider
@@ -2563,16 +2562,13 @@ mod tests {
             let batch = batch.expect("stream batch should not be an error");
             for msg in extract_checkpoint_messages(batch.schema().metadata()) {
                 match msg {
-                    CheckpointMessage::Marker { epoch, .. } => {
+                    CheckpointMessage::Marker { .. } => {
                         saw_marker = true;
-                        send(
-                            CHECKPOINT_COORDINATOR_CHANNEL,
-                            CheckpointMessage::Ack {
-                                epoch,
-                                sink_id: "roundtrip_sink".to_string(),
-                            },
-                        )
-                        .unwrap();
+                        control.sink_completed("roundtrip_sink");
+                        assert!(
+                            control.is_terminal_finalized(),
+                            "terminal epoch should be finalized synchronously after sink completion"
+                        );
                     }
                     CheckpointMessage::Finalizer(_) => saw_finalizer = true,
                     _ => {}

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1161,22 +1161,58 @@ impl ExecutionPlan for HybridSourceExec {
                                     provider.config.bounded_sources.len()
                                 );
 
-                                // Emit a terminal checkpoint marker inline,
-                                // after all bounded data, so the sinks flush and
-                                // ack a final epoch covering everything before
-                                // the pipeline tears down. The coordinator gates
-                                // shutdown on this epoch finalizing
-                                // (`await_terminal_finalized`). Reuses the
-                                // synthetic-batch flush path so the marker rides
-                                // the data stream and keeps a consistent cut.
+                                // Terminal checkpoint round-trip. The marker and
+                                // finalizer ride synthetic batches on the data
+                                // stream, so they keep a consistent cut and reach
+                                // inline consumers (e.g. the Postgres sink) the
+                                // same way every other checkpoint does.
                                 if let Some(control) = &provider.checkpoint_control {
                                     let terminal = control.begin_terminal_checkpoint();
+
+                                    // Batch #1: the terminal marker, after all
+                                    // bounded data, so the sinks flush and ack a
+                                    // final epoch covering everything.
                                     pending_for_main.lock().unwrap().push(
                                         CheckpointMessage::Marker {
-                                            epoch: terminal,
+                                            epoch: terminal.clone(),
                                             created_at_ms: now_ms(),
                                         },
                                     );
+                                    flush_pending_to_synth_batch(
+                                        &pending_for_main,
+                                        &schema_for_synth,
+                                        &tx,
+                                        &reference_name_for_spawn,
+                                    )
+                                    .await;
+
+                                    // Wait for the sinks to ack and the
+                                    // coordinator to finalize. The send above is
+                                    // buffered and the sinks pull concurrently,
+                                    // so this await does not block their
+                                    // consumption. Bounded so a sink that never
+                                    // acks cannot hang the source task.
+                                    if tokio::time::timeout(
+                                        Duration::from_secs(30),
+                                        control.await_terminal_finalized(),
+                                    )
+                                    .await
+                                    .is_err()
+                                    {
+                                        warn!(
+                                            "Hybrid source '{}': terminal checkpoint did not finalize within 30s; emitting finalizer best-effort",
+                                            reference_name_for_spawn
+                                        );
+                                    }
+
+                                    // Batch #2: carry the finalizer back inline
+                                    // so inline consumers run their finalize work
+                                    // (e.g. Postgres staging truncation) before
+                                    // their stream ends.
+                                    pending_for_main
+                                        .lock()
+                                        .unwrap()
+                                        .push(CheckpointMessage::Finalizer(terminal));
                                     flush_pending_to_synth_batch(
                                         &pending_for_main,
                                         &schema_for_synth,
@@ -2475,14 +2511,16 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_hybrid_source_emits_terminal_marker_in_job_mode() {
+    async fn test_hybrid_source_terminal_checkpoint_round_trip() {
+        use streamling_core::checkpoints::channels::send;
         use streamling_core::checkpoints::checkpoint_management::CheckpointCoordinator;
 
-        // With a control handle attached, a completing job-mode source must
-        // emit a terminal checkpoint marker on a final (synthetic) batch so the
-        // sinks can flush and ack a checkpoint covering all bounded data before
-        // the pipeline tears down.
-        let coordinator = CheckpointCoordinator::new();
+        // A completing job-mode source emits the terminal Marker, waits for the
+        // sinks to ack it and the coordinator to finalize, then carries the
+        // Finalizer back inline on a second synthetic batch so inline consumers
+        // (e.g. the Postgres sink) run their finalize work before teardown.
+        let mut coordinator = CheckpointCoordinator::new();
+        coordinator.start(3600, vec!["roundtrip_sink".to_string()]);
         let control = coordinator.control();
 
         let bounded_sources: Vec<Arc<dyn TableProvider>> =
@@ -2497,9 +2535,9 @@ mod tests {
         };
 
         let state_backend =
-            create_state_backend("test_hybrid_source_emits_terminal_marker_in_job_mode").await;
+            create_state_backend("test_hybrid_source_terminal_checkpoint_round_trip").await;
         let hybrid_provider = HybridTableProvider::new(
-            "test_terminal_marker".to_string(),
+            "test_terminal_round_trip".to_string(),
             config,
             create_test_schema(),
             state_backend,
@@ -2515,19 +2553,39 @@ mod tests {
             .expect("scan should succeed");
 
         let context = Arc::new(TaskContext::default());
-        let stream = plan.execute(0, context).expect("execute should succeed");
-        let batches: Vec<_> = stream.collect().await;
+        let mut stream = plan.execute(0, context).expect("execute should succeed");
 
-        let emitted_markers: Vec<_> = batches
-            .iter()
-            .filter_map(|b| b.as_ref().ok())
-            .flat_map(|b| extract_checkpoint_messages(b.schema().metadata()))
-            .filter(|m| matches!(m, CheckpointMessage::Marker { .. }))
-            .collect();
+        // Drive the stream like a sink would: ack the terminal Marker so the
+        // coordinator finalizes, which lets the source emit the Finalizer batch.
+        let mut saw_marker = false;
+        let mut saw_finalizer = false;
+        while let Some(batch) = stream.next().await {
+            let batch = batch.expect("stream batch should not be an error");
+            for msg in extract_checkpoint_messages(batch.schema().metadata()) {
+                match msg {
+                    CheckpointMessage::Marker { epoch, .. } => {
+                        saw_marker = true;
+                        send(
+                            CHECKPOINT_COORDINATOR_CHANNEL,
+                            CheckpointMessage::Ack {
+                                epoch,
+                                sink_id: "roundtrip_sink".to_string(),
+                            },
+                        )
+                        .unwrap();
+                    }
+                    CheckpointMessage::Finalizer(_) => saw_finalizer = true,
+                    _ => {}
+                }
+            }
+        }
 
+        coordinator.stop().await;
+
+        assert!(saw_marker, "source should emit the terminal Marker");
         assert!(
-            !emitted_markers.is_empty(),
-            "job-mode source should emit a terminal checkpoint marker on completion"
+            saw_finalizer,
+            "source should carry the Finalizer back inline once the terminal epoch finalizes"
         );
     }
 

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -2525,11 +2525,10 @@ impl DataSink for KafkaSink {
                     }
 
                     let sink_id = get_reference_name_from_metric_key(&self.metric_metadata_id);
-                    send(
+                    let _ = send(
                         CHECKPOINT_COORDINATOR_CHANNEL,
                         CheckpointMessage::Ack { epoch, sink_id },
-                    )
-                    .unwrap();
+                    );
                     metrics_recorder.record_time(
                         "checkpoint_sink_flush",
                         ack_start.elapsed(),

--- a/crates/streamling-connectors/src/table_providers/postgres/batch_processor.rs
+++ b/crates/streamling-connectors/src/table_providers/postgres/batch_processor.rs
@@ -139,11 +139,10 @@ async fn process_checkpoint_messages_with_truncation(
                 );
 
                 let sink_id = get_reference_name_from_metric_key(&context.metric_metadata_id);
-                send(
+                let _ = send(
                     CHECKPOINT_COORDINATOR_CHANNEL,
                     CheckpointMessage::Ack { epoch, sink_id },
-                )
-                .unwrap();
+                );
 
                 // Record sink flush time (time from batch arrival to ack sent)
                 context.metrics_recorder.record_time(

--- a/crates/streamling-connectors/src/table_providers/postgres/batch_processor.rs
+++ b/crates/streamling-connectors/src/table_providers/postgres/batch_processor.rs
@@ -92,6 +92,29 @@ async fn handle_checkpoint_truncation(context: &BatchProcessorContext, truncate_
     .await;
 }
 
+/// Decide which epoch to drain when the input stream ends. Per-epoch
+/// truncation lags by one (`Finalizer(N)` deletes `<= N-1`), so the last
+/// finalized epoch's rows are still in the landing table at EOF. With no more
+/// data coming, those rows are safe to delete too. Returns `None` when
+/// truncation is disabled or no checkpoint has run.
+fn eof_truncation_epoch(checkpoint_truncation: bool, current_epoch: u64) -> Option<u64> {
+    if checkpoint_truncation && current_epoch > 0 {
+        Some(current_epoch)
+    } else {
+        None
+    }
+}
+
+/// Drain the landing table's last epoch once the input stream has ended. This
+/// completes the per-epoch truncation, which otherwise leaves the final epoch's
+/// rows behind. Best-effort, like the per-finalizer truncation it mirrors.
+pub async fn finalize_landing_on_eof(context: &BatchProcessorContext) {
+    let current_epoch = *context.current_checkpoint_epoch.lock().unwrap();
+    if let Some(epoch) = eof_truncation_epoch(context.checkpoint_truncation, current_epoch) {
+        handle_checkpoint_truncation(context, epoch).await;
+    }
+}
+
 /// Process checkpoint messages with metrics and handle Finalizer for truncation.
 /// This is a PostgreSQL-specific version that extends the standard process_checkpoint_acks
 /// to handle Finalizer messages for checkpoint truncation.
@@ -460,6 +483,18 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_eof_truncation_epoch() {
+        // Truncation disabled: never delete on EOF.
+        assert_eq!(eof_truncation_epoch(false, 5), None);
+        // Enabled but no checkpoint ever ran (epoch 0): nothing to delete.
+        assert_eq!(eof_truncation_epoch(true, 0), None);
+        // Enabled with a finalized epoch: drain it. Per-epoch truncation lags
+        // by one (Finalizer(N) deletes <= N-1), so the last epoch's rows are
+        // still present at EOF and must be cleaned now that no data follows.
+        assert_eq!(eof_truncation_epoch(true, 5), Some(5));
     }
 
     #[tokio::test]

--- a/crates/streamling-connectors/src/table_providers/postgres/mod.rs
+++ b/crates/streamling-connectors/src/table_providers/postgres/mod.rs
@@ -13,7 +13,7 @@ pub use query_builder::PostgresQueryBuilder;
 // Main implementations
 use arrow_schema::SchemaRef;
 use async_trait::async_trait;
-use batch_processor::{BatchProcessorContext, process_batch};
+use batch_processor::{BatchProcessorContext, finalize_landing_on_eof, process_batch};
 use columns::ColumnInfo;
 use datafusion::catalog::Session;
 use datafusion::common::{Result, not_impl_err};
@@ -346,6 +346,10 @@ impl DataSink for PostgresSinkExec {
                 break;
             }
         }
+
+        // Stream ended: drain the landing table's final epoch, which the
+        // per-finalizer truncation leaves behind (it deletes <= N-1).
+        finalize_landing_on_eof(&processor_context).await;
 
         info!(
             "[{}] write_all completed with {} rows (table '{}.{}')",

--- a/crates/streamling-core/Cargo.toml
+++ b/crates/streamling-core/Cargo.toml
@@ -88,3 +88,4 @@ paste.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
+serial_test.workspace = true

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -73,14 +73,13 @@ pub fn process_checkpoint_acks(
                 Duration::from_millis(arrival_latency_ms),
                 metric_metadata_id,
             );
-            send(
+            let _ = send(
                 CHECKPOINT_COORDINATOR_CHANNEL,
                 CheckpointMessage::Ack {
                     epoch,
                     sink_id: sink_id.to_string(),
                 },
-            )
-            .unwrap();
+            );
             metrics_recorder.record_time(
                 "checkpoint_sink_flush",
                 ack_start.elapsed(),
@@ -190,11 +189,10 @@ impl CheckpointControl {
             metrics_recorder.record_count("checkpoint_epochs_succeeded", 1);
             metrics_recorder.record_count("checkpoint_finalizers_sent", 1);
             info!("Epoch {} finalized after sink completion", epoch.0);
-            send(
+            let _ = send(
                 CHECKPOINT_COORDINATOR_CHANNEL,
                 CheckpointMessage::Finalizer(epoch),
-            )
-            .unwrap();
+            );
         }
         record_in_flight_gauge(&self.epochs, &metrics_recorder);
     }
@@ -245,6 +243,17 @@ impl CheckpointControl {
                 }
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    /// Returns true if the terminal checkpoint has finalized.
+    pub fn is_terminal_finalized(&self) -> bool {
+        let terminal = self.terminal_epoch.lock().clone();
+        match terminal {
+            None => false,
+            Some(epoch) => {
+                matches!(self.epochs.lock().get(&epoch), Some(EpochState::Finalized))
+            }
         }
     }
 }
@@ -463,11 +472,10 @@ impl CheckpointCoordinator {
                             metrics_recorder.record_count("checkpoint_finalizers_sent", 1);
 
                             info!("Epoch finalized: {}", epoch.0);
-                            send(
+                            let _ = send(
                                 CHECKPOINT_COORDINATOR_CHANNEL,
                                 CheckpointMessage::Finalizer(epoch),
-                            )
-                            .unwrap();
+                            );
 
                             record_in_flight_gauge(&epochs, &metrics_recorder);
                         }
@@ -1039,5 +1047,58 @@ mod tests {
         }
 
         coordinator.stop().await;
+    }
+
+    #[test]
+    fn test_sink_completion_unblocks_finalization_synchronous() {
+        // Two sinks are expected. The epoch is acked by sink_b only, so it
+        // is InProgress waiting on sink_a. When sink_a's branch finished and
+        // is marked completed, it should finalize synchronously.
+        let coordinator = CheckpointCoordinator::with_timeout(300);
+        let epoch = CheckpointEpoch(1042);
+
+        // Seed expected sinks.
+        {
+            let mut expected = coordinator.expected_sinks.lock();
+            expected.insert("sink_a_dereg".to_string());
+            expected.insert("sink_b_dereg".to_string());
+        }
+
+        // Seed epoch as InProgress { acked: {sink_b_dereg} } directly.
+        {
+            let mut epochs = coordinator.epochs.lock();
+            let mut acked_sinks = HashSet::new();
+            acked_sinks.insert("sink_b_dereg".to_string());
+            epochs.insert(
+                epoch.clone(),
+                EpochState::InProgress {
+                    acked_sinks,
+                    created_at: Instant::now(),
+                },
+            );
+        }
+
+        let control = coordinator.control();
+
+        // Assert it is in progress initially.
+        {
+            let epochs = coordinator.epochs.lock();
+            assert!(
+                matches!(epochs.get(&epoch), Some(EpochState::InProgress { .. })),
+                "epoch should still be in progress waiting on sink_a"
+            );
+        }
+
+        // Mark sink_a completed synchronously.
+        control.sink_completed("sink_a_dereg");
+
+        // Assert it is Finalized.
+        {
+            let epochs = coordinator.epochs.lock();
+            assert!(
+                matches!(epochs.get(&epoch), Some(EpochState::Finalized)),
+                "epoch should finalize synchronously once the only outstanding sink completes"
+            );
+        }
     }
 }

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -118,9 +118,158 @@ pub struct CheckpointCoordinator {
     /// Monotonically increasing epoch counter. Never reuses epoch numbers,
     /// even if previous epochs are removed due to timeout.
     next_epoch: Arc<AtomicU64>,
+    /// The sinks the coordinator waits on to ack an epoch before finalizing it.
+    /// Mutable: a sink whose upstream source has completed is dropped from this
+    /// set via [`CheckpointControl::sink_completed`] so it stops blocking
+    /// finalization. Populated in [`CheckpointCoordinator::start`]; shared by
+    /// the subscriber/producer tasks and any [`CheckpointControl`] handle.
+    expected_sinks: Arc<Mutex<HashSet<String>>>,
+    /// Set once a terminal checkpoint has been begun (a bounded source is
+    /// completing). Gates the timer producer so it stops issuing epochs and
+    /// never clears the terminal epoch out of the map.
+    terminal_started: Arc<AtomicBool>,
+    /// The terminal epoch, once begun. [`CheckpointControl::await_terminal_finalized`]
+    /// resolves when this epoch reaches `Finalized`.
+    terminal_epoch: Arc<Mutex<Option<CheckpointEpoch>>>,
     running: Arc<AtomicBool>,
     handles: Vec<tokio::task::JoinHandle<()>>,
     timeout_sec: u64,
+}
+
+/// A cloneable handle for signalling checkpoint lifecycle events to the
+/// coordinator from outside its subscriber task — for example, the pipeline
+/// run loop observing a sink future drain. These are control-plane signals, so
+/// they are methods here rather than `CheckpointMessage` variants: the
+/// on-the-wire checkpoint protocol stays limited to data-plane markers, acks,
+/// and finalizers.
+#[derive(Clone)]
+pub struct CheckpointControl {
+    epochs: Arc<Mutex<BTreeMap<CheckpointEpoch, EpochState>>>,
+    expected_sinks: Arc<Mutex<HashSet<String>>>,
+    next_epoch: Arc<AtomicU64>,
+    terminal_started: Arc<AtomicBool>,
+    terminal_epoch: Arc<Mutex<Option<CheckpointEpoch>>>,
+}
+
+impl CheckpointControl {
+    /// Mark a sink as drained: it will never ack again, so drop it from the
+    /// expected-ack set and finalize any in-flight epoch the remaining live
+    /// sinks have already acked. Without this, an epoch waiting on a completed
+    /// sink — and any shutdown gated on finalization — blocks forever (the
+    /// multi-source completion case).
+    pub fn sink_completed(&self, sink_id: &str) {
+        // Snapshot the remaining set and release its lock before touching
+        // `epochs`, so we never hold both locks at once. The subscriber/producer
+        // paths lock epochs-then-expected; holding only one here keeps the lock
+        // order acyclic.
+        let expected_snapshot: HashSet<String> = {
+            let mut expected = self.expected_sinks.lock();
+            if !expected.remove(sink_id) {
+                // Unknown sink or already removed — nothing to do.
+                return;
+            }
+            expected.clone()
+        };
+        info!(
+            "Sink completed: {} (removed from expected ack set, {} live sink(s) remain)",
+            sink_id,
+            expected_snapshot.len()
+        );
+
+        let newly_finalized = finalize_ready_epochs(&self.epochs, &expected_snapshot);
+        if newly_finalized.is_empty() {
+            return;
+        }
+
+        let metrics_recorder = get_checkpoint_metrics_recorder();
+        for epoch in newly_finalized {
+            metrics_recorder.record_count("checkpoint_epochs_succeeded", 1);
+            metrics_recorder.record_count("checkpoint_finalizers_sent", 1);
+            info!("Epoch {} finalized after sink completion", epoch.0);
+            send(
+                CHECKPOINT_COORDINATOR_CHANNEL,
+                CheckpointMessage::Finalizer(epoch),
+            )
+            .unwrap();
+        }
+        record_in_flight_gauge(&self.epochs, &metrics_recorder);
+    }
+
+    /// Begin the terminal checkpoint: the single final epoch that a completing
+    /// bounded source emits inline after its last data, so the sinks flush and
+    /// ack a checkpoint covering all of it before the pipeline tears down. The
+    /// caller is responsible for emitting the returned epoch as a `Marker` on a
+    /// final (synthetic) batch so it flows to the sinks after the last data.
+    ///
+    /// Setting `terminal_started` first, then minting and inserting under the
+    /// epochs lock, prevents the timer producer from clearing this epoch: the
+    /// producer re-checks `terminal_started` under the same lock before it
+    /// clears/inserts, so it can never race a fresh timer epoch over the
+    /// terminal one.
+    pub fn begin_terminal_checkpoint(&self) -> CheckpointEpoch {
+        self.terminal_started.store(true, Ordering::SeqCst);
+
+        let mut epochs = self.epochs.lock();
+        // Drop any in-flight timer epochs. The source is done producing data,
+        // so their markers can no longer reach the sinks and they would never
+        // finalize. The terminal epoch is the only one that matters now.
+        epochs.clear();
+        let epoch_num = self.next_epoch.fetch_add(1, Ordering::SeqCst);
+        let terminal = CheckpointEpoch(epoch_num);
+        epochs.insert(
+            terminal.clone(),
+            EpochState::Started {
+                created_at: Instant::now(),
+            },
+        );
+        *self.terminal_epoch.lock() = Some(terminal.clone());
+        info!("Begin terminal checkpoint: epoch {}", terminal.0);
+        terminal
+    }
+
+    /// Resolve once the terminal checkpoint has finalized (all live sinks
+    /// acked it). Returns immediately if no terminal checkpoint was begun.
+    pub async fn await_terminal_finalized(&self) {
+        loop {
+            let terminal = self.terminal_epoch.lock().clone();
+            match terminal {
+                None => return,
+                Some(epoch) => {
+                    if matches!(self.epochs.lock().get(&epoch), Some(EpochState::Finalized)) {
+                        return;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+}
+
+/// Transition every non-finalized epoch that the given (already shrunk)
+/// expected-sink set has fully acked into `Finalized`, returning the epochs
+/// that newly finalized so the caller can broadcast their `Finalizer`.
+fn finalize_ready_epochs(
+    epochs: &Arc<Mutex<BTreeMap<CheckpointEpoch, EpochState>>>,
+    expected: &HashSet<String>,
+) -> Vec<CheckpointEpoch> {
+    let mut newly_finalized = Vec::new();
+    let mut epochs_guard = epochs.lock();
+    for (epoch, state) in epochs_guard.iter_mut() {
+        let is_complete = match state {
+            // A Started epoch has no acks yet; it can only be considered
+            // complete if no sinks remain to ack it at all.
+            EpochState::Started { .. } => expected.is_empty(),
+            EpochState::InProgress { acked_sinks, .. } => {
+                expected.iter().all(|s| acked_sinks.contains(s))
+            }
+            EpochState::Finalized => false,
+        };
+        if is_complete {
+            *state = EpochState::Finalized;
+            newly_finalized.push(epoch.clone());
+        }
+    }
+    newly_finalized
 }
 
 /// Record the current number of non-finalized epochs as a gauge metric.
@@ -149,9 +298,26 @@ impl CheckpointCoordinator {
         Self {
             epochs: Arc::new(Mutex::new(BTreeMap::new())),
             next_epoch: Arc::new(AtomicU64::new(1)),
+            expected_sinks: Arc::new(Mutex::new(HashSet::new())),
+            terminal_started: Arc::new(AtomicBool::new(false)),
+            terminal_epoch: Arc::new(Mutex::new(None)),
             running: Arc::new(AtomicBool::new(false)),
             handles: Vec::new(),
             timeout_sec,
+        }
+    }
+
+    /// Returns a cloneable control handle for signalling lifecycle events
+    /// (e.g. sink completion, beginning the terminal checkpoint) from outside
+    /// the coordinator's tasks. The handle shares the coordinator's state, so
+    /// it is valid before or after [`CheckpointCoordinator::start`].
+    pub fn control(&self) -> CheckpointControl {
+        CheckpointControl {
+            epochs: Arc::clone(&self.epochs),
+            expected_sinks: Arc::clone(&self.expected_sinks),
+            next_epoch: Arc::clone(&self.next_epoch),
+            terminal_started: Arc::clone(&self.terminal_started),
+            terminal_epoch: Arc::clone(&self.terminal_epoch),
         }
     }
 
@@ -164,7 +330,10 @@ impl CheckpointCoordinator {
 
         self.running.store(true, Ordering::SeqCst);
 
-        let expected_sinks = Arc::new(expected_sinks);
+        // Populate the shared expected-ack set in place (rather than replacing
+        // the Arc) so any control handle taken before `start` observes it.
+        *self.expected_sinks.lock() = expected_sinks.into_iter().collect();
+        let expected_sinks = Arc::clone(&self.expected_sinks);
 
         let receiver = subscribe(CHECKPOINT_COORDINATOR_CHANNEL);
         let epochs = Arc::clone(&self.epochs);
@@ -183,7 +352,7 @@ impl CheckpointCoordinator {
                         );
 
                         // Warn if this sink_id is not in the expected list
-                        if !expected_sinks_sub.contains(&sink_id) {
+                        if !expected_sinks_sub.lock().contains(&sink_id) {
                             warn!(
                                 "Received ack from unexpected sink '{}' for epoch {} (expected: {:?})",
                                 sink_id, epoch.0, *expected_sinks_sub
@@ -221,6 +390,7 @@ impl CheckpointCoordinator {
                                         );
 
                                         let is_complete = expected_sinks_sub
+                                            .lock()
                                             .iter()
                                             .all(|s| acked_sinks.contains(s));
                                         if is_complete {
@@ -256,6 +426,7 @@ impl CheckpointCoordinator {
                                         );
 
                                         let is_complete = expected_sinks_sub
+                                            .lock()
                                             .iter()
                                             .all(|s| acked_sinks.contains(s));
                                         if is_complete {
@@ -317,6 +488,7 @@ impl CheckpointCoordinator {
         let running = Arc::clone(&self.running);
         let next_epoch_counter = Arc::clone(&self.next_epoch);
         let expected_sinks_prod = Arc::clone(&expected_sinks);
+        let terminal_started_prod = Arc::clone(&self.terminal_started);
 
         let producer_handle = tokio::spawn(async move {
             let metrics_recorder = get_checkpoint_metrics_recorder();
@@ -384,12 +556,15 @@ impl CheckpointCoordinator {
                                 match state {
                                     EpochState::InProgress { acked_sinks, .. } => {
                                         expected_sinks_prod
+                                            .lock()
                                             .iter()
                                             .filter(|s| !acked_sinks.contains(*s))
                                             .cloned()
                                             .collect()
                                     }
-                                    EpochState::Started { .. } => expected_sinks_prod.to_vec(),
+                                    EpochState::Started { .. } => {
+                                        expected_sinks_prod.lock().iter().cloned().collect()
+                                    }
                                     _ => vec![],
                                 }
                             } else {
@@ -428,14 +603,25 @@ impl CheckpointCoordinator {
 
                 let created_at = Instant::now();
                 let created_at_ms = now_ms();
-                let epoch_num = next_epoch_counter.fetch_add(1, Ordering::SeqCst);
-                let new_epoch = CheckpointEpoch(epoch_num);
-                {
+                // Mint and insert under the epochs lock, re-checking the
+                // terminal flag inside that same critical section. A terminal
+                // checkpoint (begun by a completing bounded source) clears the
+                // map and inserts its own epoch under this lock, so this
+                // re-check guarantees we never clear the terminal epoch by
+                // racing a fresh timer epoch over it.
+                let new_epoch = {
                     let mut epochs_guard = epochs.lock();
+                    if terminal_started_prod.load(Ordering::SeqCst) {
+                        debug!("Terminal checkpoint started; stopping timer producer");
+                        break;
+                    }
+                    let epoch_num = next_epoch_counter.fetch_add(1, Ordering::SeqCst);
+                    let new_epoch = CheckpointEpoch(epoch_num);
                     // Previous epoch is finalized; clear it before inserting the new one
                     epochs_guard.clear();
                     epochs_guard.insert(new_epoch.clone(), EpochState::Started { created_at });
-                }
+                    new_epoch
+                };
 
                 record_in_flight_gauge(&epochs, &metrics_recorder);
 
@@ -721,6 +907,115 @@ mod tests {
         {
             let epochs = coordinator.epochs.lock();
             assert!(matches!(epochs.get(&epoch), Some(EpochState::Finalized)));
+        }
+
+        coordinator.stop().await;
+    }
+
+    #[tokio::test]
+    async fn test_sink_completion_unblocks_finalization() {
+        // Two sinks are expected. The epoch is acked by sink_b only, so it
+        // stays in progress waiting on sink_a. When sink_a's branch finishes
+        // (a bounded source completed), sink_a will never ack again. Marking
+        // it complete must remove it from the expected set and let the epoch
+        // finalize on the remaining live sink — otherwise the coordinator
+        // (and any shutdown gated on finalization) blocks forever.
+        let mut coordinator = CheckpointCoordinator::with_timeout(300);
+        let epoch = CheckpointEpoch(1042);
+
+        {
+            let mut epochs = coordinator.epochs.lock();
+            epochs.insert(
+                epoch.clone(),
+                EpochState::Started {
+                    created_at: Instant::now(),
+                },
+            );
+        }
+
+        coordinator.start(
+            3600,
+            vec!["sink_a_dereg".to_string(), "sink_b_dereg".to_string()],
+        );
+
+        // Only sink_b acks; epoch is now InProgress waiting on sink_a.
+        send(
+            CHECKPOINT_COORDINATOR_CHANNEL,
+            CheckpointMessage::Ack {
+                epoch: epoch.clone(),
+                sink_id: "sink_b_dereg".to_string(),
+            },
+        )
+        .unwrap();
+
+        sleep(Duration::from_millis(100)).await;
+
+        {
+            let epochs = coordinator.epochs.lock();
+            assert!(
+                matches!(epochs.get(&epoch), Some(EpochState::InProgress { .. })),
+                "epoch should still be in progress, waiting on sink_a"
+            );
+        }
+
+        // sink_a's branch finished and will never ack. Deregister it via the
+        // control handle (no checkpoint message involved).
+        coordinator.control().sink_completed("sink_a_dereg");
+
+        sleep(Duration::from_millis(100)).await;
+
+        {
+            let epochs = coordinator.epochs.lock();
+            assert!(
+                matches!(epochs.get(&epoch), Some(EpochState::Finalized)),
+                "epoch should finalize once the only outstanding sink completes"
+            );
+        }
+
+        coordinator.stop().await;
+    }
+
+    #[tokio::test]
+    async fn test_terminal_checkpoint_blocks_until_acked() {
+        // A bounded source, on completion, begins a terminal checkpoint and the
+        // pipeline must not tear down until that epoch finalizes. The await must
+        // block until the sink acks the terminal marker, then return.
+        let mut coordinator = CheckpointCoordinator::with_timeout(300);
+        coordinator.start(3600, vec!["sink_terminal".to_string()]);
+        let control = coordinator.control();
+
+        let terminal = control.begin_terminal_checkpoint();
+
+        // No sink has acked the terminal marker yet, so the await must not
+        // return.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(150), control.await_terminal_finalized())
+                .await
+                .is_err(),
+            "await_terminal_finalized must block until the terminal epoch is acked"
+        );
+
+        // The sink processes the terminal marker, flushes, and acks.
+        send(
+            CHECKPOINT_COORDINATOR_CHANNEL,
+            CheckpointMessage::Ack {
+                epoch: terminal.clone(),
+                sink_id: "sink_terminal".to_string(),
+            },
+        )
+        .unwrap();
+
+        // Now the terminal checkpoint finalizes and the await returns.
+        tokio::time::timeout(Duration::from_secs(2), control.await_terminal_finalized())
+            .await
+            .expect("await_terminal_finalized must return once the terminal epoch finalizes");
+
+        {
+            let epochs = coordinator.epochs.lock();
+            assert!(
+                matches!(epochs.get(&terminal), Some(EpochState::Finalized)),
+                "terminal epoch should be finalized after the sink acks"
+            );
         }
 
         coordinator.stop().await;

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -1,4 +1,4 @@
-use crate::checkpoints::channels::{send, subscribe};
+use crate::checkpoints::channels::{SubscriberId, send, subscribe_with_id, unsubscribe};
 use crate::telemetry::recorder::{
     ControlPlaneMetricsRecorder, MetricsRecorder, get_control_plane_metrics_recorder,
 };
@@ -133,6 +133,10 @@ pub struct CheckpointCoordinator {
     terminal_epoch: Arc<Mutex<Option<CheckpointEpoch>>>,
     running: Arc<AtomicBool>,
     handles: Vec<tokio::task::JoinHandle<()>>,
+    /// The subscriber id for the coordinator's channel subscription, so
+    /// [`CheckpointCoordinator::stop`] can unsubscribe and not leave a dead
+    /// sender in the global channel map.
+    subscriber_id: Option<SubscriberId>,
     timeout_sec: u64,
 }
 
@@ -303,6 +307,7 @@ impl CheckpointCoordinator {
             terminal_epoch: Arc::new(Mutex::new(None)),
             running: Arc::new(AtomicBool::new(false)),
             handles: Vec::new(),
+            subscriber_id: None,
             timeout_sec,
         }
     }
@@ -335,7 +340,8 @@ impl CheckpointCoordinator {
         *self.expected_sinks.lock() = expected_sinks.into_iter().collect();
         let expected_sinks = Arc::clone(&self.expected_sinks);
 
-        let receiver = subscribe(CHECKPOINT_COORDINATOR_CHANNEL);
+        let (receiver, subscriber_id) = subscribe_with_id(CHECKPOINT_COORDINATOR_CHANNEL);
+        self.subscriber_id = Some(subscriber_id);
         let epochs = Arc::clone(&self.epochs);
         let running = Arc::clone(&self.running);
         let expected_sinks_sub = Arc::clone(&expected_sinks);
@@ -741,6 +747,13 @@ impl CheckpointCoordinator {
             let _ = handle.await;
         }
 
+        // The subscriber task has exited and dropped its receiver; remove the
+        // now-dead sender from the global channel map so later sends don't fail
+        // against it.
+        if let Some(subscriber_id) = self.subscriber_id.take() {
+            unsubscribe(CHECKPOINT_COORDINATOR_CHANNEL, subscriber_id);
+        }
+
         info!("Checkpoint coordinator stopped");
     }
 }
@@ -792,6 +805,7 @@ mod tests {
     use super::*;
     use arrow::array::Int32Array;
     use arrow::datatypes::{DataType, Field, Fields};
+    use serial_test::serial;
     use tokio::time::sleep;
 
     fn create_test_batch_with_metadata(
@@ -858,6 +872,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_unexpected_ack_does_not_finalize_epoch() {
         let mut coordinator = CheckpointCoordinator::with_timeout(300);
         let epoch = CheckpointEpoch(42);
@@ -913,6 +928,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_sink_completion_unblocks_finalization() {
         // Two sinks are expected. The epoch is acked by sink_b only, so it
         // stays in progress waiting on sink_a. When sink_a's branch finishes
@@ -976,6 +992,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_terminal_checkpoint_blocks_until_acked() {
         // A bounded source, on completion, begins a terminal checkpoint and the
         // pipeline must not tear down until that epoch finalizes. The await must
@@ -989,9 +1006,12 @@ mod tests {
         // No sink has acked the terminal marker yet, so the await must not
         // return.
         assert!(
-            tokio::time::timeout(Duration::from_millis(150), control.await_terminal_finalized())
-                .await
-                .is_err(),
+            tokio::time::timeout(
+                Duration::from_millis(150),
+                control.await_terminal_finalized()
+            )
+            .await
+            .is_err(),
             "await_terminal_finalized must block until the terminal epoch is acked"
         );
 

--- a/crates/streamling-core/src/plugin/table_provider.rs
+++ b/crates/streamling-core/src/plugin/table_provider.rs
@@ -467,14 +467,13 @@ impl DataSink for PluginSink {
                         let sink_id =
                             metric_metadata_id_to_reference_name(&self.metric_metadata_id)
                                 .unwrap_or_else(|| self.metric_metadata_id.clone());
-                        send(
+                        let _ = send(
                             CHECKPOINT_COORDINATOR_CHANNEL,
                             CheckpointMessage::Ack {
                                 epoch: CheckpointEpoch(epoch.0),
                                 sink_id,
                             },
-                        )
-                        .unwrap();
+                        );
                     }
                     _ => {
                         warn!("Received unexpected message from plugin channel");

--- a/crates/streamling-e2e/tests/hybrid_source.rs
+++ b/crates/streamling-e2e/tests/hybrid_source.rs
@@ -571,6 +571,176 @@ sinks:
 }
 
 // ============================================================================
+// Scenario 3b: Job mode terminal checkpoint persists state at bounded completion
+// ============================================================================
+
+/// Regression test for terminal-checkpoint finalization on a job-mode hybrid
+/// source. Contract: when the bounded phase completes, the hybrid source mints
+/// and emits a single terminal checkpoint marker on a synthetic final batch,
+/// and the pipeline waits for that epoch to finalize before tearing down.
+/// Without it, the last batches of bounded data can land in the sink without
+/// any finalized checkpoint covering their state.
+///
+/// To isolate the terminal path from timer-driven checkpoints, this test sets
+/// `CHECKPOINT_INTERVAL_SEC=3600` — no timer can fire during a three-record
+/// scan. The only checkpoint that can finalize is the terminal one, so the
+/// presence of `clickhouse_source:` split keys in the state table after a
+/// clean exit is a direct post-condition on terminal-finalize having fired.
+#[tokio::test]
+async fn test_hybrid_source_job_mode_persists_terminal_checkpoint() {
+    init_tracing();
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE hybrid_terminal_ckpt_test (
+                block Int64,
+                id String,
+                data String,
+                timestamp Int64,
+                is_deleted UInt8
+            ) ENGINE = MergeTree()
+            ORDER BY (block, id)",
+        )
+        .await
+        .expect("Failed to create ClickHouse table");
+
+    clickhouse
+        .execute(
+            "INSERT INTO hybrid_terminal_ckpt_test VALUES
+            (1, 'terminal_a', 'data_a', 100, 0),
+            (2, 'terminal_b', 'data_b', 200, 0),
+            (3, 'terminal_c', 'data_c', 300, 0)",
+        )
+        .await
+        .expect("Failed to insert ClickHouse data");
+
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE kafka_offsets_terminal_ckpt (
+                topic String,
+                partition Int32,
+                offset UInt32
+            ) ENGINE = MergeTree()
+            ORDER BY (topic, partition)",
+        )
+        .await
+        .expect("Failed to create offset table");
+
+    let state_table = format!("hybrid_terminal_ckpt_{}", ctx.test_id.replace('-', "_"));
+    let application_id = format!("hybrid_terminal_ckpt_{}", ctx.test_id);
+
+    let pipeline = format!(
+        r#"
+sources:
+  hybrid_source:
+    type: hybrid
+    bounded_sources:
+      - source_type: clickhouse
+        table_name: hybrid_terminal_ckpt_test
+        columns: block,id,data,timestamp
+    unbounded_source:
+      source_type: kafka
+      topic: {kafka_topic}
+      start_at: earliest
+    offset_table:
+      topic_name: {kafka_topic}
+      table_name: kafka_offsets_terminal_ckpt
+    primary_key: id
+
+transforms: {{}}
+
+sinks:
+  pg_sink:
+    type: postgres
+    from: hybrid_source
+    table: hybrid_terminal_ckpt_results
+    schema: public
+    primary_key: id
+    on_conflict: update
+    batch_size: 1
+"#,
+        kafka_topic = ctx.kafka_topic,
+    );
+
+    // No `record_limit`: termination is driven by bounded-phase completion +
+    // job mode. The 1-hour checkpoint interval guarantees no timer-driven
+    // checkpoint can fire during the sub-second bounded scan.
+    let opts = PipelineOpts::new()
+        .timeout(std::time::Duration::from_secs(120))
+        .env("STREAMLING__JOB_MODE", "true")
+        .env("STREAMLING__RECORD_BATCH_SIZE", "1")
+        .env("STREAMLING__CHECKPOINT_INTERVAL_SEC", "3600")
+        .env("STREAMLING__APPLICATION_ID", &application_id)
+        .env("STREAMLING__STATE_BACKEND__BACKEND_TYPE", "Postgres")
+        .env(
+            "STREAMLING__STATE_BACKEND__POSTGRES__HOST",
+            &ctx.postgres.host,
+        )
+        .env(
+            "STREAMLING__STATE_BACKEND__POSTGRES__PORT",
+            ctx.postgres.port.to_string(),
+        )
+        .env("STREAMLING__STATE_BACKEND__POSTGRES__USER", "postgres")
+        .env("STREAMLING__STATE_BACKEND__POSTGRES__PASSWORD", "postgres")
+        .env("STREAMLING__STATE_BACKEND__POSTGRES__DB", &ctx.pg_database)
+        .env("STREAMLING__STATE_BACKEND__POSTGRES__SSLMODE", "disable")
+        .env(
+            "STREAMLING__STATE_BACKEND__POSTGRES__STATE_TABLE_NAME",
+            &state_table,
+        );
+
+    let status = ctx
+        .run_pipeline_with_opts(&pipeline, opts)
+        .await
+        .expect("Pipeline execution failed");
+    assert!(
+        status.success(),
+        "Job-mode pipeline should terminate cleanly after the terminal checkpoint finalizes"
+    );
+
+    // All bounded records should land in the sink. Without the terminal
+    // checkpoint round-trip the synthetic final batch can race shutdown and
+    // the tail records drop.
+    let count = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.hybrid_terminal_ckpt_results")
+        .await
+        .expect("Failed to query sink count");
+    assert_eq!(count, 3, "Sink should contain all 3 bounded records");
+
+    // Direct post-condition on terminal-finalize: with the timer disabled, the
+    // only way clickhouse split state reaches the state backend is through the
+    // terminal checkpoint's finalizer flush.
+    let state_keys: Vec<(String,)> = ctx
+        .postgres
+        .query(&format!(
+            "SELECT \"key\" FROM streamling.\"{}\" ORDER BY \"key\"",
+            state_table
+        ))
+        .await
+        .expect("Failed to query state keys");
+    let has_clickhouse_split = state_keys
+        .iter()
+        .any(|row| row.0.starts_with("clickhouse_source:"));
+    assert!(
+        has_clickhouse_split,
+        "Terminal checkpoint should have persisted clickhouse split state; \
+         observed keys: {:?}",
+        state_keys.iter().map(|r| &r.0).collect::<Vec<_>>()
+    );
+}
+
+// ============================================================================
 // Scenario 4: Hybrid resume from high savepoint/checkpoint
 // ============================================================================
 

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -496,6 +496,10 @@ impl Streamling {
         let mut plugins: BTreeMap<String, InitializedPlugin> = BTreeMap::new();
 
         let mut checkpoint_coordinator = CheckpointCoordinator::new();
+        // Control handle shared with bounded sources (to begin the terminal
+        // checkpoint) and sink futures (to signal completion). Valid before
+        // the coordinator is started since it shares the coordinator's state.
+        let checkpoint_control = checkpoint_coordinator.control();
         let mut checkpoint_sink_names: Vec<String> = Vec::new();
 
         let mut pipeline_plans: HashMap<String, LogicalPlan> = HashMap::new();
@@ -713,20 +717,26 @@ impl Streamling {
                     let offset_table = &hybrid.offset_table;
                     let primary_key_opt = &hybrid.primary_key;
 
-                    let hybrid_source_provider = Arc::new(HybridTableProvider::new_from_topology(
-                        reference_name.clone(),
-                        bounded_sources.clone(),
-                        unbounded_source.clone(),
-                        offset_table.clone(),
-                        &app_config,
-                        &state_backend_factory,
-                        session_manager.clone(),
-                        // Per-phase event-time config flows directly to the
-                        // inner WrappingSourceTableProviders (one per bounded
-                        // phase + one for unbounded), each carrying its own
-                        // `metric_key_hybrid_src_*` suffix. R9 falls out.
-                        hybrid.telemetry.as_ref(),
-                    )?);
+                    let hybrid_source_provider = Arc::new(
+                        HybridTableProvider::new_from_topology(
+                            reference_name.clone(),
+                            bounded_sources.clone(),
+                            unbounded_source.clone(),
+                            offset_table.clone(),
+                            &app_config,
+                            &state_backend_factory,
+                            session_manager.clone(),
+                            // Per-phase event-time config flows directly to the
+                            // inner WrappingSourceTableProviders (one per bounded
+                            // phase + one for unbounded), each carrying its own
+                            // `metric_key_hybrid_src_*` suffix. R9 falls out.
+                            hybrid.telemetry.as_ref(),
+                        )?
+                        // In job mode this source emits the terminal checkpoint
+                        // when its bounded phases complete; give it the control
+                        // handle so shutdown can gate on that epoch finalizing.
+                        .with_checkpoint_control(checkpoint_control.clone()),
+                    );
 
                     let provider_with_telemetry = Arc::new(WrappingSourceTableProvider::new(
                         hybrid_source_provider.clone(),
@@ -1887,6 +1897,9 @@ impl Streamling {
                     .map(|e| e.name.as_str())
                     .collect::<Vec<&str>>()
                     .join(", ");
+                // Captured for the SinkComplete signal below: one entry per
+                // sink driven by this future (a fan-out future drives several).
+                let sink_names: Vec<String> = sinks.iter().map(|e| e.name.clone()).collect();
                 let sink_plan = if sinks.len() > 1 {
                     // Fan-out: each sink gets its own RebatchExec injected by
                     // the MultiSinkExtensionPlanner, so the raw source_plan
@@ -1925,6 +1938,7 @@ impl Streamling {
 
                 if !dry_run {
                     let session_manager = session_manager.clone();
+                    let checkpoint_control = checkpoint_control.clone();
                     let sink_future = async move {
                         let result = session_manager.new_df(sink_plan).collect().await;
                         if let Err(err) = &result {
@@ -1932,6 +1946,15 @@ impl Streamling {
                                 "Sink future [{}] completed with error: {}",
                                 future_name, err
                             );
+                        }
+                        // The sink has drained its input and will not ack any
+                        // further checkpoint epochs. Tell the coordinator so it
+                        // drops these sinks from the expected-ack set and can
+                        // finalize in-flight epochs the remaining live sinks
+                        // have already acked, instead of blocking on a sink
+                        // that is gone (the multi-source completion case).
+                        for sink_name in &sink_names {
+                            checkpoint_control.sink_completed(sink_name);
                         }
                         result
                     };
@@ -2007,6 +2030,25 @@ impl Streamling {
                 .map(|_| ())
                 .map_err(Into::into)
         };
+
+        // In job mode a completing bounded source emits a terminal checkpoint as
+        // its last act. Before tearing anything down, wait for that epoch to
+        // finalize so the tail is durably checkpointed and its Finalizer reaches
+        // components that commit on it (still alive at this point). Bounded by a
+        // timeout so a sink that died without acking cannot hang shutdown, and
+        // skipped on error (no terminal checkpoint will arrive). A no-op when no
+        // terminal checkpoint was begun (the streaming case).
+        if !dry_run
+            && app_result.is_ok()
+            && timeout(
+                Duration::from_secs(30),
+                checkpoint_control.await_terminal_finalized(),
+            )
+            .await
+            .is_err()
+        {
+            warn!("Terminal checkpoint did not finalize within 30s; proceeding with shutdown");
+        }
 
         // Issue SourceComplete message to plugins. This is needed to fully clean up checkpoint channels when plugins
         // terminate.


### PR DESCRIPTION
Addresses the shutdown investigation: https://linear.app/goldsky/review/docs-shutdown-investigation-why-pipelines-hang-on-sigterm-and-lose-df5c9ddb6c34

## Problem

In job mode a bounded source (the hybrid) could complete without a finalized checkpoint covering its tail, and a multi-source pipeline could stall finalization when one branch finished while others kept running. The terminal finalizer also never reached inline consumers (e.g. the Postgres sink) at end-of-job, because there was no batch to carry it back once the source stopped producing.

## Changes

**Terminal-checkpoint barrier** (`dc07d718`)
- Coordinator: mutable expected-ack set plus a `CheckpointControl` handle. `sink_completed` drops a drained sink so it stops blocking finalization (fixes the multi-source stall). `begin_terminal_checkpoint` / `await_terminal_finalized` mint and gate on a single terminal epoch, and the timer producer is gated so it cannot clear it. No new `CheckpointMessage` variant: lifecycle signals are handle methods, the wire protocol stays marker/ack/finalizer.
- Hybrid source: on job-mode termination, emit the terminal marker inline on a synthetic batch after the last bounded data.
- Pipeline: pass the handle to the hybrid and each sink future; wait for the terminal epoch to finalize before stopping the coordinator and terminating plugins.
- README: documents the terminal-checkpoint contract for bounded sources.

**Inline finalizer round-trip and Postgres EOF cleanup** (`37d719df`)
- Hybrid source: after the terminal marker, await the finalize and carry the `Finalizer` back on a second synthetic batch, so inline consumers run their finalize work before their stream ends. Bounded by a timeout so a sink that never acks cannot hang the source.
- Postgres sink: drain the landing table's last finalized epoch on EOF, which the per-finalizer truncation (deletes `<= N-1`) otherwise leaves behind.
- Coordinator: unsubscribe from the checkpoint channel on `stop()` so it no longer leaks a dead sender into the global channel map; serialize the channel-driving coordinator tests.

## Verification

- `just lint` clean.
- Coordinator, hybrid, and Postgres unit tests pass (terminal round-trip RED to GREEN, sink deregistration, terminal-finalize gating, EOF truncation decision).
- Not run here: full connectors and e2e suites (need ClickHouse/Kafka/Postgres).
