### PR TITLE
build: bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6650,7 +6650,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streamling"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arrow-schema",
  "clap",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "streamling-common"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -6701,7 +6701,7 @@ dependencies = [
 
 [[package]]
 name = "streamling-config"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6719,7 +6719,7 @@ dependencies = [
 
 [[package]]
 name = "streamling-connectors"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "apache-avro",
  "arrow",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "streamling-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "abi_stable",
  "anyhow",
@@ -6811,7 +6811,7 @@ dependencies = [
 
 [[package]]
 name = "streamling-e2e"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "apache-avro",
  "aws-config",
@@ -6839,7 +6839,7 @@ dependencies = [
 
 [[package]]
 name = "streamling-flink-compat"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.21.7",
  "datafusion",
@@ -6876,7 +6876,7 @@ dependencies = [
 
 [[package]]
 name = "streamling-plugin-derive"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6885,7 +6885,7 @@ dependencies = [
 
 [[package]]
 name = "streamling-state"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "parking_lot 0.12.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,15 @@ too_many_arguments = "allow"
 [workspace.dependencies]
 # Internal crates. path + version lets `cargo publish` rewrite the path deps into
 # registry deps; the version is maintained here once and inherited via `{ workspace = true }`.
-streamling-config        = { path = "crates/streamling-config", version = "0.1.0" }
-streamling-common        = { path = "crates/streamling-common", version = "0.1.0" }
-streamling-state         = { path = "crates/streamling-state", version = "0.1.0" }
-streamling-core          = { path = "crates/streamling-core", version = "0.1.0" }
-streamling-connectors    = { path = "crates/streamling-connectors", version = "0.1.0" }
-streamling-flink-compat  = { path = "crates/streamling-flink-compat", version = "0.1.0" }
+streamling-config        = { path = "crates/streamling-config", version = "0.2.0" }
+streamling-common        = { path = "crates/streamling-common", version = "0.2.0" }
+streamling-state         = { path = "crates/streamling-state", version = "0.2.0" }
+streamling-core          = { path = "crates/streamling-core", version = "0.2.0" }
+streamling-connectors    = { path = "crates/streamling-connectors", version = "0.2.0" }
+streamling-flink-compat  = { path = "crates/streamling-flink-compat", version = "0.2.0" }
 streamling-plugin        = { path = "crates/streamling-plugin", version = "0.2.0" }
-streamling-plugin-derive = { path = "crates/streamling-plugin/streamling-plugin-derive", version = "0.1.0" }
-streamling-e2e           = { path = "crates/streamling-e2e", version = "0.1.0" }
+streamling-plugin-derive = { path = "crates/streamling-plugin/streamling-plugin-derive", version = "0.2.0" }
+streamling-e2e           = { path = "crates/streamling-e2e", version = "0.2.0" }
 
 # Core DataFusion ecosystem
 datafusion = { version = "49.0.2", features = ["avro", "backtrace"] }

--- a/crates/streamling-common/Cargo.toml
+++ b/crates/streamling-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamling-common"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.90.0"
 description = "Shared types, formats, and utilities for Streamling."

--- a/crates/streamling-config/Cargo.toml
+++ b/crates/streamling-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamling-config"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.90.0"
 description = "Configuration types and parsing for Streamling."

--- a/crates/streamling-connectors/Cargo.toml
+++ b/crates/streamling-connectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamling-connectors"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.90.0"
 description = "Source and sink connectors for Streamling."

--- a/crates/streamling-core/Cargo.toml
+++ b/crates/streamling-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamling-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.90.0"
 description = "Core streaming execution engine for Streamling, built on Apache DataFusion."

--- a/crates/streamling-e2e/Cargo.toml
+++ b/crates/streamling-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamling-e2e"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "End-to-end tests for streamling"
 license-file.workspace = true

--- a/crates/streamling-flink-compat/Cargo.toml
+++ b/crates/streamling-flink-compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamling-flink-compat"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Apache Flink compatibility helpers for Streamling."
 license-file.workspace = true

--- a/crates/streamling-plugin/streamling-plugin-derive/Cargo.toml
+++ b/crates/streamling-plugin/streamling-plugin-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamling-plugin-derive"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.90.0"
 description = "Derive macros for the Streamling plugin SDK."

--- a/crates/streamling-state/Cargo.toml
+++ b/crates/streamling-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamling-state"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.90.0"
 description = "State management and persistence for Streamling."

--- a/crates/streamling/Cargo.toml
+++ b/crates/streamling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamling"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.90.0"
 description = "Streamling: Performant and extensible streaming data runtime"

--- a/plugin_examples/basic/Cargo.lock
+++ b/plugin_examples/basic/Cargo.lock
@@ -4103,7 +4103,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streamling-common"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "streamling-config"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4172,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "streamling-plugin-derive"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "streamling-state"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "parking_lot",

--- a/plugin_examples/low_level/Cargo.lock
+++ b/plugin_examples/low_level/Cargo.lock
@@ -4106,7 +4106,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streamling-common"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "streamling-config"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "streamling-plugin-derive"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "streamling-state"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "parking_lot",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only metadata and lockfile updates; no runtime or API code changes in this PR.
> 
> **Overview**
> Bumps the workspace release from **0.1.0** to **0.2.0** for all internal Streamling crates so published packages and path dependencies stay aligned.
> 
> **`[workspace.dependencies]`** in the root `Cargo.toml` now pins `0.2.0` for `streamling-config`, `streamling-common`, `streamling-state`, `streamling-core`, `streamling-connectors`, `streamling-flink-compat`, `streamling-plugin-derive`, and `streamling-e2e`. Each affected crate’s `[package] version` is updated to match. **`streamling-plugin`** was already at `0.2.0` and is unchanged in this diff.
> 
> Root **`Cargo.lock`** and the plugin example locks under **`plugin_examples/basic`** and **`plugin_examples/low_level`** are refreshed so resolved `streamling-*` package versions reflect **0.2.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6862baa84572d8a3f2bfa366abd174f22b62c688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->