### PR TITLE
feat: continuous file source

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Streamling is a columnar streaming runtime easily extendable with your own opera
 
 You can write plugins for what's specific to your domain: polling a partner API, enriching from Postgres, pushing to your warehouse. Reuse them across pipelines by id. A plugin runs at native speed, and the runtime gives it the same guarantees the built-in connectors get: backpressure, checkpoint-coordinated at-least-once delivery, schema validation, and upsert (`_gs_op`) propagation.
 
-Built-in connectors for Kafka, Postgres, ClickHouse, and webhooks cover the common movement patterns, so you only write code for the parts that are yours.
+Built-in connectors for Kafka, Postgres, ClickHouse, files, and webhooks cover the common movement patterns, so you only write code for the parts that are yours.
 
 Built with Rust, Apache Arrow, and Apache DataFusion. Install with one command (see [Quick start](#quick-start)) or read more at [streamling.dev](https://streamling.dev).
 
@@ -39,7 +39,7 @@ The division of labor: you own the logic, the runtime owns correctness.
 - **Run ongoing data processes** over continuous ordered inputs: event streams, database changelogs, polled APIs, or any plugin source that emits data over time
 - **Build multi-stage flows on one columnar data plane**: plugins, SQL, WASM, HTTP enrichment, and [dynamic tables](#dynamic-tables) chained in a single topology, all exchanging Arrow `RecordBatch`es
 - **Get at-least-once delivery** with checkpoint-coordinated commit ordering: sources don't advance until sinks have durably flushed
-- **Use built-in connectors as conveniences**: Kafka, Postgres, ClickHouse, and webhooks for common data movement, no plugin required
+- **Use built-in connectors as conveniences**: Kafka, Postgres, ClickHouse, files, and webhooks for common data movement, no plugin required
 - **Run bounded batch jobs** and handle upserts (INSERT/UPDATE/DELETE via `_gs_op`) into Postgres or ClickHouse
 
 Use Streamling when you need a streaming engine to process continuously arriving data in order through a defined pipeline, not a distributed shuffle or windowed aggregation engine.
@@ -451,6 +451,58 @@ sources:
 | `STREAMLING__CLICKHOUSE_SOURCE__PASSWORD` | _(empty)_ | Password |
 | `STREAMLING__CLICKHOUSE_SOURCE__DATABASE` | `default` | Database name |
 | `STREAMLING__CLICKHOUSE_SOURCE__PAGE_SIZE` | `10000000` | Rows fetched per pagination chunk |
+
+#### File Source
+
+Reads files from a local path or object store (`s3://`, `gs://`) into the pipeline. Formats: `csv`, `json` (newline-delimited / NDJSON — aliases `ndjson`, `jsonl`), `parquet`, `avro`. The schema is inferred at startup. Because file reads are append-only, a constant `_gs_op = 'i'` column is synthesized when the data doesn't already carry one.
+
+**Layouts** — all of the following work in both modes below:
+
+- flat directories,
+- plain nested subfolders (read recursively),
+- Hive-style partition directories (`…/dt=2024-01-01/`), whose `key=value` columns (e.g. `dt`) are inferred and added to the schema.
+
+The `mode` field selects between two modes (default **continuous**):
+
+**Bounded** — lists the matching files once at startup, reads them to EOF, and the pipeline terminates on its own (so it works with `STREAMLING__JOB_MODE=true`).
+
+```yaml
+sources:
+  events:
+    type: file
+    path: s3://my-bucket/events/
+    format: parquet
+    primary_key: id
+    mode:
+      type: bounded
+```
+
+**Continuous** (default) — keeps polling `path` every `poll_interval`, ingesting newly-arrived files; never self-terminates.
+
+```yaml
+sources:
+  events:
+    type: file
+    path: /data/events/
+    format: csv
+    primary_key: id
+    mode:
+      type: continuous
+      poll_interval: 10s   # optional; defaults to 5s
+```
+
+**Discovery semantics & caveats (continuous mode).** Discovery is **polling-based** and tracked with a **scalar `last_modified` watermark** plus a small set of paths already ingested at that exact timestamp. Understand these limits before relying on it:
+
+- Each poll lists the path and ingests every file whose object `last_modified` is **greater than** the watermark, plus any file **sharing the watermark's exact timestamp** that hasn't been ingested yet — so new files landing in the same second the watermark sits on are not lost (common with second-granularity object-store mtimes). The watermark then advances to the newest `last_modified` seen, and its boundary set resets when a newer timestamp appears.
+- **Files with an older timestamp can be missed.** Any file that becomes visible with a `last_modified` **strictly below** the current watermark is skipped permanently — there is no per-file bookkeeping below the boundary.
+- **Updated files are reprocessed.** A rewritten file is re-ingested if its new `last_modified` reaches or exceeds the watermark. Reprocessed rows are emitted as inserts (`_gs_op = 'i'`) at the moment.
+- **Deletions are not detected** — removing a file has no effect on already-ingested data.
+- **At-least-once across restarts.** The watermark (and its boundary set) is persisted to the state backend only on a checkpoint **finalize** (mirroring the Kafka source). On restart the source reloads the last finalized watermark and re-reads any files from polls that had not finalized, so downstream may see duplicates (deduplicated by `primary_key` + an upsert sink).
+- Idle polls emit empty heartbeat batches so checkpoint markers keep propagating even when no new files arrive.
+
+For guaranteed no-miss discovery, ensure new data always lands as immutable, newly-named files whose `last_modified` never goes backwards (atomic writes), or use **bounded** mode for one-shot reads.
+
+**Credentials** for `s3://` / `gs://` come from the standard environment (`AWS_*`, `GOOGLE_APPLICATION_CREDENTIALS`, etc.) — there are no `STREAMLING__` overrides for the file source, and only `s3`/`s3a`/`gs` remote schemes are supported.
 
 ### Transforms
 

--- a/crates/streamling-connectors/src/table_providers/file.rs
+++ b/crates/streamling-connectors/src/table_providers/file.rs
@@ -18,7 +18,7 @@
 //! column to match what downstream consumers expect.
 
 use std::any::Any;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
 use std::time::Duration;
@@ -248,12 +248,19 @@ pub async fn build_bounded_file_source_provider(
     Ok(Arc::new(ViewTable::new(plan, None)))
 }
 
-/// Persisted discovery position for the continuous file source: the maximum
-/// object `last_modified` (epoch milliseconds) already ingested. Files with a
-/// greater `last_modified` are (re)processed on the next poll.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+/// Persisted discovery position for the continuous file source.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct FileWatermark {
+    /// Maximum object `last_modified` (epoch milliseconds) already ingested.
     pub last_modified_ms: i64,
+    /// Paths of files already ingested whose `last_modified` equals
+    /// `last_modified_ms`. New files that share that boundary timestamp (common
+    /// with second-granularity object-store mtimes) are still picked up, while the
+    /// ones already done are not reprocessed. Bounded by the number of files
+    /// sharing the latest timestamp; it resets whenever a newer file advances the
+    /// watermark.
+    #[serde(default)]
+    pub boundary_paths: Vec<String>,
 }
 
 fn watermark_state_key(reference_name: &str) -> StateKey {
@@ -261,14 +268,39 @@ fn watermark_state_key(reference_name: &str) -> StateKey {
 }
 
 /// Whether a listed object should be ingested: it must carry the format's
-/// extension and be newer than the watermark.
+/// extension and either be newer than the watermark, or share the watermark's
+/// timestamp without having been ingested already. The boundary case keeps new
+/// files that land at the exact watermark second (common with second-granularity
+/// object-store mtimes) from being missed.
 fn should_process(
     location_extension: Option<&str>,
-    last_modified_ms: i64,
     file_extension: &str,
+    last_modified_ms: i64,
     watermark_ms: i64,
+    already_ingested_at_boundary: bool,
 ) -> bool {
-    location_extension == Some(file_extension) && last_modified_ms > watermark_ms
+    if location_extension != Some(file_extension) {
+        return false;
+    }
+    last_modified_ms > watermark_ms
+        || (last_modified_ms == watermark_ms && !already_ingested_at_boundary)
+}
+
+/// Advances the watermark after a poll's files are ingested. `new_boundary` are
+/// the paths ingested at `max_seen`. When `max_seen` matches the current second (a
+/// boundary), the boundary set is unioned so future files at that timestamp are
+/// still picked up; when it advances, the watermark and boundary set reset.
+fn advance_watermark(watermark: &mut FileWatermark, max_seen: i64, new_boundary: Vec<String>) {
+    if max_seen == watermark.last_modified_ms {
+        let mut combined: HashSet<String> = std::mem::take(&mut watermark.boundary_paths)
+            .into_iter()
+            .collect();
+        combined.extend(new_boundary);
+        watermark.boundary_paths = combined.into_iter().collect();
+    } else {
+        watermark.last_modified_ms = max_seen;
+        watermark.boundary_paths = new_boundary;
+    }
 }
 
 /// Number of discovered files sampled to detect the Hive partition layout.
@@ -699,6 +731,7 @@ impl ExecutionPlan for FileSourceExec {
                 .map_err(to_df_err)?
                 .unwrap_or(FileWatermark {
                     last_modified_ms: i64::MIN,
+                    boundary_paths: Vec::new(),
                 });
             let mut total_emitted: u64 = 0;
             let mut checkpoint_buffer: Vec<CheckpointMessage> = Vec::new();
@@ -724,7 +757,7 @@ impl ExecutionPlan for FileSourceExec {
                 // restart re-reads at most this poll's files. Mirrors Kafka.
                 let mut source_complete = drain_checkpoints(
                     &checkpoint_receiver,
-                    watermark,
+                    &watermark,
                     &mut pending_watermarks,
                     &state_backend,
                     &state_key,
@@ -732,17 +765,25 @@ impl ExecutionPlan for FileSourceExec {
                 )
                 .await?;
 
+                // Files already ingested at the current watermark second, so new
+                // files sharing that timestamp are still picked up without
+                // reprocessing the done ones.
+                let boundary: HashSet<String> = watermark.boundary_paths.iter().cloned().collect();
                 let mut new_files: Vec<PartitionedFile> = Vec::new();
                 let mut max_seen = watermark.last_modified_ms;
                 let mut listing = object_store.list(Some(table_url.prefix()));
                 while let Some(meta) = listing.next().await {
                     let meta = meta?;
                     let last_modified_ms = meta.last_modified.timestamp_millis();
+                    let already_ingested_at_boundary = last_modified_ms
+                        == watermark.last_modified_ms
+                        && boundary.contains(meta.location.as_ref());
                     if !should_process(
                         meta.location.extension(),
-                        last_modified_ms,
                         &file_extension,
+                        last_modified_ms,
                         watermark.last_modified_ms,
+                        already_ingested_at_boundary,
                     ) {
                         debug!(
                             "Skipping file {}, last modified at {}",
@@ -773,6 +814,16 @@ impl ExecutionPlan for FileSourceExec {
                 }
 
                 if !new_files.is_empty() {
+                    // The new boundary set: paths ingested this poll at the newest
+                    // timestamp. Computed before `new_files` is moved below.
+                    let new_boundary: Vec<String> = new_files
+                        .iter()
+                        .filter(|file| {
+                            file.object_meta.last_modified.timestamp_millis() == max_seen
+                        })
+                        .map(|file| file.object_meta.location.as_ref().to_string())
+                        .collect();
+
                     let config = FileScanConfigBuilder::new(
                         object_store_url.clone(),
                         file_schema.clone(),
@@ -790,7 +841,7 @@ impl ExecutionPlan for FileSourceExec {
                         // waiting for the whole file group, which can take a while.
                         source_complete |= drain_checkpoints(
                             &checkpoint_receiver,
-                            watermark,
+                            &watermark,
                             &mut pending_watermarks,
                             &state_backend,
                             &state_key,
@@ -821,11 +872,11 @@ impl ExecutionPlan for FileSourceExec {
                         }
                     }
 
-                    // Advance the in-memory watermark so files aren't re-read
-                    // within this run. Durable persistence happens only on a
-                    // checkpoint finalize (see the drain above), mirroring the
-                    // Kafka source's commit-on-finalize.
-                    watermark.last_modified_ms = max_seen;
+                    // Advance the in-memory watermark so files aren't re-read within
+                    // this run. Durable persistence happens only on a checkpoint
+                    // finalize (see the drain above), mirroring the Kafka source's
+                    // commit-on-finalize.
+                    advance_watermark(&mut watermark, max_seen, new_boundary);
                 } else {
                     debug!("No new files to process");
                     // Heartbeat: on an idle poll (no new files), emit an empty batch
@@ -934,25 +985,25 @@ fn enrich_with_checkpoints(batch: RecordBatch, messages: &[CheckpointMessage]) -
 /// here (they still propagate downstream via batch metadata).
 async fn handle_checkpoint_message(
     message: &CheckpointMessage,
-    watermark: FileWatermark,
+    watermark: &FileWatermark,
     pending_watermarks: &mut BTreeMap<CheckpointEpoch, FileWatermark>,
     state_backend: &Arc<dyn StateOperatorBackend<FileWatermark>>,
     state_key: &StateKey,
 ) -> DataFusionResult<bool> {
     match message {
         CheckpointMessage::Marker { epoch, .. } => {
-            pending_watermarks.insert(epoch.clone(), watermark);
+            pending_watermarks.insert(epoch.clone(), watermark.clone());
         }
         CheckpointMessage::Finalizer(epoch) => {
             if let Some(snapshot) = pending_watermarks.remove(epoch) {
+                debug!(
+                    "Persisting watermark {:?} on finalize of epoch {:?}",
+                    snapshot, epoch
+                );
                 state_backend
                     .put(state_key.clone(), snapshot)
                     .await
                     .map_err(to_df_err)?;
-                debug!(
-                    "Persisted watermark {:?} on finalize of epoch {:?}",
-                    snapshot, epoch
-                );
             }
         }
         CheckpointMessage::SourceComplete(_) => return Ok(true),
@@ -968,7 +1019,7 @@ async fn handle_checkpoint_message(
 /// interval even while a large file group reads for a while.
 async fn drain_checkpoints(
     receiver: &crossbeam::channel::Receiver<CheckpointMessage>,
-    watermark: FileWatermark,
+    watermark: &FileWatermark,
     pending_watermarks: &mut BTreeMap<CheckpointEpoch, FileWatermark>,
     state_backend: &Arc<dyn StateOperatorBackend<FileWatermark>>,
     state_key: &StateKey,
@@ -1004,24 +1055,52 @@ mod tests {
     fn file_watermark_serde_round_trip() {
         let watermark = FileWatermark {
             last_modified_ms: 1_700_000_000_123,
+            boundary_paths: vec!["a/f1.csv".to_string(), "a/f2.csv".to_string()],
         };
         let json = serde_json::to_string(&watermark).unwrap();
         let restored: FileWatermark = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.last_modified_ms, watermark.last_modified_ms);
+        assert_eq!(restored.boundary_paths, watermark.boundary_paths);
     }
 
     #[test]
     fn should_process_requires_matching_extension() {
-        assert!(should_process(Some("parquet"), 10, "parquet", 5));
-        assert!(!should_process(Some("csv"), 10, "parquet", 5));
-        assert!(!should_process(None, 10, "parquet", 5));
+        assert!(should_process(Some("parquet"), "parquet", 10, 5, false));
+        assert!(!should_process(Some("csv"), "parquet", 10, 5, false));
+        assert!(!should_process(None, "parquet", 10, 5, false));
     }
 
     #[test]
-    fn should_process_requires_newer_than_watermark() {
-        assert!(should_process(Some("parquet"), 10, "parquet", 5));
-        assert!(!should_process(Some("parquet"), 5, "parquet", 5));
-        assert!(!should_process(Some("parquet"), 4, "parquet", 5));
+    fn should_process_handles_watermark_boundary() {
+        // Strictly newer than the watermark.
+        assert!(should_process(Some("parquet"), "parquet", 10, 5, false));
+        // Below the watermark — skipped.
+        assert!(!should_process(Some("parquet"), "parquet", 4, 5, false));
+        // At the watermark, not yet ingested — picked up (the boundary catch).
+        assert!(should_process(Some("parquet"), "parquet", 5, 5, false));
+        // At the watermark, already ingested — skipped.
+        assert!(!should_process(Some("parquet"), "parquet", 5, 5, true));
+    }
+
+    #[test]
+    fn advance_watermark_unions_at_boundary_and_resets_on_advance() {
+        let mut watermark = FileWatermark {
+            last_modified_ms: 100,
+            boundary_paths: vec!["a.csv".to_string()],
+        };
+
+        // Same second: the boundary set accumulates (so a third same-second file
+        // could still be ingested next poll), watermark unchanged.
+        advance_watermark(&mut watermark, 100, vec!["b.csv".to_string()]);
+        assert_eq!(watermark.last_modified_ms, 100);
+        let mut got = watermark.boundary_paths.clone();
+        got.sort();
+        assert_eq!(got, vec!["a.csv".to_string(), "b.csv".to_string()]);
+
+        // Newer second: watermark advances and the boundary set resets.
+        advance_watermark(&mut watermark, 200, vec!["c.csv".to_string()]);
+        assert_eq!(watermark.last_modified_ms, 200);
+        assert_eq!(watermark.boundary_paths, vec!["c.csv".to_string()]);
     }
 
     #[test]
@@ -1209,8 +1288,9 @@ mod tests {
                 epoch: CheckpointEpoch(1),
                 created_at_ms: 0,
             },
-            FileWatermark {
+            &FileWatermark {
                 last_modified_ms: 42,
+                boundary_paths: vec!["a/x.csv".to_string()],
             },
             &mut pending,
             &state_backend,
@@ -1228,8 +1308,9 @@ mod tests {
         // watermark (999) passed in here.
         handle_checkpoint_message(
             &CheckpointMessage::Finalizer(CheckpointEpoch(1)),
-            FileWatermark {
+            &FileWatermark {
                 last_modified_ms: 999,
+                boundary_paths: Vec::new(),
             },
             &mut pending,
             &state_backend,
@@ -1237,23 +1318,24 @@ mod tests {
         )
         .await
         .unwrap();
+        let persisted = state_backend.get(key.clone()).await.unwrap().unwrap();
         assert_eq!(
-            state_backend
-                .get(key.clone())
-                .await
-                .unwrap()
-                .unwrap()
-                .last_modified_ms,
-            42,
+            persisted.last_modified_ms, 42,
             "finalize must persist the snapshot captured at marker time"
+        );
+        assert_eq!(
+            persisted.boundary_paths,
+            vec!["a/x.csv".to_string()],
+            "finalize must persist the boundary set from the marker-time snapshot"
         );
         assert!(pending.is_empty());
 
         // A finalize for an unknown epoch changes nothing.
         handle_checkpoint_message(
             &CheckpointMessage::Finalizer(CheckpointEpoch(7)),
-            FileWatermark {
+            &FileWatermark {
                 last_modified_ms: 1234,
+                boundary_paths: Vec::new(),
             },
             &mut pending,
             &state_backend,
@@ -1275,8 +1357,9 @@ mod tests {
         // SourceComplete signals shutdown.
         let is_complete = handle_checkpoint_message(
             &CheckpointMessage::SourceComplete("src".to_string()),
-            FileWatermark {
+            &FileWatermark {
                 last_modified_ms: 0,
+                boundary_paths: Vec::new(),
             },
             &mut pending,
             &state_backend,

--- a/crates/streamling-connectors/src/table_providers/file.rs
+++ b/crates/streamling-connectors/src/table_providers/file.rs
@@ -77,27 +77,21 @@ fn file_format_for(format: FileSourceFormat) -> Arc<dyn FileFormat> {
 
 /// The DataFusion [`FileSource`] (per-format reader) the continuous source feeds
 /// to its runtime `FileScanConfig`.
-///
-/// CSV must be special-cased. `CsvFormat::file_source()` returns
-/// `CsvSource::default()`, whose `delimiter` and `quote` are NUL bytes
-/// (`u8::default()`) and `has_header` is `false` — a reader that finds no
-/// delimiters and so treats each whole line as a single field (yielding
-/// "incorrect number of fields" against the inferred multi-column schema). The
-/// real settings are only wired by `CsvFormat::create_physical_plan`, which the
-/// bounded `ListingTable` path goes through but a hand-built `FileScanConfig`
-/// does not. We rebuild the CSV source the same way: the `CsvFormat::default()`
-/// comma/double-quote dialect with `has_header` resolved from the catalog config,
-/// matching the startup schema inference. Other formats carry no such byte
-/// options, so their `file_source()` default is correct.
 fn file_source_for(
     format: FileSourceFormat,
     file_format: &Arc<dyn FileFormat>,
-    csv_has_header: bool,
 ) -> Arc<dyn FileSource> {
-    const CSV_DELIMITER: u8 = b',';
-    const CSV_QUOTE: u8 = b'"';
     match format {
-        FileSourceFormat::Csv => Arc::new(CsvSource::new(csv_has_header, CSV_DELIMITER, CSV_QUOTE)),
+        // CsvSource::default() has incorrect defaults, passing proper ones from CsvFormat::default()
+        FileSourceFormat::Csv => {
+            const DEFAULT_HAS_HEADER: bool = true;
+            let default_options = CsvFormat::default().options().clone();
+            Arc::new(CsvSource::new(
+                default_options.has_header.unwrap_or(DEFAULT_HAS_HEADER),
+                default_options.delimiter,
+                default_options.quote,
+            ))
+        }
         _ => file_format.file_source(),
     }
 }
@@ -374,8 +368,7 @@ impl FileSourceTableProvider {
         };
 
         let file_extension = file_format.get_ext();
-        let csv_has_header = state.config_options().catalog.has_header;
-        let file_source = file_source_for(format, &file_format, csv_has_header);
+        let file_source = file_source_for(format, &file_format);
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
         Ok(Arc::new(Self {
@@ -772,7 +765,7 @@ mod tests {
             Field::new("name", DataType::Utf8, false),
         ]));
         let file_format = file_format_for(FileSourceFormat::Csv);
-        let file_source = file_source_for(FileSourceFormat::Csv, &file_format, true);
+        let file_source = file_source_for(FileSourceFormat::Csv, &file_format);
 
         let url = ListingTableUrl::parse(format!("{}/", dir.to_str().unwrap())).unwrap();
         let object_store_url = url.object_store();

--- a/crates/streamling-connectors/src/table_providers/file.rs
+++ b/crates/streamling-connectors/src/table_providers/file.rs
@@ -603,26 +603,21 @@ impl ExecutionPlan for FileSourceExec {
                 tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).ok();
 
             loop {
-                // Drain checkpoint-coordinator messages. Each is recorded for
-                // commit-on-finalize (snapshot watermark on Marker, persist on
-                // Finalizer) and buffered to ride downstream on this poll's first
-                // emitted batch (a data batch, or the idle heartbeat), so the
-                // barrier keeps flowing even while the source is idle. The
-                // watermark snapshotted here is the pre-this-poll value, so a
-                // restart re-reads at most this poll's files. Mirrors the Kafka
-                // source.
-                let mut source_complete = false;
-                while let Ok(message) = checkpoint_receiver.try_recv() {
-                    source_complete |= handle_checkpoint_message(
-                        &message,
-                        watermark,
-                        &mut pending_watermarks,
-                        &state_backend,
-                        &state_key,
-                    )
-                    .await?;
-                    checkpoint_buffer.push(message);
-                }
+                // Drain coordinator messages that arrived during the sleep. Each
+                // is recorded for commit-on-finalize (snapshot watermark on
+                // Marker, persist on Finalizer) and buffered to ride downstream on
+                // the next emitted batch (a data batch, or the idle heartbeat).
+                // The watermark snapshotted here is the pre-this-poll value, so a
+                // restart re-reads at most this poll's files. Mirrors Kafka.
+                let mut source_complete = drain_checkpoints(
+                    &checkpoint_receiver,
+                    watermark,
+                    &mut pending_watermarks,
+                    &state_backend,
+                    &state_key,
+                    &mut checkpoint_buffer,
+                )
+                .await?;
 
                 let mut new_files: Vec<PartitionedFile> = Vec::new();
                 let mut max_seen = watermark.last_modified_ms;
@@ -657,28 +652,38 @@ impl ExecutionPlan for FileSourceExec {
 
                     let mut stream =
                         DataSourceExec::from_data_source(config).execute(0, context.clone())?;
-                    let mut checkpoints_attached = false;
                     while let Some(batch) = stream.next().await {
-                        let mut batch = build_output_batch(
-                            batch?,
-                            append_op,
-                            &full_schema,
-                            projection.as_ref(),
-                        )?;
-                        // Attach the drained checkpoint messages to this poll's
-                        // first emitted batch.
-                        if !checkpoints_attached {
-                            batch = enrich_with_checkpoints(batch, &checkpoint_buffer);
-                            checkpoint_buffer.clear();
-                            checkpoints_attached = true;
-                        }
+                        // Drain again before every batch so markers arriving mid-read
+                        // ride the next batch (within one batch interval) instead of
+                        // waiting for the whole file group, which can take a while.
+                        source_complete |= drain_checkpoints(
+                            &checkpoint_receiver,
+                            watermark,
+                            &mut pending_watermarks,
+                            &state_backend,
+                            &state_key,
+                            &mut checkpoint_buffer,
+                        )
+                        .await?;
+
+                        let batch = enrich_with_checkpoints(
+                            build_output_batch(
+                                batch?,
+                                append_op,
+                                &full_schema,
+                                projection.as_ref(),
+                            )?,
+                            &checkpoint_buffer,
+                        );
+                        checkpoint_buffer.clear();
+
                         let rows = batch.num_rows() as u64;
                         if tx.send(Ok(batch)).await.is_err() {
                             return Ok(());
                         }
                         total_emitted += rows;
-                        if let Some(limit) = num_records_before_stop
-                            && total_emitted >= limit
+                        if source_complete
+                            || num_records_before_stop.is_some_and(|limit| total_emitted >= limit)
                         {
                             return Ok(());
                         }
@@ -822,6 +827,34 @@ async fn handle_checkpoint_message(
         CheckpointMessage::Ack { .. } => {}
     }
     Ok(false)
+}
+
+/// Drains all currently-available coordinator messages, recording each (snapshot
+/// on `Marker`, persist on `Finalizer`) and buffering it for downstream
+/// enrichment. Returns whether a `SourceComplete` was seen. Called both between
+/// polls and before every emitted batch, so markers propagate within one batch
+/// interval even while a large file group reads for a while.
+async fn drain_checkpoints(
+    receiver: &crossbeam::channel::Receiver<CheckpointMessage>,
+    watermark: FileWatermark,
+    pending_watermarks: &mut BTreeMap<CheckpointEpoch, FileWatermark>,
+    state_backend: &Arc<dyn StateOperatorBackend<FileWatermark>>,
+    state_key: &StateKey,
+    buffer: &mut Vec<CheckpointMessage>,
+) -> DataFusionResult<bool> {
+    let mut source_complete = false;
+    while let Ok(message) = receiver.try_recv() {
+        source_complete |= handle_checkpoint_message(
+            &message,
+            watermark,
+            pending_watermarks,
+            state_backend,
+            state_key,
+        )
+        .await?;
+        buffer.push(message);
+    }
+    Ok(source_complete)
 }
 
 fn to_df_err<E>(e: E) -> DataFusionError

--- a/crates/streamling-connectors/src/table_providers/file.rs
+++ b/crates/streamling-connectors/src/table_providers/file.rs
@@ -18,6 +18,7 @@
 //! column to match what downstream consumers expect.
 
 use std::any::Any;
+use std::collections::BTreeMap;
 use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
 use std::time::Duration;
@@ -57,6 +58,11 @@ use tokio::sync::watch;
 use tokio::time::sleep;
 use tracing::{debug, info};
 
+use streamling_core::checkpoints::channels::subscribe;
+use streamling_core::checkpoints::checkpoint_management::{
+    CHECKPOINT_COORDINATOR_CHANNEL, CheckpointEpoch, CheckpointMessage,
+    enrich_batch_metadata_with_checkpoints,
+};
 use streamling_core::data::{COLUMN_NAME_OP, RowKind};
 use streamling_core::error::Result;
 use streamling_core::session::SessionManager;
@@ -557,6 +563,7 @@ impl ExecutionPlan for FileSourceExec {
         let file_extension = self.file_extension.clone();
         let file_schema = self.file_schema.clone();
         let full_schema = self.full_schema.clone();
+        let output_schema = self.output_schema.clone();
         let append_op = self.append_op;
         let projection = self.projection.clone();
         let poll_interval = self.poll_interval;
@@ -564,6 +571,10 @@ impl ExecutionPlan for FileSourceExec {
         let state_key = watermark_state_key(&self.reference_name);
         let num_records_before_stop = self.num_records_before_stop;
         let mut shutdown_rx = self.shutdown_rx.clone();
+
+        // Subscribe synchronously, before the stream is returned, so no
+        // coordinator message is missed; the receiver is drained each poll.
+        let checkpoint_receiver = subscribe(CHECKPOINT_COORDINATOR_CHANNEL);
 
         builder.spawn(async move {
             let object_store_url = table_url.object_store();
@@ -577,6 +588,10 @@ impl ExecutionPlan for FileSourceExec {
                     last_modified_ms: i64::MIN,
                 });
             let mut total_emitted: u64 = 0;
+            let mut checkpoint_buffer: Vec<CheckpointMessage> = Vec::new();
+            // Watermark snapshot per in-flight checkpoint epoch (taken at marker
+            // time), persisted only when that epoch is finalized.
+            let mut pending_watermarks: BTreeMap<CheckpointEpoch, FileWatermark> = BTreeMap::new();
 
             debug!("Current watermark: {:?}", watermark);
 
@@ -588,6 +603,27 @@ impl ExecutionPlan for FileSourceExec {
                 tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).ok();
 
             loop {
+                // Drain checkpoint-coordinator messages. Each is recorded for
+                // commit-on-finalize (snapshot watermark on Marker, persist on
+                // Finalizer) and buffered to ride downstream on this poll's first
+                // emitted batch (a data batch, or the idle heartbeat), so the
+                // barrier keeps flowing even while the source is idle. The
+                // watermark snapshotted here is the pre-this-poll value, so a
+                // restart re-reads at most this poll's files. Mirrors the Kafka
+                // source.
+                let mut source_complete = false;
+                while let Ok(message) = checkpoint_receiver.try_recv() {
+                    source_complete |= handle_checkpoint_message(
+                        &message,
+                        watermark,
+                        &mut pending_watermarks,
+                        &state_backend,
+                        &state_key,
+                    )
+                    .await?;
+                    checkpoint_buffer.push(message);
+                }
+
                 let mut new_files: Vec<PartitionedFile> = Vec::new();
                 let mut max_seen = watermark.last_modified_ms;
                 let mut listing = object_store.list(Some(table_url.prefix()));
@@ -621,13 +657,21 @@ impl ExecutionPlan for FileSourceExec {
 
                     let mut stream =
                         DataSourceExec::from_data_source(config).execute(0, context.clone())?;
+                    let mut checkpoints_attached = false;
                     while let Some(batch) = stream.next().await {
-                        let batch = build_output_batch(
+                        let mut batch = build_output_batch(
                             batch?,
                             append_op,
                             &full_schema,
                             projection.as_ref(),
                         )?;
+                        // Attach the drained checkpoint messages to this poll's
+                        // first emitted batch.
+                        if !checkpoints_attached {
+                            batch = enrich_with_checkpoints(batch, &checkpoint_buffer);
+                            checkpoint_buffer.clear();
+                            checkpoints_attached = true;
+                        }
                         let rows = batch.num_rows() as u64;
                         if tx.send(Ok(batch)).await.is_err() {
                             return Ok(());
@@ -640,13 +684,33 @@ impl ExecutionPlan for FileSourceExec {
                         }
                     }
 
+                    // Advance the in-memory watermark so files aren't re-read
+                    // within this run. Durable persistence happens only on a
+                    // checkpoint finalize (see the drain above), mirroring the
+                    // Kafka source's commit-on-finalize.
                     watermark.last_modified_ms = max_seen;
-                    state_backend
-                        .put(state_key.clone(), watermark)
-                        .await
-                        .map_err(to_df_err)?;
                 } else {
                     debug!("No new files to process");
+                    // Heartbeat: on an idle poll (no new files), emit an empty batch
+                    // — carrying any drained checkpoint messages — so downstream
+                    // operators keep advancing (checkpoints, liveness, time-based
+                    // logic) while the source has no data to forward.
+                    let heartbeat = enrich_with_checkpoints(
+                        RecordBatch::new_empty(output_schema.clone()),
+                        &checkpoint_buffer,
+                    );
+                    checkpoint_buffer.clear();
+                    if tx.send(Ok(heartbeat)).await.is_err() {
+                        return Ok(());
+                    }
+                }
+
+                if source_complete {
+                    debug!(
+                        "[{}] file source received SourceComplete; shutting down",
+                        reference_name
+                    );
+                    return Ok(());
                 }
 
                 tokio::select! {
@@ -709,6 +773,57 @@ fn build_output_batch(
     }
 }
 
+/// Attaches pending checkpoint-coordinator messages to a batch's schema metadata
+/// so the checkpoint barrier propagates downstream (mirrors the Kafka source).
+/// A no-op when there are no messages.
+fn enrich_with_checkpoints(batch: RecordBatch, messages: &[CheckpointMessage]) -> RecordBatch {
+    if messages.is_empty() {
+        return batch;
+    }
+    let mut metadata = batch.schema().metadata().clone();
+    enrich_batch_metadata_with_checkpoints(&mut metadata, messages);
+    let schema = Arc::new(Schema::new_with_metadata(
+        batch.schema().fields().clone(),
+        metadata,
+    ));
+    RecordBatch::try_new(schema, batch.columns().to_vec()).unwrap_or(batch)
+}
+
+/// Handles one drained checkpoint message, mirroring the Kafka source's
+/// commit-on-finalize: a `Marker` snapshots the current watermark for its epoch,
+/// and a `Finalizer` durably persists the matching snapshot (the value captured
+/// at marker time, not the now-advanced watermark) and drops it. Returns `true`
+/// for `SourceComplete` so the caller can shut down. Other messages are no-ops
+/// here (they still propagate downstream via batch metadata).
+async fn handle_checkpoint_message(
+    message: &CheckpointMessage,
+    watermark: FileWatermark,
+    pending_watermarks: &mut BTreeMap<CheckpointEpoch, FileWatermark>,
+    state_backend: &Arc<dyn StateOperatorBackend<FileWatermark>>,
+    state_key: &StateKey,
+) -> DataFusionResult<bool> {
+    match message {
+        CheckpointMessage::Marker { epoch, .. } => {
+            pending_watermarks.insert(epoch.clone(), watermark);
+        }
+        CheckpointMessage::Finalizer(epoch) => {
+            if let Some(snapshot) = pending_watermarks.remove(epoch) {
+                state_backend
+                    .put(state_key.clone(), snapshot)
+                    .await
+                    .map_err(to_df_err)?;
+                debug!(
+                    "Persisted watermark {:?} on finalize of epoch {:?}",
+                    snapshot, epoch
+                );
+            }
+        }
+        CheckpointMessage::SourceComplete(_) => return Ok(true),
+        CheckpointMessage::Ack { .. } => {}
+    }
+    Ok(false)
+}
+
 fn to_df_err<E>(e: E) -> DataFusionError
 where
     E: std::error::Error + Send + Sync + 'static,
@@ -744,63 +859,199 @@ mod tests {
         assert!(!should_process(Some("parquet"), 4, "parquet", 5));
     }
 
-    /// Regression for the NUL-delimiter bug: building the runtime `FileScanConfig`
-    /// with `CsvFormat::file_source()` (`CsvSource::default`) splits on a NUL byte,
-    /// so every line collapses to a single field and the read fails with
-    /// "incorrect number of fields". `file_source_for` must wire the comma
-    /// delimiter and header-skipping instead.
+    /// The continuous source must emit an empty `RecordBatch` on every poll — even
+    /// when no new files were discovered — so downstream operators keep advancing
+    /// while the source is idle.
     #[tokio::test]
-    async fn continuous_csv_reads_comma_delimited_rows() {
-        use datafusion::arrow::array::Array;
-        use datafusion::physical_plan::collect;
-        use datafusion::prelude::SessionContext;
+    async fn continuous_source_emits_empty_heartbeat_when_idle() {
+        use std::time::Duration;
+        use streamling_core::dynamic_table::DynamicTableRegistry;
+        use streamling_state::StateOperatorBackendFactory;
+        use streamling_state::in_memory::InMemoryStateOperatorBackendFactory;
+        use tokio::time::timeout;
 
-        let dir = std::env::temp_dir().join(format!("streamling_csv_src_{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("streamling_heartbeat_{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("1.csv"), "id,name\n1,alice\n2,bob\n3,carol").unwrap();
 
-        let file_schema = Arc::new(Schema::new(vec![
-            Field::new("id", DataType::Utf8, false),
-            Field::new("name", DataType::Utf8, false),
-        ]));
-        let file_format = file_format_for(FileSourceFormat::Csv);
-        let file_source = file_source_for(FileSourceFormat::Csv, &file_format);
+        let session_manager = SessionManager::new(100, 10, DynamicTableRegistry::new()).unwrap();
+        let state_backend = InMemoryStateOperatorBackendFactory::new()
+            .unwrap()
+            .create::<FileWatermark>("heartbeat_test");
 
-        let url = ListingTableUrl::parse(format!("{}/", dir.to_str().unwrap())).unwrap();
-        let object_store_url = url.object_store();
+        let provider = FileSourceTableProvider::try_new(
+            "heartbeat_src",
+            &format!("{}/", dir.to_str().unwrap()),
+            FileSourceFormat::Csv,
+            Duration::from_millis(100),
+            &session_manager,
+            state_backend,
+            None,
+            10,
+        )
+        .await
+        .unwrap();
 
-        let ctx = SessionContext::new();
-        let task_ctx = ctx.task_ctx();
-        let object_store = task_ctx
-            .runtime_env()
-            .object_store(&object_store_url)
-            .unwrap();
-        let files: Vec<PartitionedFile> = object_store
-            .list(Some(url.prefix()))
-            .map(|meta| PartitionedFile::from(meta.unwrap()))
-            .collect()
-            .await;
-
-        let config = FileScanConfigBuilder::new(object_store_url, file_schema, file_source)
-            .with_file_group(FileGroup::new(files))
-            .build();
-        let batches = collect(DataSourceExec::from_data_source(config), task_ctx)
+        let plan = provider
+            .scan(&session_manager.session_state(), None, &[], None)
             .await
             .unwrap();
+        let mut stream = plan
+            .execute(0, session_manager.session_context().task_ctx())
+            .unwrap();
+
+        // The first poll reads the file once (3 rows); each subsequent idle poll
+        // emits an empty heartbeat. Collecting several items spans multiple polls.
+        let mut data_rows = 0usize;
+        let mut empty_batches = 0usize;
+        for _ in 0..5 {
+            let batch = timeout(Duration::from_secs(5), stream.next())
+                .await
+                .expect("stream should yield within timeout")
+                .expect("stream should not end")
+                .unwrap();
+            if batch.num_rows() == 0 {
+                empty_batches += 1;
+            } else {
+                data_rows += batch.num_rows();
+            }
+        }
         let _ = std::fs::remove_dir_all(&dir);
 
-        let names: Vec<String> = batches
-            .iter()
-            .flat_map(|batch| {
-                let column = batch.column_by_name("name").unwrap();
-                let array = column.as_any().downcast_ref::<StringArray>().unwrap();
-                (0..array.len())
-                    .map(|i| array.value(i).to_string())
-                    .collect::<Vec<_>>()
-            })
-            .collect();
-        // Header skipped (3 rows, not 4) and fields split on the comma.
-        assert_eq!(names, vec!["alice", "bob", "carol"]);
+        assert_eq!(data_rows, 3, "the file's 3 rows are read exactly once");
+        assert!(
+            empty_batches >= 2,
+            "idle polls must emit empty heartbeat batches; got {empty_batches}"
+        );
+    }
+
+    /// Checkpoint messages drained from the coordinator are attached to a batch's
+    /// schema metadata so the barrier propagates downstream (recoverable via
+    /// `extract_checkpoint_messages`); an empty set is a no-op.
+    #[test]
+    fn enrich_with_checkpoints_attaches_marker_metadata() {
+        use streamling_core::checkpoints::checkpoint_management::{
+            CheckpointEpoch, extract_checkpoint_messages,
+        };
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, false)]));
+
+        let enriched = enrich_with_checkpoints(
+            RecordBatch::new_empty(schema.clone()),
+            &[CheckpointMessage::Marker {
+                epoch: CheckpointEpoch(3),
+                created_at_ms: 100,
+            }],
+        );
+        let extracted = extract_checkpoint_messages(enriched.schema().metadata());
+        assert!(
+            matches!(
+                extracted.as_slice(),
+                [CheckpointMessage::Marker { epoch, .. }] if epoch.0 == 3
+            ),
+            "marker should be recoverable from batch metadata; got {extracted:?}"
+        );
+
+        let untouched = enrich_with_checkpoints(RecordBatch::new_empty(schema), &[]);
+        assert!(extract_checkpoint_messages(untouched.schema().metadata()).is_empty());
+    }
+
+    /// The watermark is persisted only on a checkpoint finalize, and the value
+    /// persisted is the snapshot captured at marker time (not the now-advanced
+    /// watermark) — mirroring the Kafka source's commit-on-finalize.
+    #[tokio::test]
+    async fn persists_watermark_only_on_finalize() {
+        use streamling_state::StateOperatorBackendFactory;
+        use streamling_state::in_memory::InMemoryStateOperatorBackendFactory;
+
+        let state_backend = InMemoryStateOperatorBackendFactory::new()
+            .unwrap()
+            .create::<FileWatermark>("ns");
+        let key = watermark_state_key("src");
+        let mut pending: BTreeMap<CheckpointEpoch, FileWatermark> = BTreeMap::new();
+
+        // A marker snapshots the current watermark but persists nothing.
+        let is_complete = handle_checkpoint_message(
+            &CheckpointMessage::Marker {
+                epoch: CheckpointEpoch(1),
+                created_at_ms: 0,
+            },
+            FileWatermark {
+                last_modified_ms: 42,
+            },
+            &mut pending,
+            &state_backend,
+            &key,
+        )
+        .await
+        .unwrap();
+        assert!(!is_complete);
+        assert!(
+            state_backend.get(key.clone()).await.unwrap().is_none(),
+            "a marker must not persist the watermark"
+        );
+
+        // Finalize persists the marker-time snapshot (42), not the now-advanced
+        // watermark (999) passed in here.
+        handle_checkpoint_message(
+            &CheckpointMessage::Finalizer(CheckpointEpoch(1)),
+            FileWatermark {
+                last_modified_ms: 999,
+            },
+            &mut pending,
+            &state_backend,
+            &key,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            state_backend
+                .get(key.clone())
+                .await
+                .unwrap()
+                .unwrap()
+                .last_modified_ms,
+            42,
+            "finalize must persist the snapshot captured at marker time"
+        );
+        assert!(pending.is_empty());
+
+        // A finalize for an unknown epoch changes nothing.
+        handle_checkpoint_message(
+            &CheckpointMessage::Finalizer(CheckpointEpoch(7)),
+            FileWatermark {
+                last_modified_ms: 1234,
+            },
+            &mut pending,
+            &state_backend,
+            &key,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            state_backend
+                .get(key.clone())
+                .await
+                .unwrap()
+                .unwrap()
+                .last_modified_ms,
+            42,
+            "an unknown-epoch finalize must not change persisted state"
+        );
+
+        // SourceComplete signals shutdown.
+        let is_complete = handle_checkpoint_message(
+            &CheckpointMessage::SourceComplete("src".to_string()),
+            FileWatermark {
+                last_modified_ms: 0,
+            },
+            &mut pending,
+            &state_backend,
+            &key,
+        )
+        .await
+        .unwrap();
+        assert!(is_complete);
     }
 }

--- a/crates/streamling-connectors/src/table_providers/file.rs
+++ b/crates/streamling-connectors/src/table_providers/file.rs
@@ -1,55 +1,118 @@
-//! File source backed by DataFusion's `ListingTable`.
+//! File source backed by DataFusion's file readers.
 //!
-//! Reads files from a local path or remote object store (`s3://`, `gs://`) in a
-//! configured format, inferring the schema (and Hive-style partition columns) at
-//! startup. Because file reads are append-only, a `_gs_op = 'i'` change-operation
-//! column is synthesized when the data does not already provide one.
+//! Two modes share schema inference, object-store registration, and the
+//! `_gs_op = 'i'` change-operation contract:
+//!
+//! - **Bounded** ([`build_bounded_file_source_provider`]) wraps DataFusion's
+//!   [`ListingTable`]: it lists the matching files once at startup, reads them to
+//!   EOF (inferring the schema and Hive-style partition columns), and the job
+//!   terminates on its own.
+//! - **Continuous** ([`FileSourceTableProvider`]) keeps watching the path: a poll
+//!   loop lists the prefix every `poll_interval`, ingests files whose
+//!   `last_modified` exceeds a persisted [`FileWatermark`], and never
+//!   self-terminates.
+//!
+//! Because file reads are append-only, a constant `_gs_op = 'i'` column is
+//! synthesized when the inferred schema lacks it. Files that already carry
+//! `_gs_op` pass through unwrapped, but the column must be a non-nullable Utf8
+//! column to match what downstream consumers expect.
 
+use std::any::Any;
+use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
+use std::time::Duration;
 
-use datafusion::arrow::datatypes::DataType;
-use datafusion::common::{Column, ScalarValue};
+use async_trait::async_trait;
+use datafusion::arrow::array::{ArrayRef, RecordBatch, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::catalog::Session;
+use datafusion::common::{Column, DataFusionError, ScalarValue};
 use datafusion::datasource::file_format::FileFormat;
 use datafusion::datasource::file_format::avro::AvroFormat;
 use datafusion::datasource::file_format::csv::CsvFormat;
 use datafusion::datasource::file_format::json::JsonFormat;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::{
-    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
+    ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl, PartitionedFile,
 };
-use datafusion::datasource::{TableProvider, ViewTable, provider_as_source};
+use datafusion::datasource::physical_plan::{
+    CsvSource, FileGroup, FileScanConfigBuilder, FileSource,
+};
+use datafusion::datasource::source::DataSourceExec;
+use datafusion::datasource::{TableProvider, TableType, ViewTable, provider_as_source};
+use datafusion::error::Result as DataFusionResult;
+use datafusion::execution::TaskContext;
 use datafusion::logical_expr::{Expr, LogicalPlanBuilder, lit};
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_plan::stream::RecordBatchReceiverStreamBuilder;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+    SendableRecordBatchStream,
+    execution_plan::{Boundedness, EmissionType},
+    project_schema,
+};
+use futures::StreamExt;
+use serde_derive::{Deserialize, Serialize};
+use tokio::sync::watch;
+use tokio::time::sleep;
+use tracing::{debug, info};
 
 use streamling_core::data::{COLUMN_NAME_OP, RowKind};
 use streamling_core::error::Result;
 use streamling_core::session::SessionManager;
 use streamling_core::topology::FileSourceFormat;
 use streamling_core::{streamling_user_bail, streamling_user_err};
+use streamling_state::{StateKey, StateOperatorBackend};
 
-/// Builds the runtime provider for a `file` source backed by DataFusion's
-/// `ListingTable`. The schema is inferred from the files at startup. Because file
-/// reads are append-only, a constant `_gs_op = 'i'` column is appended (via a
-/// `ViewTable`) when the inferred schema lacks it, so the source composes with
-/// sinks that require the change-operation column. Files that already carry
-/// `_gs_op` pass through unwrapped, but the column must be a non-nullable
-/// Utf8 column to match what downstream consumers expect.
+/// Maps the source's format enum to a DataFusion [`FileFormat`]. Shared by the
+/// bounded and continuous builders.
+fn file_format_for(format: FileSourceFormat) -> Arc<dyn FileFormat> {
+    match format {
+        FileSourceFormat::Parquet => Arc::new(ParquetFormat::default()),
+        FileSourceFormat::Csv => Arc::new(CsvFormat::default()),
+        FileSourceFormat::Json => Arc::new(JsonFormat::default()),
+        FileSourceFormat::Avro => Arc::new(AvroFormat),
+    }
+}
+
+/// The DataFusion [`FileSource`] (per-format reader) the continuous source feeds
+/// to its runtime `FileScanConfig`.
 ///
-/// Supported path schemes: local paths, `s3://`, and `gs://`. Remote credentials,
-/// region, and endpoint are read from the environment by each cloud builder's
-/// `from_env()` (e.g. `AWS_*`, `GOOGLE_*`). Hive-style partition columns in the
-/// path (e.g. `…/dt=2024-01-01/`) are inferred and added to the schema.
-pub async fn build_file_source_provider(
-    reference_name: &str,
-    path: &str,
+/// CSV must be special-cased. `CsvFormat::file_source()` returns
+/// `CsvSource::default()`, whose `delimiter` and `quote` are NUL bytes
+/// (`u8::default()`) and `has_header` is `false` — a reader that finds no
+/// delimiters and so treats each whole line as a single field (yielding
+/// "incorrect number of fields" against the inferred multi-column schema). The
+/// real settings are only wired by `CsvFormat::create_physical_plan`, which the
+/// bounded `ListingTable` path goes through but a hand-built `FileScanConfig`
+/// does not. We rebuild the CSV source the same way: the `CsvFormat::default()`
+/// comma/double-quote dialect with `has_header` resolved from the catalog config,
+/// matching the startup schema inference. Other formats carry no such byte
+/// options, so their `file_source()` default is correct.
+fn file_source_for(
     format: FileSourceFormat,
-    session_manager: &SessionManager,
-) -> Result<Arc<dyn TableProvider>> {
-    let table_url = ListingTableUrl::parse(path)?;
+    file_format: &Arc<dyn FileFormat>,
+    csv_has_header: bool,
+) -> Arc<dyn FileSource> {
+    const CSV_DELIMITER: u8 = b',';
+    const CSV_QUOTE: u8 = b'"';
+    match format {
+        FileSourceFormat::Csv => Arc::new(CsvSource::new(csv_has_header, CSV_DELIMITER, CSV_QUOTE)),
+        _ => file_format.file_source(),
+    }
+}
 
-    // Local paths use the default object store; remote schemes need one
-    // registered. Each cloud builder's `from_env()` folds in credentials/region/
-    // endpoint from the environment (it lowercases keys before parsing, which the
-    // generic `parse_url` path does not — so `from_env` is required for `AWS_*`).
+/// Registers the object store for a remote path scheme on the session. Local
+/// paths use the default object store; remote schemes need one registered.
+///
+/// Each cloud builder's `from_env()` folds in credentials/region/endpoint from
+/// the environment (it lowercases keys before parsing, which the generic
+/// `parse_url` path does not — so `from_env` is required for `AWS_*`).
+fn register_object_store_for_url(
+    table_url: &ListingTableUrl,
+    path: &str,
+    session_manager: &SessionManager,
+) -> Result<()> {
     match table_url.scheme() {
         "file" => {}
         "s3" | "s3a" => {
@@ -91,13 +154,30 @@ pub async fn build_file_source_provider(
             );
         }
     }
+    Ok(())
+}
 
-    let file_format: Arc<dyn FileFormat> = match format {
-        FileSourceFormat::Parquet => Arc::new(ParquetFormat::default()),
-        FileSourceFormat::Csv => Arc::new(CsvFormat::default()),
-        FileSourceFormat::Json => Arc::new(JsonFormat::default()),
-        FileSourceFormat::Avro => Arc::new(AvroFormat),
-    };
+/// Builds the runtime provider for a **bounded** `file` source backed by
+/// DataFusion's [`ListingTable`]. The schema is inferred from the files at
+/// startup. Because file reads are append-only, a constant `_gs_op = 'i'` column
+/// is appended (via a [`ViewTable`]) when the inferred schema lacks it, so the
+/// source composes with sinks that require the change-operation column. Files
+/// that already carry `_gs_op` pass through unwrapped, but the column must be a
+/// non-nullable Utf8 column to match what downstream consumers expect.
+///
+/// Supported path schemes: local paths, `s3://`, and `gs://`. Hive-style
+/// partition columns in the path (e.g. `…/dt=2024-01-01/`) are inferred and added
+/// to the schema.
+pub async fn build_bounded_file_source_provider(
+    reference_name: &str,
+    path: &str,
+    format: FileSourceFormat,
+    session_manager: &SessionManager,
+) -> Result<Arc<dyn TableProvider>> {
+    let table_url = ListingTableUrl::parse(path)?;
+    register_object_store_for_url(&table_url, path, session_manager)?;
+
+    let file_format = file_format_for(format);
 
     let state = session_manager.session_state();
     let listing_options = ListingOptions::new(file_format);
@@ -161,4 +241,573 @@ pub async fn build_file_source_provider(
     .build()?;
 
     Ok(Arc::new(ViewTable::new(plan, None)))
+}
+
+/// Persisted discovery position for the continuous file source: the maximum
+/// object `last_modified` (epoch milliseconds) already ingested. Files with a
+/// greater `last_modified` are (re)processed on the next poll.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub struct FileWatermark {
+    pub last_modified_ms: i64,
+}
+
+fn watermark_state_key(reference_name: &str) -> StateKey {
+    StateKey::from(format!("{reference_name}:watermark"))
+}
+
+/// Whether a listed object should be ingested: it must carry the format's
+/// extension and be newer than the watermark.
+fn should_process(
+    location_extension: Option<&str>,
+    last_modified_ms: i64,
+    file_extension: &str,
+    watermark_ms: i64,
+) -> bool {
+    location_extension == Some(file_extension) && last_modified_ms > watermark_ms
+}
+
+/// Continuous (unbounded) file source. Polls `table_url` every `poll_interval`,
+/// ingesting files whose `last_modified` exceeds the persisted [`FileWatermark`],
+/// and emits their rows with a synthesized `_gs_op = 'i'` (unless the files
+/// already carry a valid `_gs_op`). Never self-terminates.
+pub struct FileSourceTableProvider {
+    reference_name: String,
+    table_url: ListingTableUrl,
+    file_source: Arc<dyn FileSource>,
+    file_extension: String,
+    /// Columns read from the files (includes `_gs_op` only if the files provide it).
+    file_schema: SchemaRef,
+    /// Published schema: `file_schema` plus a synthesized `_gs_op` when absent.
+    full_schema: SchemaRef,
+    /// Whether `_gs_op` must be synthesized (false when the files already have it).
+    append_op: bool,
+    poll_interval: Duration,
+    state_backend: Arc<dyn StateOperatorBackend<FileWatermark>>,
+    num_records_before_stop: Option<u64>,
+    internal_buffer_size: u32,
+    shutdown_rx: watch::Receiver<bool>,
+    // Kept alive so the shutdown channel stays open for `shutdown()`.
+    shutdown_tx: watch::Sender<bool>,
+}
+
+impl FileSourceTableProvider {
+    #[allow(clippy::too_many_arguments)]
+    pub async fn try_new(
+        reference_name: &str,
+        path: &str,
+        format: FileSourceFormat,
+        poll_interval: Duration,
+        session_manager: &SessionManager,
+        state_backend: Arc<dyn StateOperatorBackend<FileWatermark>>,
+        num_records_before_stop: Option<u64>,
+        internal_buffer_size: u32,
+    ) -> Result<Arc<Self>> {
+        let table_url = ListingTableUrl::parse(path)?;
+        register_object_store_for_url(&table_url, path, session_manager)?;
+
+        let file_format = file_format_for(format);
+        let state = session_manager.session_state();
+
+        // Continuous mode does not surface Hive partition columns (the poll loop
+        // builds flat file groups); bail rather than silently dropping them.
+        // `infer_partitions_from_path` only inspects the directory structure.
+        let partition_probe = ListingTableConfig::new(table_url.clone())
+            .with_listing_options(ListingOptions::new(file_format.clone()))
+            .infer_partitions_from_path(&state)
+            .await?;
+        let partition_cols = partition_probe
+            .options
+            .map(|options| options.table_partition_cols)
+            .unwrap_or_default();
+        if !partition_cols.is_empty() {
+            let names: Vec<&str> = partition_cols
+                .iter()
+                .map(|(name, _)| name.as_str())
+                .collect();
+            streamling_user_bail!(
+                "file source '{}': continuous mode does not support Hive partition \
+                 columns (found {:?} under path '{}'). Use bounded mode or a \
+                 non-partitioned path.",
+                reference_name,
+                names,
+                path
+            );
+        }
+
+        let config = ListingTableConfig::new(table_url.clone())
+            .with_listing_options(ListingOptions::new(file_format.clone()))
+            .infer_schema(&state)
+            .await?;
+        let file_schema = ListingTable::try_new(config)?.schema();
+
+        if file_schema.fields().is_empty() {
+            streamling_user_bail!(
+                "file source '{}': no files matching format {:?} found at path '{}'. \
+                 Check the path and that the files use the format's extension.",
+                reference_name,
+                format,
+                path
+            );
+        }
+
+        // Append a synthesized `_gs_op` unless the files already carry a valid one
+        // (mirrors the bounded source's ViewTable projection vs. passthrough).
+        let (full_schema, append_op) = match file_schema.field_with_name(COLUMN_NAME_OP) {
+            Ok(op_field) => {
+                if op_field.data_type() != &DataType::Utf8 || op_field.is_nullable() {
+                    streamling_user_bail!(
+                        "file source '{}': column '{}' must be a non-nullable Utf8 column, \
+                         found type {:?} (nullable: {})",
+                        reference_name,
+                        COLUMN_NAME_OP,
+                        op_field.data_type(),
+                        op_field.is_nullable()
+                    );
+                }
+                (file_schema.clone(), false)
+            }
+            Err(_) => {
+                let mut fields = file_schema.fields().to_vec();
+                fields.push(Arc::new(Field::new(COLUMN_NAME_OP, DataType::Utf8, false)));
+                (Arc::new(Schema::new(fields)), true)
+            }
+        };
+
+        let file_extension = file_format.get_ext();
+        let csv_has_header = state.config_options().catalog.has_header;
+        let file_source = file_source_for(format, &file_format, csv_has_header);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        Ok(Arc::new(Self {
+            reference_name: reference_name.to_string(),
+            table_url,
+            file_source,
+            file_extension,
+            file_schema,
+            full_schema,
+            append_op,
+            poll_interval,
+            state_backend,
+            num_records_before_stop,
+            internal_buffer_size,
+            shutdown_rx,
+            shutdown_tx,
+        }))
+    }
+
+    /// Signals the poll loop to stop. Parity with the Kafka source; the exec also
+    /// exits on SIGTERM, so this is for programmatic shutdown.
+    pub fn shutdown(&self) {
+        let _ = self.shutdown_tx.send(true);
+    }
+}
+
+impl Debug for FileSourceTableProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "FileSourceTableProvider({})", self.reference_name)
+    }
+}
+
+#[async_trait]
+impl TableProvider for FileSourceTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.full_schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(FileSourceExec::new(
+            self.reference_name.clone(),
+            self.table_url.clone(),
+            self.file_source.clone(),
+            self.file_extension.clone(),
+            self.file_schema.clone(),
+            self.full_schema.clone(),
+            self.append_op,
+            projection.cloned(),
+            self.poll_interval,
+            self.state_backend.clone(),
+            self.num_records_before_stop,
+            self.internal_buffer_size,
+            self.shutdown_rx.clone(),
+        )))
+    }
+}
+
+struct FileSourceExec {
+    reference_name: String,
+    table_url: ListingTableUrl,
+    file_source: Arc<dyn FileSource>,
+    file_extension: String,
+    file_schema: SchemaRef,
+    full_schema: SchemaRef,
+    output_schema: SchemaRef,
+    append_op: bool,
+    projection: Option<Vec<usize>>,
+    poll_interval: Duration,
+    state_backend: Arc<dyn StateOperatorBackend<FileWatermark>>,
+    num_records_before_stop: Option<u64>,
+    internal_buffer_size: u32,
+    shutdown_rx: watch::Receiver<bool>,
+    cached_properties: PlanProperties,
+}
+
+impl FileSourceExec {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        reference_name: String,
+        table_url: ListingTableUrl,
+        file_source: Arc<dyn FileSource>,
+        file_extension: String,
+        file_schema: SchemaRef,
+        full_schema: SchemaRef,
+        append_op: bool,
+        projection: Option<Vec<usize>>,
+        poll_interval: Duration,
+        state_backend: Arc<dyn StateOperatorBackend<FileWatermark>>,
+        num_records_before_stop: Option<u64>,
+        internal_buffer_size: u32,
+        shutdown_rx: watch::Receiver<bool>,
+    ) -> Self {
+        let output_schema = project_schema(&full_schema, projection.as_ref()).unwrap();
+        let cached_properties = PlanProperties::new(
+            EquivalenceProperties::new(output_schema.clone()),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Unbounded {
+                requires_infinite_memory: false,
+            },
+        );
+        Self {
+            reference_name,
+            table_url,
+            file_source,
+            file_extension,
+            file_schema,
+            full_schema,
+            output_schema,
+            append_op,
+            projection,
+            poll_interval,
+            state_backend,
+            num_records_before_stop,
+            internal_buffer_size,
+            shutdown_rx,
+            cached_properties,
+        }
+    }
+}
+
+impl Debug for FileSourceExec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "FileSourceExec")
+    }
+}
+
+impl DisplayAs for FileSourceExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> fmt::Result {
+        write!(f, "FileSourceExec")
+    }
+}
+
+impl ExecutionPlan for FileSourceExec {
+    fn name(&self) -> &'static str {
+        "FileSourceExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.cached_properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let mut builder = RecordBatchReceiverStreamBuilder::new(
+            self.output_schema.clone(),
+            self.internal_buffer_size as usize,
+        );
+        let tx = builder.tx();
+
+        let reference_name = self.reference_name.clone();
+        let table_url = self.table_url.clone();
+        let file_source = self.file_source.clone();
+        let file_extension = self.file_extension.clone();
+        let file_schema = self.file_schema.clone();
+        let full_schema = self.full_schema.clone();
+        let append_op = self.append_op;
+        let projection = self.projection.clone();
+        let poll_interval = self.poll_interval;
+        let state_backend = self.state_backend.clone();
+        let state_key = watermark_state_key(&self.reference_name);
+        let num_records_before_stop = self.num_records_before_stop;
+        let mut shutdown_rx = self.shutdown_rx.clone();
+
+        builder.spawn(async move {
+            let object_store_url = table_url.object_store();
+            let object_store = context.runtime_env().object_store(&object_store_url)?;
+
+            let mut watermark = state_backend
+                .get(state_key.clone())
+                .await
+                .map_err(to_df_err)?
+                .unwrap_or(FileWatermark {
+                    last_modified_ms: i64::MIN,
+                });
+            let mut total_emitted: u64 = 0;
+
+            debug!("Current watermark: {:?}", watermark);
+
+            // Caught once and held across iterations so a SIGTERM that arrives
+            // while sleeping is not missed (a freshly created handler would not
+            // observe a signal delivered before it existed).
+            #[cfg(unix)]
+            let mut sigterm =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).ok();
+
+            loop {
+                let mut new_files: Vec<PartitionedFile> = Vec::new();
+                let mut max_seen = watermark.last_modified_ms;
+                let mut listing = object_store.list(Some(table_url.prefix()));
+                while let Some(meta) = listing.next().await {
+                    let meta = meta?;
+                    let last_modified_ms = meta.last_modified.timestamp_millis();
+                    if should_process(
+                        meta.location.extension(),
+                        last_modified_ms,
+                        &file_extension,
+                        watermark.last_modified_ms,
+                    ) {
+                        max_seen = max_seen.max(last_modified_ms);
+                        new_files.push(PartitionedFile::from(meta));
+                    } else {
+                        debug!(
+                            "Skipping file {}, last modified at {}",
+                            meta.location, meta.last_modified
+                        );
+                    }
+                }
+
+                if !new_files.is_empty() {
+                    let config = FileScanConfigBuilder::new(
+                        object_store_url.clone(),
+                        file_schema.clone(),
+                        file_source.clone(),
+                    )
+                    .with_file_group(FileGroup::new(new_files))
+                    .build();
+
+                    let mut stream =
+                        DataSourceExec::from_data_source(config).execute(0, context.clone())?;
+                    while let Some(batch) = stream.next().await {
+                        let batch = build_output_batch(
+                            batch?,
+                            append_op,
+                            &full_schema,
+                            projection.as_ref(),
+                        )?;
+                        let rows = batch.num_rows() as u64;
+                        if tx.send(Ok(batch)).await.is_err() {
+                            return Ok(());
+                        }
+                        total_emitted += rows;
+                        if let Some(limit) = num_records_before_stop
+                            && total_emitted >= limit
+                        {
+                            return Ok(());
+                        }
+                    }
+
+                    watermark.last_modified_ms = max_seen;
+                    state_backend
+                        .put(state_key.clone(), watermark)
+                        .await
+                        .map_err(to_df_err)?;
+                } else {
+                    debug!("No new files to process");
+                }
+
+                tokio::select! {
+                    changed = shutdown_rx.changed() => {
+                        if changed.is_err() || *shutdown_rx.borrow() {
+                            return Ok(());
+                        }
+                    }
+                    _ = sleep(poll_interval) => {}
+                    // SIGTERM (unix) / Ctrl-C (otherwise): exit the poll loop so
+                    // the stream ends and downstream sinks complete. The wait is
+                    // bound to a `let` so neither cfg branch sits in a
+                    // (feature-gated) trailing-expression position.
+                    _ = async {
+                        #[cfg(unix)]
+                        let _: () = match sigterm.as_mut() {
+                            Some(stream) => {
+                                stream.recv().await;
+                            }
+                            None => std::future::pending::<()>().await,
+                        };
+                        #[cfg(not(unix))]
+                        let _: () = {
+                            let _ = tokio::signal::ctrl_c().await;
+                        };
+                    } => {
+                        info!("[{}] file source received termination signal", reference_name);
+                        return Ok(());
+                    }
+                }
+            }
+        });
+
+        Ok(builder.build())
+    }
+}
+
+/// Converts a discovered file batch into the source's output: appends the
+/// constant `_gs_op = 'i'` column when the files don't provide one, then applies
+/// the requested projection.
+fn build_output_batch(
+    batch: RecordBatch,
+    append_op: bool,
+    full_schema: &SchemaRef,
+    projection: Option<&Vec<usize>>,
+) -> DataFusionResult<RecordBatch> {
+    let full = if append_op {
+        let op_value = RowKind::Insert.to_str();
+        let op: ArrayRef = Arc::new(StringArray::from(vec![op_value.as_str(); batch.num_rows()]));
+        let mut columns = batch.columns().to_vec();
+        columns.push(op);
+        RecordBatch::try_new(full_schema.clone(), columns)?
+    } else {
+        batch
+    };
+
+    match projection {
+        Some(indices) => Ok(full.project(indices)?),
+        None => Ok(full),
+    }
+}
+
+fn to_df_err<E>(e: E) -> DataFusionError
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    DataFusionError::External(Box::new(e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_watermark_serde_round_trip() {
+        let watermark = FileWatermark {
+            last_modified_ms: 1_700_000_000_123,
+        };
+        let json = serde_json::to_string(&watermark).unwrap();
+        let restored: FileWatermark = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.last_modified_ms, watermark.last_modified_ms);
+    }
+
+    #[test]
+    fn should_process_requires_matching_extension() {
+        assert!(should_process(Some("parquet"), 10, "parquet", 5));
+        assert!(!should_process(Some("csv"), 10, "parquet", 5));
+        assert!(!should_process(None, 10, "parquet", 5));
+    }
+
+    #[test]
+    fn should_process_requires_newer_than_watermark() {
+        assert!(should_process(Some("parquet"), 10, "parquet", 5));
+        assert!(!should_process(Some("parquet"), 5, "parquet", 5));
+        assert!(!should_process(Some("parquet"), 4, "parquet", 5));
+    }
+
+    /// Regression for the NUL-delimiter bug: building the runtime `FileScanConfig`
+    /// with `CsvFormat::file_source()` (`CsvSource::default`) splits on a NUL byte,
+    /// so every line collapses to a single field and the read fails with
+    /// "incorrect number of fields". `file_source_for` must wire the comma
+    /// delimiter and header-skipping instead.
+    #[tokio::test]
+    async fn continuous_csv_reads_comma_delimited_rows() {
+        use datafusion::arrow::array::Array;
+        use datafusion::physical_plan::collect;
+        use datafusion::prelude::SessionContext;
+
+        let dir = std::env::temp_dir().join(format!("streamling_csv_src_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("1.csv"), "id,name\n1,alice\n2,bob\n3,carol").unwrap();
+
+        let file_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let file_format = file_format_for(FileSourceFormat::Csv);
+        let file_source = file_source_for(FileSourceFormat::Csv, &file_format, true);
+
+        let url = ListingTableUrl::parse(format!("{}/", dir.to_str().unwrap())).unwrap();
+        let object_store_url = url.object_store();
+
+        let ctx = SessionContext::new();
+        let task_ctx = ctx.task_ctx();
+        let object_store = task_ctx
+            .runtime_env()
+            .object_store(&object_store_url)
+            .unwrap();
+        let files: Vec<PartitionedFile> = object_store
+            .list(Some(url.prefix()))
+            .map(|meta| PartitionedFile::from(meta.unwrap()))
+            .collect()
+            .await;
+
+        let config = FileScanConfigBuilder::new(object_store_url, file_schema, file_source)
+            .with_file_group(FileGroup::new(files))
+            .build();
+        let batches = collect(DataSourceExec::from_data_source(config), task_ctx)
+            .await
+            .unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let names: Vec<String> = batches
+            .iter()
+            .flat_map(|batch| {
+                let column = batch.column_by_name("name").unwrap();
+                let array = column.as_any().downcast_ref::<StringArray>().unwrap();
+                (0..array.len())
+                    .map(|i| array.value(i).to_string())
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        // Header skipped (3 rows, not 4) and fields split on the comma.
+        assert_eq!(names, vec!["alice", "bob", "carol"]);
+    }
 }

--- a/crates/streamling-connectors/src/table_providers/file.rs
+++ b/crates/streamling-connectors/src/table_providers/file.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use datafusion::arrow::array::{ArrayRef, RecordBatch, StringArray};
-use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::datatypes::{DataType, Field, FieldRef, Schema, SchemaRef};
 use datafusion::catalog::Session;
 use datafusion::common::{Column, DataFusionError, ScalarValue};
 use datafusion::datasource::file_format::FileFormat;
@@ -33,6 +33,7 @@ use datafusion::datasource::file_format::avro::AvroFormat;
 use datafusion::datasource::file_format::csv::CsvFormat;
 use datafusion::datasource::file_format::json::JsonFormat;
 use datafusion::datasource::file_format::parquet::ParquetFormat;
+use datafusion::datasource::listing::helpers::parse_partitions_for_path;
 use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl, PartitionedFile,
 };
@@ -166,8 +167,9 @@ fn register_object_store_for_url(
 /// non-nullable Utf8 column to match what downstream consumers expect.
 ///
 /// Supported path schemes: local paths, `s3://`, and `gs://`. Hive-style
-/// partition columns in the path (e.g. `…/dt=2024-01-01/`) are inferred and added
-/// to the schema.
+/// partition columns in the path (e.g. `…/dt=2024-01-01/`) are surfaced in the
+/// schema, and nested subfolders are read recursively (the session sets
+/// `listing_table_ignore_subdirectory = false`).
 pub async fn build_bounded_file_source_provider(
     reference_name: &str,
     path: &str,
@@ -178,16 +180,19 @@ pub async fn build_bounded_file_source_provider(
     register_object_store_for_url(&table_url, path, session_manager)?;
 
     let file_format = file_format_for(format);
+    let file_extension = file_format.get_ext();
 
     let state = session_manager.session_state();
-    let listing_options = ListingOptions::new(file_format);
+    // Detect Hive partition columns ourselves (only `key=value` directories) rather
+    // than via `infer_partitions_from_path`, which treats every parent directory as
+    // a partition level and so errors on plain nested subfolders.
+    let object_store = state.runtime_env().object_store(table_url.object_store())?;
+    let partition_cols =
+        infer_partition_columns(&table_url, &file_extension, object_store.as_ref()).await;
+    let listing_options =
+        ListingOptions::new(file_format).with_table_partition_cols(partition_cols);
     let config = ListingTableConfig::new(table_url)
         .with_listing_options(listing_options)
-        // Surface Hive-style partition columns (e.g. `dt=2024-01-01/`) in the
-        // schema, matching DataFusion's dynamic-file behavior. A no-op for flat
-        // directories.
-        .infer_partitions_from_path(&state)
-        .await?
         .infer_schema(&state)
         .await?;
     let listing_table = Arc::new(ListingTable::try_new(config)?);
@@ -266,6 +271,105 @@ fn should_process(
     location_extension == Some(file_extension) && last_modified_ms > watermark_ms
 }
 
+/// Number of discovered files sampled to detect the Hive partition layout.
+const PARTITION_SAMPLE_SIZE: usize = 10;
+
+/// Detects Hive partition column names from a sample of file paths: the leading
+/// run of `key=value` parent directory segments, required to be consistent across
+/// the sample. Plain (non `key=value`) directories yield no partition columns, so
+/// arbitrary nested subfolders are read without spurious partition columns.
+///
+/// This replaces DataFusion's `infer_partitions_from_path`, which treats every
+/// parent directory as a partition level and so rejects plain nested subfolders.
+fn detect_partition_columns(
+    table_url: &ListingTableUrl,
+    sample_paths: &[object_store::path::Path],
+) -> Vec<String> {
+    let per_file: Vec<Vec<String>> = sample_paths
+        .iter()
+        .filter_map(|path| {
+            let segments: Vec<&str> = table_url.strip_prefix(path)?.collect();
+            // Parent directories only (drop the filename), then the leading run of
+            // `key=value` segments.
+            let parents = segments
+                .split_last()
+                .map(|(_, parents)| parents)
+                .unwrap_or(&[]);
+            let keys = parents
+                .iter()
+                .take_while(|segment| segment.contains('='))
+                .map(|segment| segment.split('=').next().unwrap_or(segment).to_string())
+                .collect();
+            Some(keys)
+        })
+        .collect();
+
+    match per_file.split_first() {
+        Some((first, rest)) if rest.iter().all(|keys| keys == first) => first.clone(),
+        _ => Vec::new(),
+    }
+}
+
+/// Lists a sample of files under the prefix and detects the Hive partition
+/// columns, typed as DataFusion types inferred partitions. Empty for flat /
+/// plain-subfolder layouts. Shared by the bounded and continuous builders.
+async fn infer_partition_columns(
+    table_url: &ListingTableUrl,
+    file_extension: &str,
+    object_store: &dyn object_store::ObjectStore,
+) -> Vec<(String, DataType)> {
+    let sample: Vec<object_store::path::Path> = object_store
+        .list(Some(table_url.prefix()))
+        .filter_map(|meta| {
+            let extension = file_extension.to_string();
+            async move {
+                meta.ok()
+                    .filter(|object| object.location.extension() == Some(extension.as_str()))
+                    .map(|object| object.location)
+            }
+        })
+        .take(PARTITION_SAMPLE_SIZE)
+        .collect()
+        .await;
+    detect_partition_columns(table_url, &sample)
+        .into_iter()
+        .map(|name| {
+            (
+                name,
+                DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
+            )
+        })
+        .collect()
+}
+
+/// Parses Hive partition values for a file path against the configured partition
+/// columns (typed as DataFusion's `infer_partitions_from_path` produced them).
+/// `Ok(None)` means the file is not under the expected `key=value` layout and
+/// should be skipped; `Ok(Some(vec![]))` is returned for flat / plain-subfolder
+/// layouts that have no partition columns.
+fn partition_values_for(
+    table_url: &ListingTableUrl,
+    file_path: &object_store::path::Path,
+    partition_cols: &[(String, DataType)],
+) -> DataFusionResult<Option<Vec<ScalarValue>>> {
+    if partition_cols.is_empty() {
+        return Ok(Some(vec![]));
+    }
+    match parse_partitions_for_path(
+        table_url,
+        file_path,
+        partition_cols.iter().map(|(name, _)| name.as_str()),
+    ) {
+        None => Ok(None),
+        Some(values) => values
+            .into_iter()
+            .zip(partition_cols)
+            .map(|(value, (_, datatype))| ScalarValue::try_from_string(value.to_string(), datatype))
+            .collect::<DataFusionResult<Vec<_>>>()
+            .map(Some),
+    }
+}
+
 /// Continuous (unbounded) file source. Polls `table_url` every `poll_interval`,
 /// ingesting files whose `last_modified` exceeds the persisted [`FileWatermark`],
 /// and emits their rows with a synthesized `_gs_op = 'i'` (unless the files
@@ -275,6 +379,11 @@ pub struct FileSourceTableProvider {
     table_url: ListingTableUrl,
     file_source: Arc<dyn FileSource>,
     file_extension: String,
+    /// Hive partition columns inferred from the path (empty for flat layouts);
+    /// used to parse per-file partition values during discovery.
+    partition_cols: Vec<(String, DataType)>,
+    /// Partition columns as fields for the runtime `FileScanConfig`.
+    partition_fields: Vec<Field>,
     /// Columns read from the files (includes `_gs_op` only if the files provide it).
     file_schema: SchemaRef,
     /// Published schema: `file_schema` plus a synthesized `_gs_op` when absent.
@@ -306,34 +415,13 @@ impl FileSourceTableProvider {
         register_object_store_for_url(&table_url, path, session_manager)?;
 
         let file_format = file_format_for(format);
+        let file_extension = file_format.get_ext();
+
         let state = session_manager.session_state();
 
-        // Continuous mode does not surface Hive partition columns (the poll loop
-        // builds flat file groups); bail rather than silently dropping them.
-        // `infer_partitions_from_path` only inspects the directory structure.
-        let partition_probe = ListingTableConfig::new(table_url.clone())
-            .with_listing_options(ListingOptions::new(file_format.clone()))
-            .infer_partitions_from_path(&state)
-            .await?;
-        let partition_cols = partition_probe
-            .options
-            .map(|options| options.table_partition_cols)
-            .unwrap_or_default();
-        if !partition_cols.is_empty() {
-            let names: Vec<&str> = partition_cols
-                .iter()
-                .map(|(name, _)| name.as_str())
-                .collect();
-            streamling_user_bail!(
-                "file source '{}': continuous mode does not support Hive partition \
-                 columns (found {:?} under path '{}'). Use bounded mode or a \
-                 non-partitioned path.",
-                reference_name,
-                names,
-                path
-            );
-        }
-
+        // Infer the data (file) schema from file contents. This is safe for any
+        // nesting; it does not validate a partition structure (unlike DataFusion's
+        // `infer_partitions_from_path`, which rejects plain nested subfolders).
         let config = ListingTableConfig::new(table_url.clone())
             .with_listing_options(ListingOptions::new(file_format.clone()))
             .infer_schema(&state)
@@ -350,9 +438,23 @@ impl FileSourceTableProvider {
             );
         }
 
-        // Append a synthesized `_gs_op` unless the files already carry a valid one
-        // (mirrors the bounded source's ViewTable projection vs. passthrough).
-        let (full_schema, append_op) = match file_schema.field_with_name(COLUMN_NAME_OP) {
+        // Detect Hive partition columns from a sample of discovered paths: only
+        // `key=value` directory segments count, so plain nested subfolders yield no
+        // partition columns.
+        let object_store = state.runtime_env().object_store(table_url.object_store())?;
+        let partition_cols =
+            infer_partition_columns(&table_url, &file_extension, object_store.as_ref()).await;
+        let partition_fields: Vec<Field> = partition_cols
+            .iter()
+            .map(|(name, datatype)| Field::new(name, datatype.clone(), false))
+            .collect();
+
+        // Output schema: data columns, then partition columns, then a synthesized
+        // `_gs_op` unless the data already carries a valid one (mirrors the bounded
+        // source's ViewTable projection vs. passthrough).
+        let mut output_fields: Vec<FieldRef> = file_schema.fields().iter().cloned().collect();
+        output_fields.extend(partition_fields.iter().map(|field| Arc::new(field.clone())));
+        let append_op = match file_schema.field_with_name(COLUMN_NAME_OP) {
             Ok(op_field) => {
                 if op_field.data_type() != &DataType::Utf8 || op_field.is_nullable() {
                     streamling_user_bail!(
@@ -364,16 +466,15 @@ impl FileSourceTableProvider {
                         op_field.is_nullable()
                     );
                 }
-                (file_schema.clone(), false)
+                false
             }
             Err(_) => {
-                let mut fields = file_schema.fields().to_vec();
-                fields.push(Arc::new(Field::new(COLUMN_NAME_OP, DataType::Utf8, false)));
-                (Arc::new(Schema::new(fields)), true)
+                output_fields.push(Arc::new(Field::new(COLUMN_NAME_OP, DataType::Utf8, false)));
+                true
             }
         };
+        let full_schema: SchemaRef = Arc::new(Schema::new(output_fields));
 
-        let file_extension = file_format.get_ext();
         let file_source = file_source_for(format, &file_format);
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
@@ -382,6 +483,8 @@ impl FileSourceTableProvider {
             table_url,
             file_source,
             file_extension,
+            partition_cols,
+            partition_fields,
             file_schema,
             full_schema,
             append_op,
@@ -433,6 +536,8 @@ impl TableProvider for FileSourceTableProvider {
             self.table_url.clone(),
             self.file_source.clone(),
             self.file_extension.clone(),
+            self.partition_cols.clone(),
+            self.partition_fields.clone(),
             self.file_schema.clone(),
             self.full_schema.clone(),
             self.append_op,
@@ -451,6 +556,8 @@ struct FileSourceExec {
     table_url: ListingTableUrl,
     file_source: Arc<dyn FileSource>,
     file_extension: String,
+    partition_cols: Vec<(String, DataType)>,
+    partition_fields: Vec<Field>,
     file_schema: SchemaRef,
     full_schema: SchemaRef,
     output_schema: SchemaRef,
@@ -471,6 +578,8 @@ impl FileSourceExec {
         table_url: ListingTableUrl,
         file_source: Arc<dyn FileSource>,
         file_extension: String,
+        partition_cols: Vec<(String, DataType)>,
+        partition_fields: Vec<Field>,
         file_schema: SchemaRef,
         full_schema: SchemaRef,
         append_op: bool,
@@ -495,6 +604,8 @@ impl FileSourceExec {
             table_url,
             file_source,
             file_extension,
+            partition_cols,
+            partition_fields,
             file_schema,
             full_schema,
             output_schema,
@@ -561,6 +672,8 @@ impl ExecutionPlan for FileSourceExec {
         let table_url = self.table_url.clone();
         let file_source = self.file_source.clone();
         let file_extension = self.file_extension.clone();
+        let partition_cols = self.partition_cols.clone();
+        let partition_fields = self.partition_fields.clone();
         let file_schema = self.file_schema.clone();
         let full_schema = self.full_schema.clone();
         let output_schema = self.output_schema.clone();
@@ -625,20 +738,38 @@ impl ExecutionPlan for FileSourceExec {
                 while let Some(meta) = listing.next().await {
                     let meta = meta?;
                     let last_modified_ms = meta.last_modified.timestamp_millis();
-                    if should_process(
+                    if !should_process(
                         meta.location.extension(),
                         last_modified_ms,
                         &file_extension,
                         watermark.last_modified_ms,
                     ) {
-                        max_seen = max_seen.max(last_modified_ms);
-                        new_files.push(PartitionedFile::from(meta));
-                    } else {
                         debug!(
                             "Skipping file {}, last modified at {}",
                             meta.location, meta.last_modified
                         );
+                        continue;
                     }
+                    // Parse Hive partition values from the path (empty for flat /
+                    // plain-subfolder layouts). Files outside the partition layout
+                    // are skipped.
+                    let partition_values =
+                        match partition_values_for(&table_url, &meta.location, &partition_cols)? {
+                            Some(values) => values,
+                            None => {
+                                debug!("Skipping file outside partition layout: {}", meta.location);
+                                continue;
+                            }
+                        };
+                    max_seen = max_seen.max(last_modified_ms);
+                    new_files.push(PartitionedFile {
+                        object_meta: meta,
+                        partition_values,
+                        range: None,
+                        statistics: None,
+                        extensions: None,
+                        metadata_size_hint: None,
+                    });
                 }
 
                 if !new_files.is_empty() {
@@ -647,6 +778,7 @@ impl ExecutionPlan for FileSourceExec {
                         file_schema.clone(),
                         file_source.clone(),
                     )
+                    .with_table_partition_cols(partition_fields.clone())
                     .with_file_group(FileGroup::new(new_files))
                     .build();
 
@@ -890,6 +1022,73 @@ mod tests {
         assert!(should_process(Some("parquet"), 10, "parquet", 5));
         assert!(!should_process(Some("parquet"), 5, "parquet", 5));
         assert!(!should_process(Some("parquet"), 4, "parquet", 5));
+    }
+
+    #[test]
+    fn detect_partition_columns_handles_hive_and_plain() {
+        let url = ListingTableUrl::parse("file:///t/").unwrap();
+
+        let hive = vec![
+            object_store::path::Path::from("t/dt=2024-01-01/a.parquet"),
+            object_store::path::Path::from("t/dt=2024-01-02/b.parquet"),
+        ];
+        assert_eq!(
+            detect_partition_columns(&url, &hive),
+            vec!["dt".to_string()]
+        );
+
+        let multi = vec![
+            object_store::path::Path::from("t/dt=2024-01-01/region=us/a.parquet"),
+            object_store::path::Path::from("t/dt=2024-01-02/region=eu/b.parquet"),
+        ];
+        assert_eq!(
+            detect_partition_columns(&url, &multi),
+            vec!["dt".to_string(), "region".to_string()]
+        );
+
+        // Plain nested subfolders (no `key=value`) → no partition columns, even at
+        // mixed depths.
+        let plain = vec![
+            object_store::path::Path::from("t/a/x.parquet"),
+            object_store::path::Path::from("t/b/c/y.parquet"),
+        ];
+        assert!(detect_partition_columns(&url, &plain).is_empty());
+
+        // Flat layout → no partition columns.
+        let flat = vec![object_store::path::Path::from("t/x.parquet")];
+        assert!(detect_partition_columns(&url, &flat).is_empty());
+    }
+
+    #[test]
+    fn partition_values_for_parses_hive_layout() {
+        let table_url = ListingTableUrl::parse("file:///tablepath/").unwrap();
+        let cols = vec![
+            ("dt".to_string(), DataType::Utf8),
+            ("region".to_string(), DataType::Utf8),
+        ];
+
+        // A file under a `dt=…/region=…/` layout yields its partition values.
+        let path = object_store::path::Path::from("tablepath/dt=2024-01-01/region=us/f.parquet");
+        let values = partition_values_for(&table_url, &path, &cols)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            values,
+            vec![ScalarValue::from("2024-01-01"), ScalarValue::from("us")]
+        );
+
+        // No partition columns → empty values (flat / plain-subfolder layout).
+        assert_eq!(
+            partition_values_for(&table_url, &path, &[]).unwrap(),
+            Some(vec![])
+        );
+
+        // A file not under the expected partition layout is skipped.
+        let flat = object_store::path::Path::from("tablepath/f.parquet");
+        assert_eq!(
+            partition_values_for(&table_url, &flat, &cols).unwrap(),
+            None
+        );
     }
 
     /// The continuous source must emit an empty `RecordBatch` on every poll — even

--- a/crates/streamling-core/src/session.rs
+++ b/crates/streamling-core/src/session.rs
@@ -99,6 +99,13 @@ impl SessionManager {
             // This is used when we convert to arrow ipc for export as well as any other output conversion
             // directly using datafusion.
             .set_bool("datafusion.optimizer.expand_views_at_output", true)
+            // Recurse into subdirectories when listing files. DataFusion defaults this
+            // to `true` (ignore subdirs), which makes the file source skip nested
+            // folders; Used by the file source
+            .set_bool(
+                "datafusion.execution.listing_table_ignore_subdirectory",
+                false,
+            )
             .with_option_extension(StreamlingConfig::new(internal_buffer_size as usize));
 
         let runtime = Arc::new(RuntimeEnv::default());

--- a/crates/streamling-core/src/topology.rs
+++ b/crates/streamling-core/src/topology.rs
@@ -223,16 +223,56 @@ pub struct PluginSource {
     pub telemetry: Option<Telemetry>,
 }
 
-/// Bounded source that reads files from `path` in the given `format` via
-/// DataFusion's `ListingTable`. `path` may be a local path or a remote object
-/// store URL (`s3://`, `gs://`); remote credentials come from the environment.
+/// Source that reads files from `path` in the given `format`. `path` may be a
+/// local path or a remote object store URL (`s3://`, `gs://`); remote
+/// credentials come from the environment. The `mode` selects between a
+/// continuous poll-for-new-files read (the default) and a bounded one-shot read.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct FileSource {
     pub path: String,
     pub format: FileSourceFormat,
+    #[serde(default)]
+    pub mode: FileSourceMode,
     pub primary_key: Option<String>,
     pub telemetry: Option<Telemetry>,
+}
+
+/// Default discovery interval for a `Continuous` file source when none is given.
+pub const DEFAULT_FILE_POLL_INTERVAL: &str = "10s";
+
+fn default_file_poll_interval() -> String {
+    DEFAULT_FILE_POLL_INTERVAL.to_string()
+}
+
+/// How the file source reads `path`.
+///
+/// - `Continuous` (the default) keeps polling `path` every `poll_interval`,
+///   ingesting files whose `last_modified` exceeds a persisted watermark; it
+///   never self-terminates and so is not allowed under `job_mode`. When the mode
+///   is omitted entirely (or given without `poll_interval`), `poll_interval`
+///   defaults to [`DEFAULT_FILE_POLL_INTERVAL`].
+/// - `Bounded` lists the matching files once via DataFusion's `ListingTable`,
+///   reads them to completion, and lets the job terminate.
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum FileSourceMode {
+    Bounded,
+    Continuous {
+        /// Discovery interval as a humantime string (e.g. `5s`, `500ms`),
+        /// parsed when the source is built. Defaults to
+        /// [`DEFAULT_FILE_POLL_INTERVAL`].
+        #[serde(default = "default_file_poll_interval")]
+        poll_interval: String,
+    },
+}
+
+impl Default for FileSourceMode {
+    fn default() -> Self {
+        FileSourceMode::Continuous {
+            poll_interval: default_file_poll_interval(),
+        }
+    }
 }
 
 /// Named `FileSourceFormat` to avoid colliding with DataFusion's `FileFormat`
@@ -1764,7 +1804,86 @@ sinks: {}
                 assert_eq!(file.path, "s3://my-bucket/events/");
                 assert_eq!(file.format, FileSourceFormat::Parquet);
                 assert_eq!(file.primary_key.as_deref(), Some("id"));
+                // Continuous is the default when `mode` is omitted.
+                assert_eq!(
+                    file.mode,
+                    FileSourceMode::Continuous {
+                        poll_interval: DEFAULT_FILE_POLL_INTERVAL.to_string()
+                    }
+                );
             }
+            other => panic!("expected file source, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_file_source_continuous_poll_interval_defaults() {
+        // `mode: continuous` without `poll_interval` falls back to the default.
+        let yaml = r#"
+sources:
+  events:
+    type: file
+    path: /tmp/events
+    format: parquet
+    mode:
+      type: continuous
+transforms: {}
+sinks: {}
+"#;
+        let topology = PipelineTopology::load_from_string(yaml).unwrap();
+        match topology.sources.get("events").unwrap() {
+            Source::file(file) => assert_eq!(
+                file.mode,
+                FileSourceMode::Continuous {
+                    poll_interval: DEFAULT_FILE_POLL_INTERVAL.to_string()
+                }
+            ),
+            other => panic!("expected file source, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_file_source_parses_bounded_mode() {
+        let yaml = r#"
+sources:
+  events:
+    type: file
+    path: /tmp/events
+    format: parquet
+    mode:
+      type: bounded
+transforms: {}
+sinks: {}
+"#;
+        let topology = PipelineTopology::load_from_string(yaml).unwrap();
+        match topology.sources.get("events").unwrap() {
+            Source::file(file) => assert_eq!(file.mode, FileSourceMode::Bounded),
+            other => panic!("expected file source, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_file_source_parses_continuous_mode() {
+        let yaml = r#"
+sources:
+  events:
+    type: file
+    path: /tmp/events
+    format: parquet
+    mode:
+      type: continuous
+      poll_interval: 5s
+transforms: {}
+sinks: {}
+"#;
+        let topology = PipelineTopology::load_from_string(yaml).unwrap();
+        match topology.sources.get("events").unwrap() {
+            Source::file(file) => assert_eq!(
+                file.mode,
+                FileSourceMode::Continuous {
+                    poll_interval: "5s".to_string()
+                }
+            ),
             other => panic!("expected file source, got {:?}", other),
         }
     }

--- a/crates/streamling-core/src/topology.rs
+++ b/crates/streamling-core/src/topology.rs
@@ -239,7 +239,7 @@ pub struct FileSource {
 }
 
 /// Default discovery interval for a `Continuous` file source when none is given.
-pub const DEFAULT_FILE_POLL_INTERVAL: &str = "10s";
+pub const DEFAULT_FILE_POLL_INTERVAL: &str = "5s";
 
 fn default_file_poll_interval() -> String {
     DEFAULT_FILE_POLL_INTERVAL.to_string()

--- a/crates/streamling-core/src/topology_validation.rs
+++ b/crates/streamling-core/src/topology_validation.rs
@@ -8,7 +8,7 @@
 
 use crate::sql_parse::extract_table_references_from_sql;
 use crate::streamling_user_err;
-use crate::topology::{PipelineTopology, Source};
+use crate::topology::{FileSourceMode, PipelineTopology, Source};
 use std::collections::HashMap;
 
 fn strip_sql_quotes(name: &str) -> &str {
@@ -130,12 +130,24 @@ pub fn validate_no_orphan_nodes(config: &str) -> crate::error::Result<()> {
     }
 }
 
+/// Whether a source self-terminates and so can run under `job_mode`. Hybrid
+/// sources terminate after all bounded phases complete; file sources terminate
+/// only in `Bounded` mode (a `Continuous` file source is unbounded and never
+/// completes).
+fn source_supports_job_mode(source: &Source) -> bool {
+    match source {
+        Source::hybrid(_) => true,
+        Source::file(file) => matches!(file.mode, FileSourceMode::Bounded),
+        _ => false,
+    }
+}
+
 /// Validates that job_mode is only enabled when every source supports it.
 ///
 /// Job mode requires bounded sources that terminate on their own: hybrid sources
-/// (they terminate after all bounded phases complete) and file sources (they read
-/// their files once and complete). If any source is neither, we fail early with a
-/// clear message listing the unsupported sources.
+/// (they terminate after all bounded phases complete) and file sources in bounded
+/// mode (they read their files once and complete). If any source is neither, we
+/// fail early with a clear message listing the unsupported sources.
 pub fn validate_job_mode(job_mode: bool, topology: &PipelineTopology) -> crate::error::Result<()> {
     if !job_mode {
         return Ok(());
@@ -144,7 +156,7 @@ pub fn validate_job_mode(job_mode: bool, topology: &PipelineTopology) -> crate::
     let mut unsupported: Vec<&String> = topology
         .sources
         .iter()
-        .filter(|(_, s)| !matches!(s, Source::hybrid(_) | Source::file(_)))
+        .filter(|(_, s)| !source_supports_job_mode(s))
         .map(|(name, _)| name)
         .collect();
 
@@ -153,7 +165,7 @@ pub fn validate_job_mode(job_mode: bool, topology: &PipelineTopology) -> crate::
         return Err(streamling_user_err!(
             "job_mode is enabled but the following source(s) do not support it: {}. \
              Job mode is only supported for pipelines where every source is a hybrid or \
-             file (bounded) source.",
+             bounded file source.",
             unsupported
                 .iter()
                 .map(|s| format!("'{s}'"))
@@ -688,6 +700,8 @@ sources:
     path: /tmp/events
     format: parquet
     primary_key: id
+    mode:
+      type: bounded
 transforms: {}
 sinks:
   out:
@@ -697,8 +711,35 @@ sinks:
         let topology = PipelineTopology::load_from_string(config).unwrap();
         assert!(
             validate_job_mode(true, &topology).is_ok(),
-            "job_mode with a file source should succeed"
+            "job_mode with a bounded file source should succeed"
         );
+    }
+
+    #[test]
+    fn job_mode_with_continuous_file_source_rejected() {
+        let config = r#"
+sources:
+  src:
+    type: file
+    path: /tmp/events
+    format: parquet
+    mode:
+      type: continuous
+      poll_interval: 5s
+transforms: {}
+sinks:
+  out:
+    type: print
+    from: src
+"#;
+        let topology = PipelineTopology::load_from_string(config).unwrap();
+        let result = validate_job_mode(true, &topology);
+        assert!(
+            result.is_err(),
+            "job_mode with a continuous file source should fail"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("'src'"), "error should name the source: {err}");
     }
 
     #[test]
@@ -709,6 +750,8 @@ sources:
     type: file
     path: /tmp/events
     format: json
+    mode:
+      type: bounded
   hybrid_src:
     type: hybrid
     bounded_sources:

--- a/crates/streamling-e2e/tests/file_source.rs
+++ b/crates/streamling-e2e/tests/file_source.rs
@@ -1,8 +1,9 @@
 //! File source e2e tests.
 //!
-//! Streamling reads files from a temp directory, a print sink captures output to assert.
-//! Verifies schema inference, the synthesized `_gs_op = 'i'` column, Hive-partition
-//! inference, and fail-fast on bad paths.
+//! Streamling reads files from a temp directory; a print sink captures output to
+//! assert. Covers the matrix of mode (bounded, continuous) × layout (flat, nested
+//! subfolders, Hive partitions), plus the synthesized `_gs_op = 'i'` column,
+//! continuous mid-run file pickup, and fail-fast on bad paths.
 //!
 //! The file source uses neither Kafka nor Postgres, but `TestContext` still
 //! provisions them, so these tests require the e2e Docker stack like the rest.
@@ -213,6 +214,178 @@ sinks:
         "Hive partition column 'dt' should be inferred from the path; got {:?}",
         output.column_names()
     );
+}
+
+/// Continuous mode infers Hive partition columns and traverses the partition
+/// subdirectories.
+#[tokio::test]
+async fn file_source_continuous_infers_hive_partition_columns() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("Failed to create test context");
+
+    let root = ctx.temp_dir.path().join("continuous_hive");
+    fs::create_dir_all(root.join("dt=2024-01-01")).expect("create partition 1");
+    fs::create_dir_all(root.join("dt=2024-01-02")).expect("create partition 2");
+    fs::write(
+        root.join("dt=2024-01-01/a.csv"),
+        "id,name\n1,alice\n2,bob\n",
+    )
+    .expect("write partition 1");
+    fs::write(root.join("dt=2024-01-02/b.csv"), "id,name\n3,carol\n").expect("write partition 2");
+
+    let pipeline = format!(
+        r#"
+sources:
+  file_src:
+    type: file
+    path: {path}/
+    format: csv
+    primary_key: id
+    mode:
+      type: continuous
+      poll_interval: 1s
+
+transforms: {{}}
+
+sinks:
+  print_sink:
+    type: print
+    from: file_src
+    sample_every: 1
+"#,
+        path = root.display()
+    );
+
+    // Cold start reads all 3 rows on the first poll; the limit ends the run.
+    let output = ctx
+        .run_pipeline_with_capture(&pipeline, PipelineOpts::new().record_limit(3))
+        .await
+        .expect("Pipeline should complete successfully");
+
+    assert_eq!(output.len(), 3, "expected 3 rows across both partitions");
+    assert!(
+        output.has_column("dt"),
+        "Hive partition column 'dt' should be inferred from the path; got {:?}",
+        output.column_names()
+    );
+}
+
+/// Bounded mode reads plain nested subfolders (no `key=value`) recursively, with
+/// no partition column from the directory names.
+#[tokio::test]
+async fn file_source_bounded_reads_nested_subfolders() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("Failed to create test context");
+
+    let root = ctx.temp_dir.path().join("bounded_nested");
+    fs::create_dir_all(root.join("a/b")).expect("create nested dirs");
+    fs::write(root.join("a/b/x.csv"), "id,name\n1,alice\n").expect("write nested csv");
+    fs::write(root.join("a/y.csv"), "id,name\n2,bob\n").expect("write nested csv");
+
+    let pipeline = format!(
+        r#"
+sources:
+  file_src:
+    type: file
+    path: {path}/
+    format: csv
+    primary_key: id
+    mode:
+      type: bounded
+
+transforms: {{}}
+
+sinks:
+  print_sink:
+    type: print
+    from: file_src
+    sample_every: 1
+"#,
+        path = root.display()
+    );
+
+    let output = ctx
+        .run_pipeline_with_capture(&pipeline, PipelineOpts::new())
+        .await
+        .expect("Pipeline should complete successfully");
+
+    assert_eq!(
+        output.len(),
+        2,
+        "both nested files must be read recursively"
+    );
+    assert!(
+        output.has_column("id"),
+        "inferred id column; got {:?}",
+        output.column_names()
+    );
+    assert!(output.has_column("name"), "inferred name column");
+    assert!(
+        !output.has_column("a"),
+        "plain directory names must not become partition columns; got {:?}",
+        output.column_names()
+    );
+}
+
+/// Continuous mode reads plain nested subfolders recursively.
+#[tokio::test]
+async fn file_source_continuous_reads_nested_subfolders() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("Failed to create test context");
+
+    let root = ctx.temp_dir.path().join("continuous_nested");
+    fs::create_dir_all(root.join("a/b")).expect("create nested dirs");
+    fs::write(root.join("a/b/x.csv"), "id,name\n1,alice\n").expect("write nested csv");
+    fs::write(root.join("a/y.csv"), "id,name\n2,bob\n").expect("write nested csv");
+
+    let pipeline = format!(
+        r#"
+sources:
+  file_src:
+    type: file
+    path: {path}/
+    format: csv
+    primary_key: id
+    mode:
+      type: continuous
+      poll_interval: 1s
+
+transforms: {{}}
+
+sinks:
+  print_sink:
+    type: print
+    from: file_src
+    sample_every: 1
+"#,
+        path = root.display()
+    );
+
+    let output = ctx
+        .run_pipeline_with_capture(&pipeline, PipelineOpts::new().record_limit(2))
+        .await
+        .expect("Pipeline should complete successfully");
+
+    assert_eq!(
+        output.len(),
+        2,
+        "both nested files must be read recursively"
+    );
+    assert!(
+        output.has_column("id"),
+        "inferred id column; got {:?}",
+        output.column_names()
+    );
+    assert!(output.has_column("name"), "inferred name column");
 }
 
 /// A path matching no files fails fast instead of producing a silent empty source.

--- a/crates/streamling-e2e/tests/file_source.rs
+++ b/crates/streamling-e2e/tests/file_source.rs
@@ -8,6 +8,7 @@
 //! provisions them, so these tests require the e2e Docker stack like the rest.
 
 use std::fs;
+use std::time::Duration;
 
 use streamling_e2e::{init_tracing, PipelineOpts, TestContext};
 
@@ -38,6 +39,8 @@ sources:
     path: {path}/
     format: csv
     primary_key: id
+    mode:
+      type: bounded
 
 transforms: {{}}
 
@@ -78,6 +81,88 @@ sinks:
     }
 }
 
+/// Continuous file source: ingests the files present at startup, then picks up a
+/// new file dropped in after the pipeline is already running. The watermark stops
+/// the initial files from being re-read, so the run only reaches the record limit
+/// once the new file is discovered on a later poll.
+#[tokio::test]
+async fn file_source_continuous_picks_up_new_files() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("Failed to create test context");
+
+    let data_dir = ctx.temp_dir.path().join("continuous_data");
+    fs::create_dir_all(&data_dir).expect("create data dir");
+    // Three rows are present at startup; two more arrive while the source polls.
+    fs::write(
+        data_dir.join("initial.csv"),
+        "id,name\n1,alice\n2,bob\n3,carol\n",
+    )
+    .expect("write initial csv");
+
+    let pipeline = format!(
+        r#"
+sources:
+  file_src:
+    type: file
+    path: {path}/
+    format: csv
+    primary_key: id
+    mode:
+      type: continuous
+      poll_interval: 1s
+
+transforms: {{}}
+
+sinks:
+  print_sink:
+    type: print
+    from: file_src
+    sample_every: 1
+"#,
+        path = data_dir.display()
+    );
+
+    // The continuous source never self-terminates, so bound the run by record
+    // count. The limit (5) exceeds the 3 startup rows, so the run can only finish
+    // after the 2-row file that is dropped in mid-run is discovered.
+    let new_file = data_dir.join("new.csv");
+    let writer = async {
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        fs::write(&new_file, "id,name\n4,dave\n5,erin\n").expect("write new csv");
+    };
+
+    let (result, ()) = tokio::join!(
+        ctx.run_pipeline_with_capture(&pipeline, PipelineOpts::new().record_limit(5)),
+        writer,
+    );
+    let output = result.expect("Pipeline should complete successfully");
+
+    // Reaching the limit of 5 is itself proof the mid-run file was ingested: the
+    // 3 startup rows are read once (the watermark blocks re-reads), so the run
+    // cannot finish without the 2 rows from `new.csv`.
+    assert_eq!(
+        output.len(),
+        5,
+        "expected 3 startup rows plus 2 from the file added mid-run"
+    );
+
+    for row in output.rows() {
+        assert_eq!(
+            row.row_kind, "Insert",
+            "append-only file rows must be inserts"
+        );
+    }
+
+    let ops = output.column_values("_gs_op");
+    assert_eq!(ops.len(), 5, "every row should carry a synthesized _gs_op");
+    for op in ops {
+        assert_eq!(op.as_str(), Some("i"), "synthesized _gs_op must be 'i'");
+    }
+}
+
 /// Hive-style partition columns encoded in the path are inferred into the schema.
 #[tokio::test]
 async fn file_source_infers_hive_partition_columns() {
@@ -103,6 +188,8 @@ sources:
     path: {path}/
     format: csv
     primary_key: id
+    mode:
+      type: bounded
 
 transforms: {{}}
 

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -10,7 +10,9 @@ use std::time::Duration;
 use streamling_config::AppConfig;
 use streamling_connectors::table_providers::blackhole::BlackholeTableProvider;
 use streamling_connectors::table_providers::clickhouse::ClickHouseTableProvider;
-use streamling_connectors::table_providers::file::build_file_source_provider;
+use streamling_connectors::table_providers::file::{
+    FileSourceTableProvider, build_bounded_file_source_provider,
+};
 use streamling_connectors::table_providers::http::HttpTableProvider;
 use streamling_connectors::table_providers::hybrid::HybridTableProvider;
 use streamling_connectors::table_providers::kafka::KafkaSourceTableProvider;
@@ -774,16 +776,43 @@ impl Streamling {
                         .get(reference_name)
                         .expect("node context must exist");
 
-                    let provider = build_file_source_provider(
-                        reference_name,
-                        &file.path,
-                        file.format,
-                        &session_manager,
-                    )
-                    .await
-                    .map_err(|e| {
-                        e.context(format!("{}: failed to create file source", ctx.format()))
-                    })?;
+                    let provider: Arc<dyn TableProvider> = match &file.mode {
+                        topology::FileSourceMode::Bounded => build_bounded_file_source_provider(
+                            reference_name,
+                            &file.path,
+                            file.format,
+                            &session_manager,
+                        )
+                        .await
+                        .map_err(|e| {
+                            e.context(format!("{}: failed to create file source", ctx.format()))
+                        })?,
+                        topology::FileSourceMode::Continuous { poll_interval } => {
+                            let interval =
+                                humantime::parse_duration(poll_interval).map_err(|e| {
+                                    streamling_user_err!(
+                                        "{}: invalid poll_interval '{}': {}",
+                                        ctx.format(),
+                                        poll_interval,
+                                        e
+                                    )
+                                })?;
+                            FileSourceTableProvider::try_new(
+                                reference_name,
+                                &file.path,
+                                file.format,
+                                interval,
+                                &session_manager,
+                                state_backend_factory.create(app_config.state_backend_namespace()),
+                                app_config.num_records_before_stop,
+                                app_config.internal_buffer_size,
+                            )
+                            .await
+                            .map_err(|e| {
+                                e.context(format!("{}: failed to create file source", ctx.format()))
+                            })?
+                        }
+                    };
 
                     let provider_with_telemetry = Arc::new(WrappingSourceTableProvider::new(
                         provider,


### PR DESCRIPTION
Continuation of https://github.com/goldsky-io/streamling/pull/15 that introduces continuous polling mode + some fixes. 

Both bounded and continuous modes support subfolders and Hive partitions. Continuous mode relies on the last modified file timestamp, so it can miss new files with old timestamps.

Sample pipeline:

```yaml
sources:
  file_src:
    type: file
    path: /Users/sap1ens/Downloads/test-data/
    format: csv
    primary_key: id
    mode:
      type: continuous

transforms: {}

sinks:
  print_sink:
    type: print
    from: file_src
```

---

NOTE: I decided to make continuous mode the default. Happy to debate this. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new unbounded source path with watermark discovery semantics that can permanently skip late files with older mtimes; checkpoint/state behavior affects at-least-once recovery across restarts.
> 
> **Overview**
> Adds a **continuous** file source (now the default) that polls a path on `poll_interval`, discovers new objects by `last_modified`, and runs until shutdown—alongside an explicit **bounded** one-shot `ListingTable` read.
> 
> Topology gains `mode: { type: bounded | continuous, poll_interval?: … }` (default continuous, 5s). **job_mode** only allows bounded file sources; continuous file sources are rejected. Runtime wiring selects `build_bounded_file_source_provider` vs `FileSourceTableProvider::try_new` with state backend for watermarks.
> 
> The continuous implementation (`FileSourceExec`) lists object stores, filters by extension and a persisted **`FileWatermark`** (`last_modified_ms` + `boundary_paths` for same-second mtimes), reads via DataFusion `FileScanConfig`, synthesizes `_gs_op`, emits **idle heartbeats**, and integrates **checkpoint marker/finalizer** persistence (Kafka-style commit-on-finalize). Bounded and continuous paths share custom **Hive partition** inference (only `key=value` dirs) so **plain nested subfolders** work; DataFusion `listing_table_ignore_subdirectory` is set to `false` in the session.
> 
> README documents discovery caveats (older mtimes missed, rewrites re-ingested, at-least-once on restart). Unit and e2e tests cover watermark logic, checkpoints, layouts, and mid-run file pickup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 615662a9339b943ed3ecffb91ea7487e27c6bab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->