### PR TITLE
fix: u256/i256 correctness in CASE expressions and ClickHouse hybrid

### DIFF
--- a/crates/streamling-common/src/functions/u256_ops.rs
+++ b/crates/streamling-common/src/functions/u256_ops.rs
@@ -42,6 +42,7 @@ impl ToU256Func {
                     TypeSignature::Exact(vec![DataType::UInt16]),
                     TypeSignature::Exact(vec![DataType::Int8]),
                     TypeSignature::Exact(vec![DataType::UInt8]),
+                    TypeSignature::Exact(vec![DataType::FixedSizeBinary(32)]),
                 ],
                 Volatility::Immutable,
             ),
@@ -201,6 +202,10 @@ impl ScalarUDFImpl for ToU256Func {
                     let bytes = u256::u256_to_bytes(&value);
                     builder.push(Some(bytes.to_vec()));
                 }
+            }
+            DataType::FixedSizeBinary(32) => {
+                // Passthrough: input is already U256
+                return Ok(ColumnarValue::Array(array));
             }
             _ => {
                 streamling_user_bail!(
@@ -482,6 +487,46 @@ mod tests {
         } else {
             panic!("Expected array result");
         }
+    }
+
+    #[test]
+    fn test_to_u256_fixed_size_binary_passthrough() {
+        // to_u256 over already-encoded u256 bytes (FixedSizeBinary(32)) must pass
+        // the value through unchanged. The preprocessor relies on this to wrap
+        // CASE results so the u256 extension metadata is re-declared on the output
+        // field (mirrors to_i256, which already supports this).
+        let func = ToU256Func::new();
+        let bytes = u256::u256_to_bytes(&U256::from(12345u64));
+        let input = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+            vec![Some(bytes.to_vec()), None].into_iter(),
+            32,
+        )
+        .unwrap();
+
+        let args = ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(input))],
+            arg_fields: vec![Arc::new(arrow_schema::Field::new(
+                "value",
+                U256Type::new(),
+                true,
+            ))],
+            number_rows: 2,
+            return_field: Arc::new(arrow_schema::Field::new("result", U256Type::new(), true)),
+        };
+
+        let result = func.invoke_with_args(args).unwrap();
+        let ColumnarValue::Array(arr) = result else {
+            panic!("expected array result");
+        };
+        let binary = arr
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .expect("result should be FixedSizeBinary");
+        assert_eq!(binary.len(), 2);
+        let mut recovered = [0u8; 32];
+        recovered.copy_from_slice(binary.value(0));
+        assert_eq!(u256::bytes_to_u256(&recovered), U256::from(12345u64));
+        assert!(binary.is_null(1), "null should pass through");
     }
 
     #[test]

--- a/crates/streamling-common/src/functions/u256_ops.rs
+++ b/crates/streamling-common/src/functions/u256_ops.rs
@@ -530,6 +530,72 @@ mod tests {
     }
 
     #[test]
