### PR TITLE
fix(ai-review): use supported model id

### DIFF
--- a/scripts/ai-review/review_config.json
+++ b/scripts/ai-review/review_config.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-sonnet-4-20250514",
+  "model": "claude-sonnet-4-6",
   "max_turns": 15,
   "weights": {
     "change_density": 0.20,


### PR DESCRIPTION
## Summary
- `claude-sonnet-4-20250514` retired on 2026-06-15 (two days ago). The AI review workflow has been silently failing since: the Claude Code action initializes, the SDK exits immediately with `is_error: true`, `total_cost_usd: 0`, `num_turns: 1` after ~317ms, and no comment is posted on PRs.
- Switch the model in `scripts/ai-review/review_config.json` to `claude-sonnet-4-6`, the documented migration target. The workflow reads the model via the `Read review config` step, so no workflow changes are needed.

Failed run that surfaced this: https://github.com/goldsky-io/streamling/actions/runs/27662382056/job/81809218587?pr=18

## Test plan
- [ ] Merge and observe the next PR's AI review job posts a sticky comment.