### PR TITLE
feat: configurable Kafka sink compression codec (STRM-6290)

### DIFF
--- a/crates/streamling-config/src/app_config.rs
+++ b/crates/streamling-config/src/app_config.rs
@@ -295,6 +295,50 @@ impl KafkaConfig {
     }
 }
 
+/// Compression codec applied by the Kafka sink's producer (librdkafka
+/// `compression.type`). Defaults to `lz4`, which is the historical built-in
+/// behavior. Parsing is case-insensitive so env-var overrides arriving as
+/// strings work.
+///
+/// Only the codecs that librdkafka always links are exposed: `none`, `gzip`,
+/// and `lz4`. `gzip` (or `none`) is needed for brokers that don't accept lz4.
+/// `snappy`/`zstd` are intentionally omitted for now — `zstd` in particular
+/// requires libzstd to be linked at build time — and can be added once that is
+/// verified.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum KafkaCompression {
+    None,
+    Gzip,
+    #[default]
+    Lz4,
+}
+
+impl KafkaCompression {
+    /// The librdkafka `compression.type` value for this codec.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            KafkaCompression::None => "none",
+            KafkaCompression::Gzip => "gzip",
+            KafkaCompression::Lz4 => "lz4",
+        }
+    }
+}
+
+impl<'de> SerdeDeserialize<'de> for KafkaCompression {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        match s.trim().to_lowercase().as_str() {
+            "none" => Ok(KafkaCompression::None),
+            "gzip" => Ok(KafkaCompression::Gzip),
+            "lz4" => Ok(KafkaCompression::Lz4),
+            other => Err(DeError::custom(format!(
+                "unknown Kafka compression `{}`; expected `none`, `gzip`, or `lz4`",
+                other
+            ))),
+        }
+    }
+}
+
 /// Wire-format compression to apply to outbound HTTP request bodies sent to
 /// ClickHouse. Accepted values: `"none"` (default) or `"gzip"`. Parsing is
 /// case-insensitive so env-var overrides arriving as strings work. The
@@ -967,6 +1011,52 @@ password: ""
                 "unexpected error for {bad}: {err}"
             );
         }