+    fn test_u256_to_string_decodes_bytes_as_big_endian() {
+        // u256_to_string is the only public path from the FixedSizeBinary(32)
+        // buffer to a human-readable decimal — if it ever switched to little-
+        // endian decoding (or a producer ever wrote LE bytes), value 1 would
+        // surface as 2^248 and most multiplications would overflow.
+        let bytes = u256::u256_to_bytes(&U256::from(1u64));
+        let input = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+            vec![Some(bytes.to_vec())].into_iter(),
+            32,
+        )
+        .unwrap();
+
+        let func = U256ToStringFunc::new();
+        let args = ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(input))],
+            arg_fields: vec![Arc::new(arrow_schema::Field::new(
+                "value",
+                U256Type::new(),
+                true,
+            ))],
+            number_rows: 1,
+            return_field: Arc::new(arrow_schema::Field::new("result", DataType::Utf8, true)),
+        };
+        let ColumnarValue::Array(arr) = func.invoke_with_args(args).unwrap() else {
+            panic!("expected array result");
+        };
+        let s = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(s.value(0), "1");
+    }
+
+    #[test]
+    fn test_u256_to_string_misread_le_bytes_yields_2_pow_248() {
+        // Anti-regression for the ClickHouse hybrid endianness gap: ClickHouse
+        // emits UInt256 columns as FixedSizeBinary(32) in little-endian, and
+        // streamling stores big-endian. If the read-side normalizer
+        // (normalize_batch_from_clickhouse) ever stops reversing those bytes,
+        // u256_to_string reads 1 as 2^248 and downstream multiplication
+        // overflows. Pin the symptom so a regression is loud.
+        let mut le_one = [0u8; 32];
+        le_one[0] = 1;
+        let input = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+            vec![Some(le_one.to_vec())].into_iter(),
+            32,
+        )
+        .unwrap();
+
+        let func = U256ToStringFunc::new();
+        let args = ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(input))],
+            arg_fields: vec![Arc::new(arrow_schema::Field::new(
+                "value",
+                U256Type::new(),
+                true,
+            ))],
+            number_rows: 1,
+            return_field: Arc::new(arrow_schema::Field::new("result", DataType::Utf8, true)),
+        };
+        let ColumnarValue::Array(arr) = func.invoke_with_args(args).unwrap() else {
+            panic!("expected array result");
+        };
+        let s = arr.as_any().downcast_ref::<StringArray>().unwrap();
+        let expected = u256::u256_to_string(&(U256::from(1u64) << 248));
+        assert_eq!(s.value(0), expected);
+    }
+
+    #[test]
     fn test_u256_add() {
         let func = U256AddFunc::new();
 

--- a/crates/streamling-common/src/types/i256.rs
+++ b/crates/streamling-common/src/types/i256.rs
@@ -292,9 +292,13 @@ pub fn i256_to_string(value: &I256) -> String {
 pub fn add(a: &[u8; 32], b: &[u8; 32]) -> crate::error::Result<[u8; 32]> {
     let a_val = bytes_to_i256(a);
     let b_val = bytes_to_i256(b);
-    let result = a_val
-        .checked_add(&b_val)
-        .ok_or_else(|| streamling_err!("I256 addition overflow"))?;
+    let result = a_val.checked_add(&b_val).ok_or_else(|| {
+        streamling_err!(
+            "I256 addition overflow: {} + {}",
+            i256_to_string(&a_val),
+            i256_to_string(&b_val)
+        )
+    })?;
     Ok(i256_to_bytes(&result))
 }
 
@@ -302,9 +306,13 @@ pub fn add(a: &[u8; 32], b: &[u8; 32]) -> crate::error::Result<[u8; 32]> {
 pub fn sub(a: &[u8; 32], b: &[u8; 32]) -> crate::error::Result<[u8; 32]> {
     let a_val = bytes_to_i256(a);
     let b_val = bytes_to_i256(b);
-    let result = a_val
-        .checked_sub(&b_val)
-        .ok_or_else(|| streamling_err!("I256 subtraction overflow"))?;
+    let result = a_val.checked_sub(&b_val).ok_or_else(|| {
+        streamling_err!(
+            "I256 subtraction overflow: {} - {}",
+            i256_to_string(&a_val),
+            i256_to_string(&b_val)
+        )
+    })?;
     Ok(i256_to_bytes(&result))
 }
 
@@ -312,9 +320,13 @@ pub fn sub(a: &[u8; 32], b: &[u8; 32]) -> crate::error::Result<[u8; 32]> {
 pub fn mul(a: &[u8; 32], b: &[u8; 32]) -> crate::error::Result<[u8; 32]> {
     let a_val = bytes_to_i256(a);
     let b_val = bytes_to_i256(b);
-    let result = a_val
-        .checked_mul(&b_val)
-        .ok_or_else(|| streamling_err!("I256 multiplication overflow"))?;
+    let result = a_val.checked_mul(&b_val).ok_or_else(|| {
+        streamling_err!(
+            "I256 multiplication overflow: {} * {}",
+            i256_to_string(&a_val),
+            i256_to_string(&b_val)
+        )
+    })?;
     Ok(i256_to_bytes(&result))
 }
 
@@ -389,6 +401,21 @@ mod tests {
         let result = add(&a, &b).unwrap();
         let result_val = bytes_to_i256(&result);
         assert_eq!(result_val, I256::from_i64(50));
+    }
+
+    #[test]
+    fn test_mul_overflow_error_includes_operands() {
+        // 2^200 * 2^200 = 2^400, over I256::MAX. The error must name the
+        // operands so an overflowing row can be identified without guessing.
+        let big_val = I256::from_u256(U256::from(1u64) << 200);
+        let big = i256_to_bytes(&big_val);
+        let err = mul(&big, &big).unwrap_err();
+        let msg = format!("{err}");
+        let operand = i256_to_string(&big_val);
+        assert!(
+            msg.contains(&operand),
+            "overflow error should include the operand value {operand}, got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/streamling-common/src/types/u256.rs
+++ b/crates/streamling-common/src/types/u256.rs
@@ -96,7 +96,7 @@ pub fn add(a: &[u8; 32], b: &[u8; 32]) -> crate::error::Result<[u8; 32]> {
     let b_val = bytes_to_u256(b);
     let result = a_val
         .checked_add(b_val)
-        .ok_or_else(|| streamling_err!("U256 addition overflow"))?;
+        .ok_or_else(|| streamling_err!("U256 addition overflow: {} + {}", a_val, b_val))?;
     Ok(u256_to_bytes(&result))
 }
 
@@ -106,7 +106,7 @@ pub fn sub(a: &[u8; 32], b: &[u8; 32]) -> crate::error::Result<[u8; 32]> {
     let b_val = bytes_to_u256(b);
     let result = a_val
         .checked_sub(b_val)
-        .ok_or_else(|| streamling_err!("U256 subtraction underflow"))?;
+        .ok_or_else(|| streamling_err!("U256 subtraction underflow: {} - {}", a_val, b_val))?;
     Ok(u256_to_bytes(&result))
 }
 
@@ -116,7 +116,7 @@ pub fn mul(a: &[u8; 32], b: &[u8; 32]) -> crate::error::Result<[u8; 32]> {
     let b_val = bytes_to_u256(b);
     let result = a_val
         .checked_mul(b_val)
-        .ok_or_else(|| streamling_err!("U256 multiplication overflow"))?;
+        .ok_or_else(|| streamling_err!("U256 multiplication overflow: {} * {}", a_val, b_val))?;
     Ok(u256_to_bytes(&result))
 }
 
@@ -180,6 +180,21 @@ mod tests {
         let max = u256_to_bytes(&U256::max_value());
         let one = u256_to_bytes(&U256::from(1u64));
         assert!(add(&max, &one).is_err());
+    }
+
+    #[test]
+    fn test_mul_overflow_error_includes_operands() {
+        // 2^200 * 2^200 = 2^400, well over U256::MAX. The error must name the
+        // operands so an overflowing row can be identified without guessing.
+        let big_val = U256::from(1u64) << 200;
+        let big = u256_to_bytes(&big_val);
+        let err = mul(&big, &big).unwrap_err();
+        let msg = format!("{err}");
+        let operand = u256_to_string(&big_val);
+        assert!(
+            msg.contains(&operand),
+            "overflow error should include the operand value {operand}, got: {msg}"
+        );
     }
 
     #[test]

--- a/crates/streamling-common/src/types/u256.rs
+++ b/crates/streamling-common/src/types/u256.rs
@@ -183,6 +183,75 @@ mod tests {
     }
 
     #[test]
+    fn test_byte_order_is_big_endian() {
+        // U256 storage is big-endian: the least-significant byte lives at index 31,
+        // not index 0. Pinning this prevents a silent corruption where a producer
+        // writes Arrow's native little-endian i256/Decimal256 bytes into the
+        // FixedSizeBinary(32) buffer, since every read here assumes big-endian.
+        let bytes = u256_to_bytes(&U256::from(1u64));
+        let mut expected = [0u8; 32];
+        expected[31] = 1;
+        assert_eq!(bytes, expected);
+
+        let bytes = u256_to_bytes(&U256::from(0x0102_0304_0506_0708u64));
+        assert_eq!(
+            &bytes[24..32],
+            &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
+        );
+        assert_eq!(&bytes[..24], &[0u8; 24]);
+    }
+
+    #[test]
+    fn test_misendian_bytes_blow_up_value() {
+        // ClickHouse stores UInt256 little-endian and emits its Arrow output in
+        // that layout, while streamling stores big-endian. Without a reversal at
+        // the read boundary (see normalize_batch_from_clickhouse), a logical 1
+        // arrives as [0x01, 0;31], which bytes_to_u256 reads as 2^248. Squaring
+        // that overflows U256, matching the user-visible "u256 multiplication
+        // overflow" failure mode this test was added for.
+        let mut le_one = [0u8; 32];
+        le_one[0] = 1;
+        let mis_read = bytes_to_u256(&le_one);
+        assert_eq!(mis_read, U256::from(1u64) << 248);
+        assert_ne!(mis_read, U256::from(1u64));
+
+        // Squaring the mis-read value overflows U256.
+        let mis = u256_to_bytes(&mis_read);
+        assert!(mul(&mis, &mis).is_err());
+    }
+
+    #[test]
+    fn test_wei_squared_does_not_overflow() {
+        // 1 ETH = 1e18 wei; (1e18)^2 = 1e36, well inside U256::MAX (~1.16e77).
+        // Correctly stored wei-scale values must not raise false overflow.
+        let one_eth = string_to_u256("1000000000000000000").unwrap();
+        let bytes = u256_to_bytes(&one_eth);
+        let product = mul(&bytes, &bytes).expect("1e18 * 1e18 fits in U256");
+        assert_eq!(
+            u256_to_string(&bytes_to_u256(&product)),
+            "1000000000000000000000000000000000000"
+        );
+    }
+
+    #[test]
+    fn test_mul_at_max_boundary() {
+        let max = u256_to_bytes(&U256::max_value());
+        let zero = u256_to_bytes(&U256::zero());
+        let one = u256_to_bytes(&U256::from(1u64));
+        let two = u256_to_bytes(&U256::from(2u64));
+        let half_max = u256_to_bytes(&(U256::max_value() / U256::from(2u64)));
+
+        assert_eq!(bytes_to_u256(&mul(&max, &zero).unwrap()), U256::zero());
+        assert_eq!(bytes_to_u256(&mul(&max, &one).unwrap()), U256::max_value());
+        // floor(MAX/2) * 2 = MAX - 1 (MAX = 2^256 - 1 is odd).
+        assert_eq!(
+            bytes_to_u256(&mul(&half_max, &two).unwrap()),
+            U256::max_value() - U256::from(1u64)
+        );
+        assert!(mul(&max, &two).is_err());
+    }
+
+    #[test]
     fn test_mul_overflow_error_includes_operands() {
         // 2^200 * 2^200 = 2^400, well over U256::MAX. The error must name the
         // operands so an overflowing row can be identified without guessing.

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -1,7 +1,7 @@
-use arrow_schema::{ArrowError, SchemaRef};
+use arrow_schema::{ArrowError, FieldRef, Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::arrow;
-use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::array::{ArrayRef, RecordBatch};
 use datafusion::catalog::{Session, TableProvider};
 use datafusion::datasource::TableType;
 use datafusion::error::{DataFusionError, Result};
@@ -1798,8 +1798,13 @@ impl ClickHouseClient {
     /// raw passthrough corrupts every value (a logical 1 reads as 2^248, which
     /// overflows U256 on multiplication). For each column whose target field is
     /// u256/i256 but whose incoming field lacks that metadata, reverse the bytes
-    /// and adopt the target field. Other columns pass through unchanged; the
-    /// resulting batch carries `target_schema`.
+    /// and adopt the target field on that column only.
+    ///
+    /// Crucially, untouched columns keep their original Field rather than
+    /// being rewritten against `target_schema`. The hybrid layer deliberately
+    /// tolerates List inner-field-name differences (e.g. ClickHouse's `item`
+    /// vs Kafka/Avro's `element`); forcing target_schema onto every column
+    /// would reject those List columns at `RecordBatch::try_new`.
     pub(crate) fn normalize_batch_from_clickhouse(
         batch: &RecordBatch,
         target_schema: &SchemaRef,
@@ -1811,50 +1816,63 @@ impl ClickHouseClient {
         }
 
         let original_schema = batch.schema();
+        let mut new_columns: Vec<ArrayRef> = Vec::with_capacity(batch.num_columns());
+        let mut new_fields: Vec<FieldRef> = Vec::with_capacity(batch.num_columns());
+        let mut changed = false;
 
-        let normalized_columns: Result<Vec<_>, DataFusionError> = batch
+        for ((column, original_field), target_field) in batch
             .columns()
             .iter()
             .zip(original_schema.fields().iter())
             .zip(target_schema.fields().iter())
-            .map(|((column, original_field), target_field)| {
-                let needs_reverse = matches!(
-                    (original_field.data_type(), target_field.data_type()),
-                    (DataType::FixedSizeBinary(32), DataType::FixedSizeBinary(32))
-                ) && (U256Type::is_u256_metadata(target_field.metadata())
-                    || I256Type::is_i256_metadata(target_field.metadata()))
-                    && !U256Type::is_u256_metadata(original_field.metadata())
-                    && !I256Type::is_i256_metadata(original_field.metadata());
+        {
+            let needs_reverse = matches!(
+                (original_field.data_type(), target_field.data_type()),
+                (DataType::FixedSizeBinary(32), DataType::FixedSizeBinary(32))
+            ) && (U256Type::is_u256_metadata(target_field.metadata())
+                || I256Type::is_i256_metadata(target_field.metadata()))
+                && !U256Type::is_u256_metadata(original_field.metadata())
+                && !I256Type::is_i256_metadata(original_field.metadata());
 
-                if !needs_reverse {
-                    return Ok(column.clone());
-                }
+            if !needs_reverse {
+                new_columns.push(column.clone());
+                new_fields.push(original_field.clone());
+                continue;
+            }
 
-                let func = ReverseBytes32Func::new();
-                let args = ScalarFunctionArgs {
-                    args: vec![ColumnarValue::Array(column.clone())],
-                    arg_fields: vec![original_field.clone()],
-                    number_rows: batch.num_rows(),
-                    return_field: ScalarUDFImpl::return_field_from_args(
-                        &func,
-                        ReturnFieldArgs {
-                            arg_fields: std::slice::from_ref(original_field),
-                            scalar_arguments: &[None],
-                        },
-                    )?,
-                };
-                let result = ScalarUDFImpl::invoke_with_args(&func, args)?;
-                match result {
-                    ColumnarValue::Array(arr) => Ok(arr),
-                    ColumnarValue::Scalar(s) => Ok(s.to_array()?),
-                }
-            })
-            .collect();
+            let func = ReverseBytes32Func::new();
+            let args = ScalarFunctionArgs {
+                args: vec![ColumnarValue::Array(column.clone())],
+                arg_fields: vec![original_field.clone()],
+                number_rows: batch.num_rows(),
+                return_field: ScalarUDFImpl::return_field_from_args(
+                    &func,
+                    ReturnFieldArgs {
+                        arg_fields: std::slice::from_ref(original_field),
+                        scalar_arguments: &[None],
+                    },
+                )?,
+            };
+            let result = ScalarUDFImpl::invoke_with_args(&func, args)?;
+            let arr = match result {
+                ColumnarValue::Array(arr) => arr,
+                ColumnarValue::Scalar(s) => s.to_array()?,
+            };
+            new_columns.push(arr);
+            new_fields.push(target_field.clone());
+            changed = true;
+        }
 
-        Ok(
-            RecordBatch::try_new(Arc::clone(target_schema), normalized_columns?)
-                .streamling_context("failed to create normalized batch from clickhouse")?,
-        )
+        if !changed {
+            return Ok(batch.clone());
+        }
+
+        let new_schema = Arc::new(Schema::new_with_metadata(
+            new_fields,
+            original_schema.metadata().clone(),
+        ));
+        Ok(RecordBatch::try_new(new_schema, new_columns)
+            .streamling_context("failed to create normalized batch from clickhouse")?)
     }
 
     /// Send normalized Arrow batches to ClickHouse
@@ -2684,6 +2702,110 @@ mod tests {
             .unwrap();
         assert_eq!(out.value(0), 1);
         assert_eq!(out.value(2), 3);
+    }
+
+    #[test]
+    fn test_normalize_batch_from_clickhouse_preserves_list_field_names() {
+        // Regression for a prod failure: the hybrid layer's compatibility check
+        // deliberately tolerates differing List inner-field names ("item" from
+        // ClickHouse vs "element" from Kafka/Avro). An earlier version of this
+        // normalizer rebuilt every column against target_schema verbatim, which
+        // forced an exact List-inner-field match and blew up with
+        //   "expected List(Field name: element ...) but found List(Field name: item ...)".
+        // The normalizer must only touch fields it actually transforms (u256/i256
+        // byte reversal). Untouched columns keep their original Field.
+        use arrow::array::{Array, FixedSizeBinaryArray, ListBuilder, StringBuilder};
+
+        let incoming_list_field = Arc::new(Field::new("item", DataType::Utf8, false));
+        let target_list_field = Arc::new(Field::new("element", DataType::Utf8, false));
+
+        let incoming_schema = Arc::new(Schema::new(vec![Field::new(
+            "tags",
+            DataType::List(incoming_list_field.clone()),
+            false,
+        )]));
+        let target_schema = Arc::new(Schema::new(vec![Field::new(
+            "tags",
+            DataType::List(target_list_field.clone()),
+            false,
+        )]));
+
+        let mut builder = ListBuilder::new(StringBuilder::new()).with_field(incoming_list_field);
+        builder.values().append_value("a");
+        builder.values().append_value("b");
+        builder.append(true);
+        let list_arr = builder.finish();
+
+        let batch = RecordBatch::try_new(incoming_schema, vec![Arc::new(list_arr)]).unwrap();
+
+        let normalized =
+            ClickHouseClient::normalize_batch_from_clickhouse(&batch, &target_schema).unwrap();
+        assert_eq!(normalized.num_rows(), 1);
+        assert_eq!(normalized.num_columns(), 1);
+
+        // Sanity: u256 metadata transform still fires even when other columns
+        // have mismatched List inner names. Add a u256 column to the same batch
+        // to prove both paths coexist.
+        let incoming_with_u256_schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "tags",
+                DataType::List(Arc::new(Field::new("item", DataType::Utf8, false))),
+                false,
+            ),
+            Field::new("balance", DataType::FixedSizeBinary(32), false),
+        ]));
+        let target_with_u256_schema = Arc::new(Schema::new(vec![
+            Field::new(
+                "tags",
+                DataType::List(Arc::new(Field::new("element", DataType::Utf8, false))),
+                false,
+            ),
+            Field::new("balance", DataType::FixedSizeBinary(32), false)
+                .with_metadata(U256Type::metadata()),
+        ]));
+
+        let mut tags_builder = ListBuilder::new(StringBuilder::new())
+            .with_field(Arc::new(Field::new("item", DataType::Utf8, false)));
+        tags_builder.values().append_value("a");
+        tags_builder.append(true);
+        let tags_arr = tags_builder.finish();
+
+        let mut le_one = [0u8; 32];
+        le_one[0] = 1;
+        let balance_arr = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+            vec![Some(le_one.to_vec())].into_iter(),
+            32,
+        )
+        .unwrap();
+
+        let mixed_batch = RecordBatch::try_new(
+            incoming_with_u256_schema,
+            vec![Arc::new(tags_arr), Arc::new(balance_arr)],
+        )
+        .unwrap();
+
+        let normalized = ClickHouseClient::normalize_batch_from_clickhouse(
+            &mixed_batch,
+            &target_with_u256_schema,
+        )
+        .unwrap();
+
+        // u256 column carries the metadata now.
+        assert!(U256Type::is_u256_field(
+            normalized.schema().field_with_name("balance").unwrap()
+        ));
+
+        // u256 bytes were reversed (LE -> BE).
+        use streamling_core::types::u256::{U256, bytes_to_u256};
+        let out = normalized
+            .column_by_name("balance")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap();
+        let mut row = [0u8; 32];
+        row.copy_from_slice(out.value(0));
+        assert_eq!(bytes_to_u256(&row), U256::from(1u64));
     }
 
     #[test]

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -1796,43 +1796,53 @@ impl ClickHouseClient {
     /// `FixedSizeBinary(32)` without the streamling u256/i256 extension metadata.
     /// Streamling's internal convention is big-endian + extension metadata, so a
     /// raw passthrough corrupts every value (a logical 1 reads as 2^248, which
-    /// overflows U256 on multiplication). For each column whose target field is
-    /// u256/i256 but whose incoming field lacks that metadata, reverse the bytes
-    /// and adopt the target field on that column only.
+    /// overflows U256 on multiplication). For each incoming column whose target
+    /// field is u256/i256 but whose own field lacks that metadata, reverse the
+    /// bytes and adopt the target field on that column only.
     ///
-    /// Crucially, untouched columns keep their original Field rather than
-    /// being rewritten against `target_schema`. The hybrid layer deliberately
-    /// tolerates List inner-field-name differences (e.g. ClickHouse's `item`
-    /// vs Kafka/Avro's `element`); forcing target_schema onto every column
-    /// would reject those List columns at `RecordBatch::try_new`.
+    /// Columns are paired against `target_schema` **by name**, not position.
+    /// This keeps the normalizer robust against subset projections and column
+    /// reordering — both invariants the bounded ClickHouse source currently
+    /// upholds but that an upstream change (e.g. real projection pushdown)
+    /// could break silently. Columns without a target match pass through
+    /// unchanged.
+    ///
+    /// Untouched columns keep their original Field rather than being rewritten
+    /// against `target_schema`. The hybrid layer deliberately tolerates List
+    /// inner-field-name differences (e.g. ClickHouse's `item` vs Kafka/Avro's
+    /// `element`); forcing target_schema onto every column would reject those
+    /// List columns at `RecordBatch::try_new`.
     pub(crate) fn normalize_batch_from_clickhouse(
         batch: &RecordBatch,
         target_schema: &SchemaRef,
     ) -> Result<RecordBatch, DataFusionError> {
         use arrow::datatypes::DataType;
+        use std::collections::HashMap;
 
-        if batch.num_columns() != target_schema.fields().len() {
-            return Ok(batch.clone());
-        }
+        let target_by_name: HashMap<&str, &FieldRef> = target_schema
+            .fields()
+            .iter()
+            .map(|f| (f.name().as_str(), f))
+            .collect();
 
         let original_schema = batch.schema();
         let mut new_columns: Vec<ArrayRef> = Vec::with_capacity(batch.num_columns());
         let mut new_fields: Vec<FieldRef> = Vec::with_capacity(batch.num_columns());
         let mut changed = false;
 
-        for ((column, original_field), target_field) in batch
-            .columns()
-            .iter()
-            .zip(original_schema.fields().iter())
-            .zip(target_schema.fields().iter())
+        for (column, original_field) in batch.columns().iter().zip(original_schema.fields().iter())
         {
-            let needs_reverse = matches!(
-                (original_field.data_type(), target_field.data_type()),
-                (DataType::FixedSizeBinary(32), DataType::FixedSizeBinary(32))
-            ) && (U256Type::is_u256_metadata(target_field.metadata())
-                || I256Type::is_i256_metadata(target_field.metadata()))
-                && !U256Type::is_u256_metadata(original_field.metadata())
-                && !I256Type::is_i256_metadata(original_field.metadata());
+            let target_field = target_by_name.get(original_field.name().as_str()).copied();
+
+            let needs_reverse = target_field.is_some_and(|tf| {
+                matches!(
+                    (original_field.data_type(), tf.data_type()),
+                    (DataType::FixedSizeBinary(32), DataType::FixedSizeBinary(32))
+                ) && (U256Type::is_u256_metadata(tf.metadata())
+                    || I256Type::is_i256_metadata(tf.metadata()))
+                    && !U256Type::is_u256_metadata(original_field.metadata())
+                    && !I256Type::is_i256_metadata(original_field.metadata())
+            });
 
             if !needs_reverse {
                 new_columns.push(column.clone());
@@ -1859,7 +1869,8 @@ impl ClickHouseClient {
                 ColumnarValue::Scalar(s) => s.to_array()?,
             };
             new_columns.push(arr);
-            new_fields.push(target_field.clone());
+            // Safe: needs_reverse implied target_field.is_some().
+            new_fields.push(target_field.unwrap().clone());
             changed = true;
         }
 
@@ -2800,6 +2811,113 @@ mod tests {
         let out = normalized
             .column_by_name("balance")
             .unwrap()
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap();
+        let mut row = [0u8; 32];
+        row.copy_from_slice(out.value(0));
+        assert_eq!(bytes_to_u256(&row), U256::from(1u64));
+    }
+
+    #[test]
+    fn test_normalize_batch_from_clickhouse_handles_reordered_columns() {
+        // Defense-in-depth: pairing columns by position would silently reverse
+        // the wrong column when the bounded source emits fields in a different
+        // order than target_schema. Today the ClickHouseSourceExec ignores
+        // pushed-down projection so the orders coincide, but a future change
+        // could break that invariant. Pin name-based pairing.
+        use arrow::array::{FixedSizeBinaryArray, Int64Array};
+        use streamling_core::types::u256::{U256, bytes_to_u256};
+
+        // Incoming order: [id, balance]. Target order: [balance, id].
+        let incoming_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("balance", DataType::FixedSizeBinary(32), false),
+        ]));
+        let target_schema = Arc::new(Schema::new(vec![
+            Field::new("balance", DataType::FixedSizeBinary(32), false)
+                .with_metadata(U256Type::metadata()),
+            Field::new("id", DataType::Int64, false),
+        ]));
+
+        let mut le_one = [0u8; 32];
+        le_one[0] = 1;
+        let balance = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+            vec![Some(le_one.to_vec())].into_iter(),
+            32,
+        )
+        .unwrap();
+        let id = Int64Array::from(vec![42i64]);
+        let batch =
+            RecordBatch::try_new(incoming_schema, vec![Arc::new(id), Arc::new(balance)]).unwrap();
+
+        let normalized =
+            ClickHouseClient::normalize_batch_from_clickhouse(&batch, &target_schema).unwrap();
+
+        // Balance column found by name, reversed, metadata attached.
+        assert!(U256Type::is_u256_field(
+            normalized.schema().field_with_name("balance").unwrap()
+        ));
+        let out = normalized
+            .column_by_name("balance")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap();
+        let mut row = [0u8; 32];
+        row.copy_from_slice(out.value(0));
+        assert_eq!(bytes_to_u256(&row), U256::from(1u64));
+
+        // The id column is untouched, in its original position.
+        let id_out = normalized
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(id_out.value(0), 42);
+    }
+
+    #[test]
+    fn test_normalize_batch_from_clickhouse_handles_subset_projection() {
+        // If the incoming batch carries only a subset of the target schema's
+        // columns (e.g. projection pushdown), the u256 columns that ARE present
+        // must still be reversed and metadata-tagged. Target columns missing
+        // from the batch just aren't in the output — no silent passthrough of
+        // little-endian bytes.
+        use arrow::array::FixedSizeBinaryArray;
+        use streamling_core::types::u256::{U256, bytes_to_u256};
+
+        let incoming_schema = Arc::new(Schema::new(vec![Field::new(
+            "balance",
+            DataType::FixedSizeBinary(32),
+            false,
+        )]));
+        // Target carries an extra `extra_col` field that the batch doesn't
+        // include. Previously the count-mismatch guard would silently bail
+        // here and leave balance unreversed.
+        let target_schema = Arc::new(Schema::new(vec![
+            Field::new("balance", DataType::FixedSizeBinary(32), false)
+                .with_metadata(U256Type::metadata()),
+            Field::new("extra_col", DataType::Utf8, true),
+        ]));
+
+        let mut le_one = [0u8; 32];
+        le_one[0] = 1;
+        let arr = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+            vec![Some(le_one.to_vec())].into_iter(),
+            32,
+        )
+        .unwrap();
+        let batch = RecordBatch::try_new(incoming_schema, vec![Arc::new(arr)]).unwrap();
+
+        let normalized =
+            ClickHouseClient::normalize_batch_from_clickhouse(&batch, &target_schema).unwrap();
+        assert!(U256Type::is_u256_field(
+            normalized.schema().field_with_name("balance").unwrap()
+        ));
+        let out = normalized
+            .column(0)
             .as_any()
             .downcast_ref::<FixedSizeBinaryArray>()
             .unwrap();

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -1790,6 +1790,73 @@ impl ClickHouseClient {
         )
     }
 
+    /// Mirror of `normalize_batch_for_clickhouse` for the read side.
+    ///
+    /// ClickHouse stores `UInt256` / `Int256` as little-endian and emits them as
+    /// `FixedSizeBinary(32)` without the streamling u256/i256 extension metadata.
+    /// Streamling's internal convention is big-endian + extension metadata, so a
+    /// raw passthrough corrupts every value (a logical 1 reads as 2^248, which
+    /// overflows U256 on multiplication). For each column whose target field is
+    /// u256/i256 but whose incoming field lacks that metadata, reverse the bytes
+    /// and adopt the target field. Other columns pass through unchanged; the
+    /// resulting batch carries `target_schema`.
+    pub(crate) fn normalize_batch_from_clickhouse(
+        batch: &RecordBatch,
+        target_schema: &SchemaRef,
+    ) -> Result<RecordBatch, DataFusionError> {
+        use arrow::datatypes::DataType;
+
+        if batch.num_columns() != target_schema.fields().len() {
+            return Ok(batch.clone());
+        }
+
+        let original_schema = batch.schema();
+
+        let normalized_columns: Result<Vec<_>, DataFusionError> = batch
+            .columns()
+            .iter()
+            .zip(original_schema.fields().iter())
+            .zip(target_schema.fields().iter())
+            .map(|((column, original_field), target_field)| {
+                let needs_reverse = matches!(
+                    (original_field.data_type(), target_field.data_type()),
+                    (DataType::FixedSizeBinary(32), DataType::FixedSizeBinary(32))
+                ) && (U256Type::is_u256_metadata(target_field.metadata())
+                    || I256Type::is_i256_metadata(target_field.metadata()))
+                    && !U256Type::is_u256_metadata(original_field.metadata())
+                    && !I256Type::is_i256_metadata(original_field.metadata());
+
+                if !needs_reverse {
+                    return Ok(column.clone());
+                }
+
+                let func = ReverseBytes32Func::new();
+                let args = ScalarFunctionArgs {
+                    args: vec![ColumnarValue::Array(column.clone())],
+                    arg_fields: vec![original_field.clone()],
+                    number_rows: batch.num_rows(),
+                    return_field: ScalarUDFImpl::return_field_from_args(
+                        &func,
+                        ReturnFieldArgs {
+                            arg_fields: std::slice::from_ref(original_field),
+                            scalar_arguments: &[None],
+                        },
+                    )?,
+                };
+                let result = ScalarUDFImpl::invoke_with_args(&func, args)?;
+                match result {
+                    ColumnarValue::Array(arr) => Ok(arr),
+                    ColumnarValue::Scalar(s) => Ok(s.to_array()?),
+                }
+            })
+            .collect();
+
+        Ok(
+            RecordBatch::try_new(Arc::clone(target_schema), normalized_columns?)
+                .streamling_context("failed to create normalized batch from clickhouse")?,
+        )
+    }
+
     /// Send normalized Arrow batches to ClickHouse
     pub async fn send_arrow_batch(
         &self,
@@ -2489,6 +2556,134 @@ mod tests {
             clickhouse_type, "FixedString(32)",
             "FixedSizeBinary(32) without metadata should be converted to FixedString(32)"
         );
+    }
+
+    #[test]
+    fn test_normalize_batch_from_clickhouse_reverses_le_u256() {
+        // ClickHouse emits UInt256 as FixedSizeBinary(32) without u256 metadata
+        // and in little-endian. Without reversal, a logical 1 reads as 2^248 and
+        // downstream u256_mul overflows. This test simulates one such column
+        // arriving from ClickHouse and asserts the bytes come out big-endian
+        // with the u256 extension metadata attached.
+        use arrow::array::{Array, FixedSizeBinaryArray, Int64Array};
+        use streamling_core::types::u256::{U256, bytes_to_u256, u256_to_bytes};
+
+        // ClickHouse-side: FixedSizeBinary(32) without u256 metadata.
+        let incoming_field = Arc::new(Field::new("balance", DataType::FixedSizeBinary(32), false));
+        let id_field = Arc::new(Field::new("id", DataType::Int64, false));
+        let incoming_schema = Arc::new(Schema::new(vec![
+            id_field.as_ref().clone(),
+            incoming_field.as_ref().clone(),
+        ]));
+
+        // LE-encoded payload: logical value 1 stored as [0x01, 0x00, ..., 0x00].
+        let mut le_one = [0u8; 32];
+        le_one[0] = 1;
+        let mut le_two = [0u8; 32];
+        le_two[0] = 2;
+        let incoming_balance = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+            vec![Some(le_one.to_vec()), Some(le_two.to_vec())].into_iter(),
+            32,
+        )
+        .unwrap();
+        let incoming_id = Int64Array::from(vec![1, 2]);
+        let batch = RecordBatch::try_new(
+            incoming_schema,
+            vec![Arc::new(incoming_id), Arc::new(incoming_balance)],
+        )
+        .unwrap();
+
+        // Target schema: streamling u256 with extension metadata.
+        let target_balance = Arc::new(
+            Field::new("balance", DataType::FixedSizeBinary(32), false)
+                .with_metadata(U256Type::metadata()),
+        );
+        let target_schema = Arc::new(Schema::new(vec![
+            id_field.as_ref().clone(),
+            target_balance.as_ref().clone(),
+        ]));
+
+        let normalized =
+            ClickHouseClient::normalize_batch_from_clickhouse(&batch, &target_schema).unwrap();
+
+        // Output schema carries the u256 metadata.
+        assert!(U256Type::is_u256_field(
+            normalized.schema().field_with_name("balance").unwrap()
+        ));
+
+        // Output bytes are big-endian: a logical 1 lives at byte 31.
+        let out = normalized
+            .column_by_name("balance")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap();
+        let mut row0 = [0u8; 32];
+        row0.copy_from_slice(out.value(0));
+        assert_eq!(bytes_to_u256(&row0), U256::from(1u64));
+        let mut row1 = [0u8; 32];
+        row1.copy_from_slice(out.value(1));
+        assert_eq!(bytes_to_u256(&row1), U256::from(2u64));
+
+        // Sanity: a real big-endian payload round-trips through u256_to_bytes
+        // to the same bytes the normalizer produced.
+        let expected = u256_to_bytes(&U256::from(1u64));
+        assert_eq!(out.value(0), &expected[..]);
+    }
+
+    #[test]
+    fn test_normalize_batch_from_clickhouse_skips_metadata_tagged_batch() {
+        // Kafka/Avro batches arrive already-tagged with the u256 extension
+        // metadata and already in big-endian. Reversing them would corrupt
+        // every value. The normalizer must skip when the incoming field already
+        // carries the metadata.
+        use arrow::array::FixedSizeBinaryArray;
+        use streamling_core::types::u256::{U256, bytes_to_u256, u256_to_bytes};
+
+        let already_tagged = Arc::new(
+            Field::new("balance", DataType::FixedSizeBinary(32), false)
+                .with_metadata(U256Type::metadata()),
+        );
+        let schema = Arc::new(Schema::new(vec![already_tagged.as_ref().clone()]));
+        let be_one = u256_to_bytes(&U256::from(1u64));
+        let arr = FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+            vec![Some(be_one.to_vec())].into_iter(),
+            32,
+        )
+        .unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(arr)]).unwrap();
+
+        let normalized =
+            ClickHouseClient::normalize_batch_from_clickhouse(&batch, &schema).unwrap();
+        let out = normalized
+            .column(0)
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap();
+        let mut row = [0u8; 32];
+        row.copy_from_slice(out.value(0));
+        assert_eq!(bytes_to_u256(&row), U256::from(1u64));
+    }
+
+    #[test]
+    fn test_normalize_batch_from_clickhouse_noop_without_bigint_fields() {
+        // Target schemas without any u256/i256 field must pass batches through
+        // verbatim — no column should be transformed.
+        use arrow::array::Int64Array;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        let arr = Int64Array::from(vec![1i64, 2, 3]);
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(arr)]).unwrap();
+
+        let normalized =
+            ClickHouseClient::normalize_batch_from_clickhouse(&batch, &schema).unwrap();
+        let out = normalized
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(out.value(0), 1);
+        assert_eq!(out.value(2), 3);
     }
 
     #[test]

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1054,6 +1054,7 @@ impl ExecutionPlan for HybridSourceExec {
         });
 
         let schema_for_synth = schema.clone();
