### PR TITLE
fix(e2e): stop ClickHouse OOM by bounding server memory to the container

### DIFF
--- a/infra/local-k8s/clickhouse.yaml
+++ b/infra/local-k8s/clickhouse.yaml
@@ -19,6 +19,25 @@ data:
         </default>
       </users>
     </clickhouse>
+  memory.xml: |
+    <?xml version="1.0"?>
+    <!--
+      Bound ClickHouse memory to the container cgroup. By default ClickHouse 24.8
+      sizes its caches off the *host* RAM (the k3d node reports ~7.6 GiB), not the
+      1Gi container limit, so mark_cache (5 GiB) + uncompressed_cache (8 GiB) alone
+      blow past the cgroup and OOM-kill the pod. Cap the server's tracked memory and
+      shrink the caches so it stays well inside the limit regardless of host RAM.
+    -->
+    <clickhouse>
+      <!-- Absolute cap (1 GiB), well under the 1536Mi cgroup. We set the absolute
+           value rather than the *_to_ram_ratio because the ratio is computed against
+           host RAM (~7.6 GiB on the k3d node), not the container limit. Leaving the
+           ratio at its default is fine: a non-zero absolute max_server_memory_usage
+           takes precedence. -->
+      <max_server_memory_usage>1073741824</max_server_memory_usage>
+      <mark_cache_size>134217728</mark_cache_size>
+      <uncompressed_cache_size>134217728</uncompressed_cache_size>
+    </clickhouse>
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -62,12 +81,17 @@ spec:
             - name: clickhouse-config
               mountPath: /etc/clickhouse-server/users.d/users.xml
               subPath: users.xml
+            - name: clickhouse-config
+              mountPath: /etc/clickhouse-server/config.d/memory.xml
+              subPath: memory.xml
           resources:
             requests:
               memory: "256Mi"
               cpu: "250m"
             limits:
-              memory: "1Gi"
+              # Server memory is capped at 1Gi via config.d/memory.xml; the extra
+              # headroom covers untracked allocations (page cache, threads).
+              memory: "1536Mi"
               cpu: "1000m"
           readinessProbe:
             httpGet:


### PR DESCRIPTION
## Problem

The e2e ClickHouse pod repeatedly OOM-killed (`Exit Code: 137`) and crash-looped, taking down all ClickHouse-dependent e2e tests on the long-lived local cluster.

## Root cause

ClickHouse 24.8 sizes its caches off **host RAM** (the k3d node reports ~7.6 GiB), not the 1Gi container cgroup. The defaults `mark_cache_size` (5 GiB) and `uncompressed_cache_size` (8 GiB) alone dwarf the limit, so the server is killed on load. Accumulating `test_*` databases on the `emptyDir` across reused-cluster runs compounds startup memory.

## Fix

`config.d/memory.xml` caps ClickHouse to the container instead of host RAM:
- `max_server_memory_usage = 1 GiB` (absolute — the `*_to_ram_ratio` is host-RAM-based and so unusable here; a non-zero absolute value takes precedence, and setting the ratio to 0 instead zeroes the cap, so we don't)
- `mark_cache_size` / `uncompressed_cache_size` = 128 MiB each (were 5 / 8 GiB)

Container memory limit bumped 1Gi → 1536Mi for headroom above the 1Gi server cap (page cache, threads).

## Verification

- `system.server_settings` confirms `max_server_memory_usage=1073741824` and the 128 MiB caches.
- The pod runs through a **full `streamling-e2e` suite (94 tests) with 0 restarts and no OOM** — previously the same suite OOM-killed ClickHouse and failed ~20 ClickHouse-dependent tests.

Optional follow-up (not included to keep this focused): wire the existing `cleanup_clickhouse` (`scripts/k3s-cleanup-orphans.sh`) into `env-setup` to drop stale `test_*` databases on the reused cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)