+    }
+
+    #[test]
+    fn kafka_compression_parses_known_codecs() {
+        // Covers all three codecs plus case/whitespace normalization, since
+        // env-var overrides arrive as strings.
+        for (s, expected) in [
+            ("none", KafkaCompression::None),
+            ("gzip", KafkaCompression::Gzip),
+            ("lz4", KafkaCompression::Lz4),
+            ("NONE", KafkaCompression::None),
+            (" Gzip ", KafkaCompression::Gzip),
+            ("LZ4", KafkaCompression::Lz4),
+        ] {
+            let value: KafkaCompression =
+                serde_yaml::from_str(&format!(r#""{}""#, s)).expect("should parse");
+            assert_eq!(value, expected, "input: {s:?}");
+        }
+    }
+
+    #[test]
+    fn kafka_compression_defaults_to_lz4() {
+        // Preserves the historical hardcoded producer default.
+        assert_eq!(KafkaCompression::default(), KafkaCompression::Lz4);
+    }
+
+    #[test]
+    fn kafka_compression_rejects_unknown_codec() {
+        // snappy/zstd are intentionally not exposed yet, so they must be rejected
+        // rather than silently misconfiguring the producer.
+        for bad in ["snappy", "zstd", "brotli"] {
+            let err = serde_yaml::from_str::<KafkaCompression>(&format!(r#""{}""#, bad))
+                .expect_err("should reject");
+            assert!(
+                err.to_string()
+                    .contains("expected `none`, `gzip`, or `lz4`"),
+                "unexpected error for {bad}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn kafka_compression_as_str_matches_librdkafka_values() {
+        assert_eq!(KafkaCompression::None.as_str(), "none");
+        assert_eq!(KafkaCompression::Gzip.as_str(), "gzip");
+        assert_eq!(KafkaCompression::Lz4.as_str(), "lz4");
     }
 
     #[test]

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -2,7 +2,7 @@ mod config_optimizer;
 mod metadata;
 mod schema_registry;
 
-use streamling_config::KafkaConfig;
+use streamling_config::{KafkaCompression, KafkaConfig};
 use streamling_core::checkpoints::channels::{send, subscribe};
 use streamling_core::checkpoints::checkpoint_management::{
     CHECKPOINT_COORDINATOR_CHANNEL, CheckpointEpoch, CheckpointMessage,
@@ -1966,6 +1966,8 @@ pub struct KafkaSink {
     message_max_bytes: Option<u32>,
     /// Number of parallel producers (each with independent connections/queues)
     parallelism: usize,
+    /// Producer compression codec (maps to librdkafka's compression.type)
+    compression: KafkaCompression,
 }
 
 impl KafkaSink {
@@ -1983,6 +1985,7 @@ impl KafkaSink {
         batch_flush_interval_ms: Option<u64>,
         message_max_bytes: Option<u32>,
         parallelism: Option<usize>,
+        compression: KafkaCompression,
     ) -> Self {
         let subject_name_strategy = SubjectNameStrategy::TopicNameStrategy(topic.to_owned(), false);
         let topic_partitions = topic_partitions.unwrap_or(DEFAULT_NUM_PARTITIONS);
@@ -2004,6 +2007,7 @@ impl KafkaSink {
             batch_flush_interval_ms,
             message_max_bytes,
             parallelism: parallelism.unwrap_or(1).max(1),
+            compression,
         }
     }
 
@@ -2034,48 +2038,62 @@ impl KafkaSink {
         }
     }
 
+    /// Assemble the librdkafka producer configuration.
+    fn build_producer_config(
+        config: &KafkaConfig,
+        batch_size: Option<u32>,
+        batch_flush_interval_ms: Option<u64>,
+        message_max_bytes: Option<u32>,
+        compression: KafkaCompression,
+    ) -> ClientConfig {
+        let mut builder = KafkaCommon::build_client(config);
+
+        builder
+            .set("message.timeout.ms", "600000")
+            .set("acks", "all");
+
+        let kafka_config_optimizer = KafkaConfigOptimizer::new(config);
+        for (key, value) in kafka_config_optimizer.optimized_producer_config() {
+            builder.set(key, value);
+        }
+
+        if let Some(batch_num_messages) = batch_size {
+            builder.set("batch.num.messages", batch_num_messages.to_string());
+        }
+        if let Some(linger_ms) = batch_flush_interval_ms {
+            builder.set("linger.ms", linger_ms.to_string());
+        }
+        if let Some(max_bytes) = message_max_bytes {
+            builder.set("message.max.bytes", max_bytes.to_string());
+        }
+        // Applied last so the per-sink setting wins over the optimizer default.
+        builder.set("compression.type", compression.as_str());
+
+        builder
+    }
+
     fn create_producers(&self) -> streamling_core::error::Result<Vec<KafkaThreadedProducer>> {
         info!(
-            "Creating {} Kafka producer(s) for topic: {} (message.timeout.ms=600000, acks=all, batch_size={:?}, batch_flush_interval_ms={:?}, message_max_bytes={:?})",
+            "Creating {} Kafka producer(s) for topic: {} (message.timeout.ms=600000, acks=all, batch_size={:?}, batch_flush_interval_ms={:?}, message_max_bytes={:?}, compression={})",
             self.parallelism,
             self.topic,
             self.batch_size,
             self.batch_flush_interval_ms,
             self.message_max_bytes,
+            self.compression.as_str(),
         );
 
         (0..self.parallelism)
             .map(|_| {
-                let mut builder = KafkaCommon::build_client(&self.config);
-
-                builder
-                    .set("message.timeout.ms", "600000")
-                    .set("acks", "all");
-
-                let kafka_config_optimizer = KafkaConfigOptimizer::new(&self.config);
-                kafka_config_optimizer
-                    .optimized_producer_config()
-                    .iter()
-                    .for_each(|(key, value)| {
-                        builder.set(key, value);
-                    });
-
-                if let Some(batch_num_messages) = self.batch_size {
-                    builder.set(
-                        "batch.num.messages",
-                        batch_num_messages.to_string().as_str(),
-                    );
-                }
-                if let Some(linger_ms) = self.batch_flush_interval_ms {
-                    builder.set("linger.ms", linger_ms.to_string().as_str());
-                }
-                if let Some(max_bytes) = self.message_max_bytes {
-                    builder.set("message.max.bytes", max_bytes.to_string().as_str());
-                }
-
-                builder
-                    .create_with_context(KafkaProducerContext::new())
-                    .streamling_context("failed to create Kafka producer")
+                Self::build_producer_config(
+                    &self.config,
+                    self.batch_size,
+                    self.batch_flush_interval_ms,
+                    self.message_max_bytes,
+                    self.compression,
+                )
+                .create_with_context(KafkaProducerContext::new())
+                .streamling_context("failed to create Kafka producer")
             })
             .collect()
     }
@@ -2603,6 +2621,8 @@ pub struct KafkaSinkTableProvider {
     /// Maximum Kafka protocol request message size in bytes (maps to message.max.bytes)
     message_max_bytes: Option<u32>,
     parallelism: Option<usize>,
+    /// Producer compression codec (maps to librdkafka's compression.type)
+    compression: KafkaCompression,
     telemetry: Option<Telemetry>,
 }
 
@@ -2622,6 +2642,7 @@ impl KafkaSinkTableProvider {
         batch_flush_interval_ms: Option<u64>,
         message_max_bytes: Option<u32>,
         parallelism: Option<usize>,
+        compression: KafkaCompression,
         telemetry: Option<Telemetry>,
     ) -> Self {
         Self {
@@ -2638,6 +2659,7 @@ impl KafkaSinkTableProvider {
             batch_flush_interval_ms,
             message_max_bytes,
             parallelism,
+            compression,
             telemetry,
         }
     }
@@ -2687,6 +2709,7 @@ impl TableProvider for KafkaSinkTableProvider {
             self.batch_flush_interval_ms,
             self.message_max_bytes,
             self.parallelism,
+            self.compression,
         ));
         let metric_metadata_id = self.metric_metadata_id.clone();
         let wrapper_data_sink = Arc::new(WrappingDataSink::new(
@@ -2702,6 +2725,75 @@ impl TableProvider for KafkaSinkTableProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_kafka_config() -> KafkaConfig {
+        KafkaConfig {
+            brokers: "localhost:9092".to_string(),
+            security_protocol: "plaintext".to_string(),
+            sasl_mechanism: None,
+            sasl_username: None,
+            sasl_password: None,
+            schema_registry_url: None,
+            schema_registry_username: None,
+            schema_registry_password: None,
+            consumer_group_id: None,
+            client_id: None,
+            lag_report_interval_ms: None,
+        }
+    }
+
+    #[test]
+    fn build_producer_config_sets_requested_compression() {
+        for compression in [
+            KafkaCompression::None,
+            KafkaCompression::Gzip,
+            KafkaCompression::Lz4,
+        ] {
+            let cfg = KafkaSink::build_producer_config(
+                &test_kafka_config(),
+                None,
+                None,
+                None,
+                compression,
+            );
+            assert_eq!(
+                cfg.get("compression.type"),
+                Some(compression.as_str()),
+                "compression {compression:?} should reach the producer config"
+            );
+        }
+    }
+
+    #[test]
+    fn build_producer_config_compression_overrides_optimizer_default() {
+        // The optimizer seeds compression.type=lz4; an explicit gzip is applied
+        // afterwards and must win.
+        let cfg = KafkaSink::build_producer_config(
+            &test_kafka_config(),
+            None,
+            None,
+            None,
+            KafkaCompression::Gzip,
+        );
+        assert_eq!(cfg.get("compression.type"), Some("gzip"));
+    }
+
+    #[test]
+    fn build_producer_config_threads_optional_tunables() {
+        let cfg = KafkaSink::build_producer_config(
+            &test_kafka_config(),
+            Some(5000),
+            Some(250),
+            Some(20_000_000),
+            KafkaCompression::Lz4,
+        );
+        assert_eq!(cfg.get("batch.num.messages"), Some("5000"));
+        assert_eq!(cfg.get("linger.ms"), Some("250"));
+        assert_eq!(cfg.get("message.max.bytes"), Some("20000000"));
+        // Invariants that must always hold for the sink producer.
+        assert_eq!(cfg.get("acks"), Some("all"));
+        assert_eq!(cfg.get("message.timeout.ms"), Some("600000"));
+    }
 
     #[test]
     fn build_schema_id_overrides_map_empty_returns_empty_map() {

--- a/crates/streamling-core/src/topology.rs
+++ b/crates/streamling-core/src/topology.rs
@@ -7,7 +7,9 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::de;
 use serde::{Deserialize, Deserializer};
-use streamling_config::{ClickHouseCompression, DynamicTableBackendType, GzipCompressionLevel};
+use streamling_config::{
+    ClickHouseCompression, DynamicTableBackendType, GzipCompressionLevel, KafkaCompression,
+};
 use tracing::log::info;
 
 // ============================================================================
@@ -651,6 +653,10 @@ pub struct KafkaSink {
     /// Number of parallel Kafka producers. Each producer has independent connections
     /// and queues, multiplying broker throughput. Defaults to 1.
     pub parallelism: Option<usize>,
+    /// Producer compression codec (`none`, `gzip`, or `lz4`). Defaults to `lz4`.
+    /// Set `gzip` or `none` for brokers that reject lz4.
+    #[serde(default)]
+    pub compression: KafkaCompression,
     pub telemetry: Option<Telemetry>,
 }
 
@@ -1007,6 +1013,30 @@ impl PipelineTopology {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn kafka_sink_yaml(extra: &str) -> String {
+        format!(
+            r#"
+from: src
+topic: out
+data_format: avro
+{extra}
+"#
+        )
+    }
+
+    #[test]
+    fn kafka_sink_parses_compression() {
+        let sink: KafkaSink = serde_yaml::from_str(&kafka_sink_yaml("compression: gzip")).unwrap();
+        assert_eq!(sink.compression, KafkaCompression::Gzip);
+    }
+
+    #[test]
+    fn kafka_sink_compression_defaults_to_lz4_when_omitted() {
+        // Preserves the historical producer default when YAML omits the field.
+        let sink: KafkaSink = serde_yaml::from_str(&kafka_sink_yaml("")).unwrap();
+        assert_eq!(sink.compression, KafkaCompression::Lz4);
+    }
 
     #[test]
     fn test_plugin_options_nested_format() {

--- a/crates/streamling-e2e/tests/kafka_sink.rs
+++ b/crates/streamling-e2e/tests/kafka_sink.rs
@@ -128,6 +128,92 @@ sinks:
 }
 
 // ============================================================================
+// Scenario 1b: Kafka sink with gzip compression
+// ============================================================================
+
+/// Read from Kafka and write to a Kafka sink configured with `compression: gzip`.
+/// Exercises the non-default producer codec end-to-end: a successful
+/// produce-then-consume round-trip proves gzip-encoded messages are written and
+/// readable — the codec needed for brokers that reject the default lz4.
+#[tokio::test]
+async fn test_kafka_sink_gzip_compression() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("Failed to create test context");
+
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+
+    let output_topic = ctx
+        .create_kafka_topic("output")
+        .await
+        .expect("Failed to create output topic");
+
+    let records_to_produce = 50;
+    let records: Vec<TestRecord> = (1..=records_to_produce)
+        .map(|i| TestRecord {
+            id: i,
+            value: format!("value_{}", i),
+            timestamp: 1000 + i,
+        })
+        .collect();
+
+    ctx.kafka
+        .produce_avro_records(&records)
+        .await
+        .expect("Failed to produce records");
+
+    let pipeline = format!(
+        r#"
+sources:
+  kafka_source:
+    type: kafka
+    topic: {input_topic}
+    starting_offsets: earliest
+    primary_key: id
+
+transforms: {{}}
+
+sinks:
+  kafka_sink:
+    type: kafka
+    from: kafka_source
+    topic: {output_topic}
+    topic_partitions: 1
+    data_format: avro
+    compression: gzip
+"#,
+        input_topic = ctx.kafka_topic,
+        output_topic = output_topic.topic,
+    );
+
+    let status = ctx
+        .run_pipeline(&pipeline, records_to_produce as u64)
+        .await
+        .expect("Streamling execution failed");
+
+    assert!(status.success(), "Streamling should exit successfully");
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let messages = ctx
+        .consume_kafka_messages(&output_topic.topic, records_to_produce as usize + 10)
+        .await
+        .expect("Failed to consume gzip-compressed messages from output topic");
+
+    assert!(
+        messages.len() >= records_to_produce as usize,
+        "Expected at least {} gzip-compressed messages in output topic, got {}",
+        records_to_produce,
+        messages.len()
+    );
+}
+
+// ============================================================================
 // Scenario 2: Multiple batches through Kafka sink
 // ============================================================================
 

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -1773,6 +1773,7 @@ impl Streamling {
                         batch_flush_interval_ms,
                         kafka_sink.message_max_bytes,
                         kafka_sink.parallelism,
+                        kafka_sink.compression,
                         sink_telemetry.clone(),
                     ));
                     session_manager


### PR DESCRIPTION
## What

Adds an optional `compression` field to the Kafka sink, accepting `none`, `gzip`, or `lz4`. Defaults to `lz4`, which is the codec the producer has always used — so existing pipelines are unaffected.

```yaml
sinks:
  my_sink:
    type: kafka
    from: my_source
    topic: my.topic
    data_format: avro
    compression: gzip   # new; defaults to lz4 when omitted
```

## Why

The producer's compression codec was hardcoded to `lz4`. Some Kafka-compatible brokers don't accept it: Azure Event Hubs' Kafka endpoint, for example, supports only `gzip` or no compression and rejects lz4. There was no way to change the codec from pipeline config, so those brokers were unusable as a Kafka sink.

## How

- New `KafkaCompression` enum in `streamling-config` with a validating deserializer (rejects unknown codecs at config load with a clear message), mirroring the existing `ClickHouseCompression` pattern.
- Threaded through the topology `KafkaSink` → `KafkaSinkTableProvider` → `KafkaSink` connector.
- `compression.type` is set on the producer *after* the optimizer defaults, so the per-sink value takes precedence over the optimizer's `lz4`. Producer config assembly was extracted into `build_producer_config` so it can be unit-tested without opening a connection.

## Testing

- Unit: enum parsing (codecs, case-insensitivity, default, rejection); topology parsing; `build_producer_config` asserts the codec reaches the producer and overrides the optimizer default.
- E2E (`test_kafka_sink_gzip_compression`): produce → run with `compression: gzip` → consume, verifying gzip messages round-trip. All `test_kafka_sink_*` e2e tests pass locally against k3d Redpanda (6/6).
- `just fix && just lint` clean.

## Assumptions & unknowns (for reviewers)

- **Codec scope:** intentionally limited to `none`/`gzip`/`lz4`. These are always linked by librdkafka. `snappy`/`zstd` are omitted for now — `zstd` needs libzstd linked at build time, which I haven't verified. Easy to add later behind the same enum.
- **Not validated against a real Azure Event Hubs broker** — only local Redpanda. The compression mismatch is fixed, but EH has other constraints (e.g. message size limits, idempotence/`acks` behavior) that are out of scope here and unverified.