+        let schema_for_main = schema.clone();
         let pending_for_main = pending_markers.clone();
 
         let reference_name_for_spawn = self.provider.reference_name.clone();
@@ -1101,7 +1102,23 @@ impl ExecutionPlan for HybridSourceExec {
                 while let Some(batch_result) = stream.next().await {
                     match batch_result {
                         Ok(batch) => {
-                            let merged = merge_pending_markers(batch, &pending_for_main);
+                            // Bounded sources (ClickHouse) emit u256/i256 columns as
+                            // FixedSizeBinary(32) without extension metadata and in
+                            // little-endian. Reverse the bytes and adopt the target
+                            // schema's metadata so downstream arithmetic UDFs (which
+                            // assume big-endian + metadata) see correct values.
+                            // No-op for sources that already match (e.g. Kafka/Avro).
+                            let normalized = match ClickHouseClient::normalize_batch_from_clickhouse(
+                                &batch,
+                                &schema_for_main,
+                            ) {
+                                Ok(b) => b,
+                                Err(e) => {
+                                    let _ = tx.send(Err(e)).await;
+                                    break 'outer;
+                                }
+                            };
+                            let merged = merge_pending_markers(normalized, &pending_for_main);
                             if tx.send(Ok(merged)).await.is_err() {
                                 break 'outer;
                             }

--- a/crates/streamling-core/src/session.rs
+++ b/crates/streamling-core/src/session.rs
@@ -407,6 +407,100 @@ impl SessionManager {
 mod tests {
     use super::*;
 
+    // Test infrastructure for end-to-end CASE-over-u256 behavior. Exercises the
+    // full session (preprocessor + registered UDFs), so it catches both the
+    // type-coercion failure and the field-metadata loss that a bare
+    // SessionContext (used in the preprocessor's string-only tests) cannot.
+    use crate::types::u256::{U256, U256Type, u256_to_bytes};
+    use datafusion::arrow::array::{
+        Array, FixedSizeBinaryArray, Int64Array, RecordBatch, StringArray,
+    };
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::MemTable;
+
+    fn u256_col(vals: &[Option<u64>]) -> FixedSizeBinaryArray {
+        let iter = vals
+            .iter()
+            .map(|v| v.map(|x| u256_to_bytes(&U256::from(x)).to_vec()));
+        FixedSizeBinaryArray::try_from_sparse_iter_with_size(iter, 32).unwrap()
+    }
+
+    /// A `txs` table with two u256 columns (`gas_price`, nullable
+    /// `effective_gas_price`) and a non-u256 `flag` for CASE conditions.
+    fn u256_session() -> SessionManager {
+        let sm = SessionManager::new(8192, 10, DynamicTableRegistry::new()).unwrap();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("gas_price", U256Type::new(), false).with_metadata(U256Type::metadata()),
+            Field::new("effective_gas_price", U256Type::new(), true)
+                .with_metadata(U256Type::metadata()),
+            Field::new("flag", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["a", "b"])),
+                Arc::new(u256_col(&[Some(10), Some(20)])),
+                Arc::new(u256_col(&[None, Some(99)])),
+                Arc::new(Int64Array::from(vec![1, 0])),
+            ],
+        )
+        .unwrap();
+        let table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        sm.register_table("txs", Arc::new(table)).unwrap();
+        sm
+    }
+
+    async fn collect_sql(sm: &SessionManager, sql: &str) -> Result<Vec<RecordBatch>> {
+        let plan = sm.create_logical_plan(sql.to_string()).await?;
+        sm.new_df(plan).collect().await
+    }
+
+    #[tokio::test]
+    async fn test_case_with_u256_and_literal_branch_does_not_kill_stream() {
+        // A literal branch (`ELSE 0`) alongside a u256 branch must not fail
+        // type-coercion (FixedSizeBinary(32) vs Int64). Before the fix this
+        // errored with "Failed to coerce then/else ... in CASE WHEN expression",
+        // which terminates the stream.
+        let sm = u256_session();
+        let sql = "SELECT id, u256_to_string(CASE WHEN flag = 1 THEN gas_price ELSE 0 END) AS chosen FROM txs";
+        let batches = collect_sql(&sm, sql)
+            .await
+            .expect("CASE with literal branch over u256 should plan and execute");
+        let batch = &batches[0];
+        let chosen = batch
+            .column(batch.schema().index_of("chosen").unwrap())
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("chosen should be a string");
+        // row 0: flag=1 -> gas_price=10 ; row 1: flag=0 -> 0
+        assert_eq!(chosen.value(0), "10");
+        assert_eq!(chosen.value(1), "0");
+    }
+
+    #[tokio::test]
+    async fn test_case_over_u256_preserves_metadata_for_numeric_sink() {
+        // A CASE whose branches are u256 must yield an output field that still
+        // carries the streamling.u256 extension metadata, otherwise the Postgres
+        // sink falls back to BYTEA instead of numeric(78,0).
+        let sm = u256_session();
+        let sql = "SELECT id, CASE WHEN flag = 1 THEN gas_price ELSE effective_gas_price END AS chosen FROM txs";
+        let batches = collect_sql(&sm, sql)
+            .await
+            .expect("CASE over u256 should execute");
+        let field = batches[0]
+            .schema()
+            .field_with_name("chosen")
+            .unwrap()
+            .clone();
+        assert_eq!(field.data_type(), &DataType::FixedSizeBinary(32));
+        assert!(
+            U256Type::is_u256_metadata(field.metadata()),
+            "CASE output lost u256 metadata: {:?}",
+            field.metadata()
+        );
+    }
+
     #[test]
     fn test_extract_schema_and_table_names() {
         assert_eq!(

--- a/crates/streamling-core/src/types/bigint_sql_preprocessor.rs
+++ b/crates/streamling-core/src/types/bigint_sql_preprocessor.rs
@@ -241,6 +241,20 @@ fn is_bigint_expr<K: BigIntKind>(expr: &SqlExpr, cols: &HashSet<String>) -> bool
             }
             false
         }
+        // A CASE produces a bigint value iff any of its result branches does.
+        // The WHEN conditions and operand do not affect the result type.
+        SqlExpr::Case {
+            conditions,
+            else_result,
+            ..
+        } => {
+            conditions
+                .iter()
+                .any(|when| is_bigint_expr::<K>(&when.result, cols))
+                || else_result
+                    .as_ref()
+                    .is_some_and(|e| is_bigint_expr::<K>(e, cols))
+        }
         _ => false,
     }
 }
@@ -281,7 +295,97 @@ fn contains_bigint_operations<K: BigIntKind>(expr: &SqlExpr, cols: &HashSet<Stri
             }
             false
         }
+        SqlExpr::Case {
+            conditions,
+            else_result,
+            ..
+        } => {
+            conditions
+                .iter()
+                .any(|when| contains_bigint_operations::<K>(&when.result, cols))
+                || else_result
+                    .as_ref()
+                    .is_some_and(|e| contains_bigint_operations::<K>(e, cols))
+        }
         _ => false,
+    }
+}
+
+/// Returns true when a NULL literal — these are left untouched in CASE branches
+/// because DataFusion coerces NULL to any branch type, whereas to_<kind>() would
+/// reject it.
+fn is_null_literal(e: &SqlExpr) -> bool {
+    matches!(
+        e,
+        SqlExpr::Value(v)
+            if matches!(v.value, datafusion::logical_expr::sqlparser::ast::Value::Null)
+    )
+}
+
+/// Coerce a single CASE result branch to the bigint kind when needed. Branches
+/// that are already kind-typed (columns, to_<kind>() calls, bigint expressions)
+/// and NULL literals are left as-is; everything else (e.g. an integer literal
+/// `0`) is wrapped in to_<kind>() so all branches share the FixedSizeBinary(32)
+/// type and DataFusion's CASE type-coercion succeeds.
+fn coerce_case_branch<K: BigIntKind>(branch: &mut SqlExpr, cols: &HashSet<String>) {
+    if is_kind_func_call::<K>(branch)
+        || is_bigint_expr::<K>(branch, cols)
+        || is_null_literal(branch)
+    {
+        return;
+    }
+    if let Some(wrapped) = parse_wrapped_fn(K::TO_NAME, branch) {
+        *branch = wrapped;
+    }
+}
+
+/// Rewrite a CASE expression for the given bigint kind. Recurses into every
+/// sub-expression, and when the CASE produces a bigint value: coerces literal
+/// result branches to the kind, then wraps the whole CASE in to_<kind>(). The
+/// outer wrap is an identity passthrough for FixedSizeBinary(32) that re-declares
+/// the extension metadata which native CASE drops — the Postgres sink relies on
+/// that metadata to cast to numeric(78,0).
+fn rewrite_case_kind<K: BigIntKind>(e: &mut SqlExpr, cols: &HashSet<String>) {
+    let result_is_kind = {
+        let SqlExpr::Case {
+            operand,
+            conditions,
+            else_result,
+        } = e
+        else {
+            return;
+        };
+
+        if let Some(op) = operand.as_mut() {
+            rewrite_expr_kind::<K>(op, cols);
+        }
+        for when in conditions.iter_mut() {
+            rewrite_expr_kind::<K>(&mut when.condition, cols);
+            rewrite_expr_kind::<K>(&mut when.result, cols);
+        }
+        if let Some(er) = else_result.as_mut() {
+            rewrite_expr_kind::<K>(er, cols);
+        }
+
+        let is_kind = conditions.iter().any(|when| {
+            is_kind_func_call::<K>(&when.result) || is_bigint_expr::<K>(&when.result, cols)
+        }) || else_result
+            .as_ref()
+            .is_some_and(|er| is_kind_func_call::<K>(er) || is_bigint_expr::<K>(er, cols));
+
+        if is_kind {
+            for when in conditions.iter_mut() {
+                coerce_case_branch::<K>(&mut when.result, cols);
+            }
+            if let Some(er) = else_result.as_mut() {
+                coerce_case_branch::<K>(er, cols);
+            }
+        }
+        is_kind
+    };
+
+    if result_is_kind && let Some(wrapped) = parse_wrapped_fn(K::TO_NAME, e) {
+        *e = wrapped;
     }
 }
 
@@ -317,6 +421,7 @@ fn rewrite_expr_kind<K: BigIntKind>(e: &mut SqlExpr, cols: &HashSet<String>) {
                 }
             }
         }
+        SqlExpr::Case { .. } => rewrite_case_kind::<K>(e, cols),
         SqlExpr::Nested(inner) => rewrite_expr_kind::<K>(inner.as_mut(), cols),
         SqlExpr::UnaryOp { op, expr } => {
             if matches!(op, UnaryOperator::Minus) {
@@ -1660,6 +1765,101 @@ mod tests {
             "COALESCE should not be rewritten to coalesce_meta when \
              the result is Utf8, got: {}",
             rewritten
+        );
+    }
+
+    #[tokio::test]
+    async fn test_case_literal_branch_is_wrapped() {
+        let ctx = setup_session_context();
+        register_u256_table(&ctx, "t", vec![("value", true), ("flag", false)]);
+
+        // A bare integer literal branch (`ELSE 0`) alongside a u256 branch would
+        // fail DataFusion type-coercion. The preprocessor must wrap the literal
+        // with to_u256() so both branches share the u256 type.
+        let sql = "SELECT CASE WHEN flag = 1 THEN value ELSE 0 END AS x FROM t";
+        let rewritten = preprocess_bigint_binary_ops_with_schema(&ctx, sql)
+            .await
+            .unwrap();
+        assert_eq!(
+            rewritten,
+            "SELECT to_u256(CASE WHEN flag = 1 THEN value ELSE to_u256(0) END) AS x FROM t"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_case_over_u256_is_wrapped_to_preserve_metadata() {
+        let ctx = setup_session_context();
+        register_u256_table(&ctx, "t", vec![("a", true), ("b", true), ("flag", false)]);
+
+        // Even when both branches are u256, the whole CASE is wrapped in to_u256
+        // so the result field re-declares the u256 extension metadata (native
+        // CASE drops it).
+        let sql = "SELECT CASE WHEN flag = 1 THEN a ELSE b END AS x FROM t";
+        let rewritten = preprocess_bigint_binary_ops_with_schema(&ctx, sql)
+            .await
+            .unwrap();
+        assert_eq!(
+            rewritten,
+            "SELECT to_u256(CASE WHEN flag = 1 THEN a ELSE b END) AS x FROM t"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_case_inside_u256_to_string() {
+        let ctx = setup_session_context();
+        register_u256_table(&ctx, "t", vec![("value", true), ("flag", false)]);
+
+        let sql = "SELECT u256_to_string(CASE WHEN flag = 1 THEN value ELSE 0 END) AS x FROM t";
+        let rewritten = preprocess_bigint_binary_ops_with_schema(&ctx, sql)
+            .await
+            .unwrap();
+        assert_eq!(
+            rewritten,
+            "SELECT u256_to_string(to_u256(CASE WHEN flag = 1 THEN value ELSE to_u256(0) END)) AS x FROM t"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_case_arithmetic_branch_is_rewritten() {
+        let ctx = setup_session_context();
+        register_u256_table(&ctx, "t", vec![("value", true), ("flag", false)]);
+
+        // Arithmetic inside a branch must be rewritten to the u256 UDF form.
+        let sql = "SELECT CASE WHEN flag = 1 THEN value * 2 ELSE value END AS x FROM t";
+        let rewritten = preprocess_bigint_binary_ops_with_schema(&ctx, sql)
+            .await
+            .unwrap();
+        assert_eq!(
+            rewritten,
+            "SELECT to_u256(CASE WHEN flag = 1 THEN u256_mul(value, to_u256(2)) ELSE value END) AS x FROM t"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_non_u256_case_is_unchanged() {
+        let ctx = setup_session_context();
+        register_u256_table(&ctx, "t", vec![("value", false), ("flag", false)]);
+
+        // No u256 columns involved -> CASE must be left exactly as-is.
+        let sql = "SELECT CASE WHEN flag = 1 THEN value ELSE 0 END AS x FROM t";
+        let rewritten = preprocess_bigint_binary_ops_with_schema(&ctx, sql)
+            .await
+            .unwrap();
+        assert_eq!(rewritten, sql);
+    }
+
+    #[tokio::test]
+    async fn test_i256_case_literal_branch_is_wrapped() {
+        let ctx = setup_session_context();
+        register_i256_table(&ctx, "t", vec![("balance", true), ("flag", false)]);
+
+        let sql = "SELECT CASE WHEN flag = 1 THEN balance ELSE 0 END AS x FROM t";
+        let rewritten = preprocess_bigint_binary_ops_with_schema(&ctx, sql)
+            .await
+            .unwrap();
+        assert_eq!(
+            rewritten,
+            "SELECT to_i256(CASE WHEN flag = 1 THEN balance ELSE to_i256(0) END) AS x FROM t"
         );
     }
 }

--- a/crates/streamling-e2e/tests/hybrid_source.rs
+++ b/crates/streamling-e2e/tests/hybrid_source.rs
@@ -1441,6 +1441,8 @@ sources:
 
 transforms:
   stringify:
+    type: sql
+    primary_key: id
     from: hybrid_source
     sql: "SELECT block, id, u256_to_string(wei_value) AS wei_str FROM hybrid_source"
 

--- a/crates/streamling-e2e/tests/hybrid_source.rs
+++ b/crates/streamling-e2e/tests/hybrid_source.rs
@@ -1334,3 +1334,177 @@ sinks:
         count
     );
 }
+
+// ============================================================================
+// Scenario: Hybrid source ClickHouse Nullable(UInt128) → u256 endianness
+// ============================================================================
+
+/// Avro schema with a Decimal logical type at precision > 76 — converts to
+/// streamling u256 (FixedSizeBinary(32) + u256 extension metadata).
+const U256_SCHEMA: &str = r#"{
+    "type": "record",
+    "name": "U256TestMessage",
+    "fields": [
+        {"name": "block", "type": "long"},
+        {"name": "id", "type": "string"},
+        {"name": "wei_value", "type": ["null", {"type": "bytes", "logicalType": "decimal", "precision": 78, "scale": 0}], "default": null}
+    ]
+}"#;
+
+/// Regression for the ClickHouse → streamling u256 endianness asymmetry.
+///
+/// ClickHouse stores UInt128/UInt256 little-endian and the hybrid layer's
+/// schema adapter widens `Nullable(UInt128)` to `Nullable(UInt256)` via a
+/// server-side CAST. ClickHouse emits UInt256 as Arrow `FixedSizeBinary(32)`
+/// in little-endian, while streamling stores big-endian. Before
+/// `normalize_batch_from_clickhouse` was added on the read side, a logical
+/// `1` arrived as `2^248` and downstream u256 arithmetic / serialization
+/// produced garbage.
+///
+/// Job mode lets the bounded phase finish and exits without consuming Kafka,
+/// so the unbounded source is only present to declare the u256 schema (which
+/// drives the bounded CAST + the read-side normalization).
+#[tokio::test]
+async fn test_hybrid_clickhouse_uint128_widened_to_u256_preserves_value() {
+    init_tracing();
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+
+    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE hybrid_u256_test (
+                block Int64,
+                id String,
+                wei_value Nullable(UInt128),
+                is_deleted UInt8
+            ) ENGINE = MergeTree()
+            ORDER BY (block, id)",
+        )
+        .await
+        .expect("Failed to create ClickHouse table");
+
+    // Spread of magnitudes that would all collapse to ~2^248-range garbage if
+    // the LE-stored bytes were re-read big-endian.
+    clickhouse
+        .execute(
+            "INSERT INTO hybrid_u256_test (block, id, wei_value, is_deleted) VALUES
+            (1, 'one',  1, 0),
+            (2, 'eth',  1000000000000000000, 0),
+            (3, 'gwei', 100000000000, 0),
+            (4, 'null', NULL, 0)",
+        )
+        .await
+        .expect("Failed to insert");
+
+    // Register the unbounded schema. We never produce Kafka records — job mode
+    // terminates after the bounded phase — but the topic + schema must exist
+    // because the hybrid validates the unbounded schema at startup and uses it
+    // as the source of truth for u256 metadata.
+    ctx.kafka
+        .register_schema(U256_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE kafka_offsets_u256 (
+                topic String,
+                partition Int32,
+                offset UInt32
+            ) ENGINE = MergeTree()
+            ORDER BY (topic, partition)",
+        )
+        .await
+        .expect("Failed to create offset table");
+
+    let pipeline = format!(
+        r#"
+sources:
+  hybrid_source:
+    type: hybrid
+    bounded_sources:
+      - source_type: clickhouse
+        table_name: hybrid_u256_test
+        columns: block,id,wei_value
+    unbounded_source:
+      source_type: kafka
+      topic: {kafka_topic}
+      start_at: earliest
+    offset_table:
+      topic_name: {kafka_topic}
+      table_name: kafka_offsets_u256
+    primary_key: id
+
+transforms:
+  stringify:
+    from: hybrid_source
+    sql: "SELECT block, id, u256_to_string(wei_value) AS wei_str FROM hybrid_source"
+
+sinks:
+  pg_sink:
+    type: postgres
+    from: stringify
+    table: hybrid_u256_results
+    schema: public
+    primary_key: id
+    on_conflict: update
+    batch_size: 1
+"#,
+        kafka_topic = ctx.kafka_topic,
+    );
+
+    let status = ctx
+        .run_pipeline_with_opts(
+            &pipeline,
+            PipelineOpts::new()
+                .env("STREAMLING__JOB_MODE", "true")
+                .env("STREAMLING__RECORD_BATCH_SIZE", "1")
+                .timeout(std::time::Duration::from_secs(120)),
+        )
+        .await
+        .expect("Pipeline execution failed");
+
+    assert!(
+        status.success(),
+        "Pipeline should exit successfully in job mode"
+    );
+
+    let rows: Vec<(String, Option<String>)> = ctx
+        .postgres
+        .query("SELECT id, wei_str FROM public.hybrid_u256_results ORDER BY id")
+        .await
+        .expect("Failed to query postgres");
+
+    let by_id: std::collections::HashMap<String, Option<String>> = rows.into_iter().collect();
+
+    // Logical 1 must arrive as "1", not "452312848583266388373324160190187140051835877600158453279131187530910662656"
+    // (which is 2^248, the value bytes_to_u256 yields when fed LE bytes for 1).
+    assert_eq!(
+        by_id.get("one"),
+        Some(&Some("1".to_string())),
+        "Bounded ClickHouse u256 value 1 must arrive intact, got {:?}",
+        by_id.get("one")
+    );
+    assert_eq!(
+        by_id.get("eth"),
+        Some(&Some("1000000000000000000".to_string())),
+        "Bounded ClickHouse u256 value 1e18 must arrive intact, got {:?}",
+        by_id.get("eth")
+    );
+    assert_eq!(
+        by_id.get("gwei"),
+        Some(&Some("100000000000".to_string())),
+        "Bounded ClickHouse u256 value 1e11 must arrive intact, got {:?}",
+        by_id.get("gwei")
+    );
+    assert_eq!(
+        by_id.get("null"),
+        Some(&None),
+        "Nullable u256 must propagate NULL, got {:?}",
+        by_id.get("null")
+    );
+}

--- a/crates/streamling-e2e/tests/hybrid_source.rs
+++ b/crates/streamling-e2e/tests/hybrid_source.rs
@@ -1443,7 +1443,6 @@ transforms:
   stringify:
     type: sql
     primary_key: id
-    from: hybrid_source
     sql: "SELECT block, id, u256_to_string(wei_value) AS wei_str FROM hybrid_source"
 
 sinks:


### PR DESCRIPTION
## Summary

Three related correctness fixes for 256-bit integer handling, each independently reproducible and unit-tested.

### 1. CASE expressions over u256/i256 dropped type/metadata

**Symptom.** A `CASE` whose branches mix a bigint column with a literal (e.g. `ELSE 0`) failed DataFusion type-coercion (`FixedSizeBinary(32)` vs `Int64`) and terminated the stream. A `CASE` whose branches were all bigint planned, but the output field lost the `streamling.u256`/`i256` extension metadata, so the Postgres sink fell back to `BYTEA` instead of `numeric(78,0)`.

**Fix.** The SQL preprocessor now recurses into `CASE`: arithmetic branches get rewritten in place, literal branches are wrapped in `to_<kind>()` to share the `FixedSizeBinary(32)` type, and the whole `CASE` is wrapped in `to_<kind>()` to re-declare the extension metadata. `to_u256` grows a `FixedSizeBinary(32)` passthrough so the outer wrap is a no-op for already-encoded values.

Bigint overflow errors now include the operand values so an offending row can be identified without guessing.

### 2. ClickHouse hybrid read path stored u256/i256 little-endian as big-endian

**Symptom.** Multiplying u256 columns sourced from a hybrid ClickHouse provider raised \"U256 multiplication overflow\" on values that obviously fit. `u256_to_string` reported astronomic values for known-small wei amounts.

**Cause.** The sink already reversed bytes (`normalize_batch_for_clickhouse`, BE→LE) because ClickHouse stores `UInt256`/`Int256` little-endian. The read path never reversed back. ClickHouse emits `UInt256` as Arrow `FixedSizeBinary(32)` in little-endian; streamling reads big-endian. A logical \`1\` arrived as \`2^248\`, and any multiplication of wei-scale values overflowed \`U256::MAX\`.

**Fix.** New `ClickHouseClient::normalize_batch_from_clickhouse` mirrors the sink-side normalizer: for each column whose target field has u256/i256 metadata but whose incoming field lacks it, reverse the 32 bytes and adopt the target field. Applied in `HybridSourceExec::execute`'s batch-receiving loop. No-op on Kafka/Avro batches (already metadata-tagged + BE).

### 3. Normalizer broke List columns whose inner field names differ

**Symptom (prod).** After fix #2 shipped, `obib-case4-baseline` failed at column 28 with:
> `Invalid argument error: column types must match schema types, expected List(Field name: \"element\", ...) but found List(Field name: \"item\", ...)`

**Cause.** The first cut of `normalize_batch_from_clickhouse` rebuilt every column against \`target_schema\` verbatim. The hybrid layer's \`is_compatible_data_type\` deliberately tolerates ClickHouse's \`item\` vs Kafka/Avro's \`element\` for List inner fields — but \`RecordBatch::try_new\` doesn't.

**Fix.** Only swap the \`Field\` for columns whose bytes we actually transform (u256/i256 byte reversal). All other columns keep their incoming \`Field\`. The output schema mixes incoming and target fields per-column, matching the hybrid's relaxed compatibility rules. A unit regression reproduces the exact prod error before the fix and asserts the same batch flows through afterwards.

## Test plan

- [x] \`cargo nextest run -p streamling-common -p streamling-core -p streamling-connectors\` — all new and existing unit tests pass
- [x] \`just lint\` clean
- [x] New unit tests pin behavior:
  - \`u256\`/\`u256_ops\`: 6 endianness pin tests (BE storage, mis-endian explodes, wei-squared safe, MAX boundary)
  - \`bigint_sql_preprocessor\`: 6 CASE rewrite tests (literal branch, u256/u256, arithmetic branch, non-u256 left alone, i256 parallel)
  - \`clickhouse\`: 4 normalize_batch tests (LE reversal, metadata-tagged passthrough, no-op without bigint, **List inner-name preservation**)
  - \`session\`: 2 end-to-end CASE-over-u256 tests (DataFusion coercion + metadata preservation)
- [x] New e2e test \`test_hybrid_clickhouse_uint128_widened_to_u256_preserves_value\` exercises the full hybrid path (CI runs against k3s)
- [x] Verify against \`obib-case4-baseline\` on the new image (\`fix-case-bigint-coercion-latest\` after this lands)