### PR TITLE
docs: add AI plugin authoring skills and README table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ Streamling powers [Goldsky Turbo](https://goldsky.com/products/turbo-pipelines),
 
 Install with one command (see [Quick start](#quick-start)) or read more at [streamling.dev](https://streamling.dev).
 
+## Contents
+
+- [Why Streamling](#why-streamling)
+- [Quick start](#quick-start)
+- [Common patterns](#common-patterns)
+- [Development setup](#development-setup)
+- [Reference](#reference)
+- [Topology](#topology)
+- [Dynamic Tables](#dynamic-tables)
+- [Side Outputs](#side-outputs)
+- [Checkpointing](#checkpointing)
+- [State Backends](#state-backends)
+- [Error Handling](#error-handling)
+- [Upsert Semantics](#upsert-semantics)
+- [Plugin System](#plugin-system)
+- [Profiling](#profiling)
+- [Telemetry and Metrics](#telemetry-and-metrics)
+
 ## Why Streamling
 
 Streamling enables teams to build and deploy custom sources, transforms, sinks, and UDFs through plugins without sacrificing performance or correctness. It's also meant to be highly efficient. 
@@ -1800,6 +1818,39 @@ To build a plugin (using the high-level API):
 5. Build with `cargo build`
 
 The resulting shared library (`.so`, `.dylib`, `.dll`) can be loaded by Streamling via the `STREAMLING__PLUGIN__PATH` configuration.
+
+### AI Authoring Skills
+
+Streamling ships a pack of AI agent skills (in [`skills/`](skills/)) that teach a coding agent how to build plugins correctly — the registration macros, constructor contracts, checkpoint/exactly-once lifecycle, error types, and option/secret patterns, all grounded in this repo's plugin API. Install them once and an agent can scaffold a new source/sink/transform/preprocessor/UDF without re-deriving the FFI contract.
+
+| Skill | Covers |
+|---|---|
+| `streamling-plugin-basics` | crate setup, registration macros, constructor contracts, lifecycle, async runtime, errors, options/secrets, metrics, state — **start here** |
+| `streamling-source-plugin` | `SourcePlugin`, `_gs_op`, `generate_batch`, resumable pagination, backpressure |
+| `streamling-sink-plugin` | `SinkPlugin`, lazy client init, batched writes with retry + partial-failure handling, checkpoint acks |
+| `streamling-transform-plugin` | `TransformPlugin`, `process_batch`, arrow-compute filtering |
+| `streamling-udf-plugin` | DataFusion scalar UDFs — `ScalarUDFImpl`, `invoke_with_args`, calling custom functions from SQL |
+| `streamling-advanced-plugins` | preprocessors, side outputs, multi-kind crates, low-level FFI |
+
+#### Installing the skills
+
+Each skill is `<name>/SKILL.md`. Symlink the ones you want into your coding agent's personal skills directory (they then stay in sync with the repo):
+
+| Agent | Skills directory |
+|---|---|
+| Claude Code | `~/.claude/skills/` |
+| Codex, GitHub Copilot CLI, Gemini CLI | `~/.agents/skills/` (cross-runtime alias) |
+
+```bash
+cd /path/to/streamling
+for d in skills/streamling-*; do
+  for dir in ~/.claude/skills ~/.agents/skills; do
+    mkdir -p "$dir" && ln -sf "$(pwd)/$d" "$dir/$(basename "$d")"
+  done
+done
+```
+
+Skills are discovered at agent **startup** — restart your session after installing. See [`skills/README.md`](skills/README.md) for the full per-agent path table (incl. `~/.codex`, `~/.copilot`, `~/.gemini`, Antigravity), a copy/freeze option, and verification steps.
 
 ### Checkpointing Support
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,64 @@
+# Streamling Plugin Authoring Skills
+
+A pack of [Agent Skills](https://agentskills.io/) that teach an AI coding agent how to build
+Streamling plugins correctly. Install them once and your agent gains the exact registration
+macro signatures, constructor contracts, checkpoint/exactly-once lifecycle, error types, and
+option/secret patterns — grounded in this repo's plugin API.
+
+## Skills
+
+| Skill | Use when |
+|---|---|
+| `streamling-plugin-basics` | Creating any plugin crate — cdylib setup, registration macros, constructor contracts, lifecycle, async runtime, errors, options/secrets, metrics, state. **Start here.** |
+| `streamling-source-plugin` | Implementing a `SourcePlugin` — output schema + `_gs_op`, `generate_batch`, fetcher/buffer/runner split, resumable cursor pagination, backpressure. |
+| `streamling-sink-plugin` | Implementing a `SinkPlugin` — lazy client init, empty-batch guard, NDJSON, batched writes with retry + partial-failure handling, checkpoint acks. |
+| `streamling-transform-plugin` | Implementing a `TransformPlugin` — `process_batch`, `output_schema`, arrow-compute filtering. |
+| `streamling-udf-plugin` | Implementing a DataFusion scalar UDF — `ScalarUDFImpl`, the modern `invoke_with_args`/`ScalarFunctionArgs` API, calling custom functions from SQL. |
+| `streamling-advanced-plugins` | Preprocessors (YAML rewrite), side outputs, multi-kind crate registration, low-level manual FFI. |
+
+The skills cross-reference each other by `skill://<name>` links, which resolve once installed.
+
+## Installation
+
+Each skill is a plain `<name>/SKILL.md` file. Install by symlinking (recommended — stays in sync with the repo) or copying into your coding agent's personal skills directory. **Skills are discovered at agent startup — restart your session after installing.**
+
+### Per-agent skill directories
+
+| Agent | User skills directory |
+|---|---|
+| Claude Code | `~/.claude/skills/` |
+| OpenAI Codex | `~/.codex/skills/`, or `~/.agents/skills/` |
+| GitHub Copilot CLI | `~/.copilot/skills/`, or `~/.agents/skills/` |
+| Google Gemini CLI | `~/.gemini/skills/`, or `~/.agents/skills/` |
+| Antigravity (`agy`) | symlink into `~/.agents/skills/` (or a package `skills/` dir); load each via `view_file … IsSkillFile: true` |
+
+`~/.agents/skills/` is a **cross-runtime alias** shared by Codex, Copilot CLI, and Gemini CLI — installing there covers all three at once. Claude Code reads only `~/.claude/skills/`.
+
+### Recommended — symlink into both common directories
+
+Covers every agent above in one shot:
+
+```bash
+cd /path/to/streamling
+for d in skills/streamling-*; do
+  for dir in ~/.claude/skills ~/.agents/skills; do
+    mkdir -p "$dir" && ln -sf "$(pwd)/$d" "$dir/$(basename "$d")"
+  done
+done
+```
+
+### Copy (freeze a snapshot, or runtimes that don't follow symlinks)
+
+```bash
+cp -r /path/to/streamling/skills/streamling-* ~/.claude/skills/   # or ~/.agents/skills/
+```
+
+## Verifying
+
+After restarting your agent, ask it to list available skills, or check that a skill resolves, e.g. `skill://streamling-plugin-basics`.
+
+## Editing
+
+Edit any `streamling-*/SKILL.md` here and the change takes effect on the next agent restart
+(with Option 1/2; with Option 3, re-copy). Keep each skill's `name` and `description` frontmatter
+in sync — the description is what the agent uses to decide when to load the skill.

--- a/skills/streamling-advanced-plugins/SKILL.md
+++ b/skills/streamling-advanced-plugins/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: streamling-advanced-plugins
+description: Use when implementing a streamling preprocessor (rewriting pipeline topology YAML before it parses), a DataFusion scalar UDF usable in SQL, a side output (observing every source without joining the pipeline), registering many component kinds in one crate, or dropping below the registration macros to the low-level manual FFI plugin module. Assumes streamling-plugin-basics.
+---
+
+# streamling advanced plugin kinds — Agent Skill
+
+Beyond sources, transforms, and sinks, a plugin crate can register three more component kinds — **preprocessors**, **UDFs**, and **side outputs** — and can mix all six in one `cdylib`. This skill also covers the **low-level manual FFI** escape hatch for when the registration macros don't fit.
+
+**Prerequisite:** [`streamling-plugin-basics`](skill://streamling-plugin-basics).
+
+## Preprocessors — rewrite topology YAML before parsing
+
+A preprocessor transforms the **raw topology config string** (the pipeline YAML) before streamling parses it. Use it to inject default options, expand shorthand dataset names into concrete source configs, or enforce per-source conventions — without touching streamling's core config parser.
+
+```rust
+use async_trait::async_trait;
+use std::collections::HashMap;
+use streamling_plugin::api::PluginError;
+use streamling_plugin::{PluginInitializationError, PreprocessorPlugin};
+
+pub struct DefaultsPreprocessor {
+    default_region: String,
+}
+
+impl DefaultsPreprocessor {
+    /// Constructor takes ONLY options (no schema/rt/state/metrics).
+    pub fn new(options: HashMap<String, String>) -> Result<Self, PluginInitializationError> {
+        Ok(Self {
+            default_region: options.get("region").cloned().unwrap_or_else(|| "us-east-1".into()),
+        })
+    }
+}
+
+#[async_trait]
+impl PreprocessorPlugin for DefaultsPreprocessor {
+    async fn preprocess_topology(&self, config: String) -> Result<String, PluginError> {
+        // Parse, mutate, re-serialize. serde_yaml is the usual tool.
+        let mut doc: serde_yaml::Value = serde_yaml::from_str(&config)
+            .map_err(|e| PluginError::Internal(format!("parse topology: {e}")))?;
+
+        if let Some(sinks) = doc.get_mut("sinks").and_then(|v| v.as_mapping_mut()) {
+            for (_, sink) in sinks.iter_mut() {
+                if let Some(map) = sink.as_mapping_mut() {
+                    let key = serde_yaml::Value::String("region".into());
+                    map.entry(key).or_insert_with(|| serde_yaml::Value::String(self.default_region.clone()));
+                }
+            }
+        }
+
+        serde_yaml::to_string(&doc).map_err(|e| PluginError::Internal(format!("emit topology: {e}")))
+    }
+}
+```
+
+Register and **order matters** — preprocessors run in registration order, and later ones see earlier ones' output:
+```rust
+register_plugin_preprocessor!("my_plugin", "defaults", DefaultsPreprocessor);
+```
+
+**Discipline:**
+- **Never overwrite a user-set field.** Check existence first (`entry().or_insert(..)` / `contains_key`) and only fill gaps.
+- Preprocessors are async but should stay fast and deterministic — they run once at pipeline load.
+- Parse failures must become `PluginError::Internal`, never panics.
+
+## UDFs — custom functions usable in SQL
+
+A **UDF** is a DataFusion scalar function your plugin exposes so pipeline SQL can call it (`SELECT my_func(col) FROM ...`) — the lightest way to add a derived column. It implements `ScalarUDFImpl` and registers with `register_plugin_udf!(MyFunc)` (or `register_plugin_udf_fn!(create_fn)` for the legacy `create_udf` closure form).
+
+**Full coverage — the modern `invoke_with_args` / `ScalarFunctionArgs` API, a complete worked example, argument helpers, `return_type` vs `return_field_from_args`, volatility, and the legacy path — lives in its own skill:** [`streamling-udf-plugin`](skill://streamling-udf-plugin).
+
+## Side outputs — observe every source
+
+A **side output** observes data from **all sources** without joining the pipeline or modifying records — e.g. a monitor that logs batch counts, tracks a high-water mark, or emits a heartbeat. Unlike other kinds, side outputs use **direct FFI invocation** (no channels), and **one instance is created per source** (the macro manages a `HashMap<source_name, instance>`).
+
+```rust
+use arrow::array::RecordBatch;
+use streamling_plugin::SideOutputPlugin;
+
+pub struct MonitorSideOutput;
+
+impl SideOutputPlugin for MonitorSideOutput {
+    fn process_batch(&self, batch: &RecordBatch) -> Result<(), String> {
+        tracing::info!(rows = batch.num_rows(), "observed source batch");
+        Ok(())
+    }
+    fn shutdown(&self) { tracing::info!("side output shutting down"); }
+}
+```
+
+Register with an id:
+```rust
+register_plugin_side_output!("monitor", MonitorSideOutput);
+```
+
+Note: `SideOutputPlugin` is sync and returns `Result<(), String>` (a plain `String` error, not `PluginError`). Instances are auto-registered against every source; you don't wire a `from:`.
+
+## Registering many kinds in one crate
+
+A single `cdylib` can register sources, transforms, sinks, preprocessors, UDFs, and side outputs together — this is how production plugin crates are structured. Group them by `mod`, then list every macro call above the **single** `init_plugin_with_async_runtime!()`:
+
+```rust
+mod sinks; mod sources; mod transforms; mod udfs; mod preprocessors;
+
+use crate::preprocessors::DefaultsPreprocessor;
+use crate::sinks::{MySink, QueueSink};
+use crate::sources::ApiSource;
+use crate::transforms::FilterTransform;
+use crate::udfs::BytesToHexFunc;
+
+use streamling_plugin::{
+    init_plugin_with_async_runtime, register_plugin_preprocessor, register_plugin_sink,
+    register_plugin_source, register_plugin_transform, register_plugin_udf,
+    set_plugin_output_buffer,
+};
+
+register_plugin_source!("my_plugin", "api_source", ApiSource);
+set_plugin_output_buffer!("my_plugin.api_source", 1);
+
+register_plugin_transform!("my_plugin", "filter", FilterTransform);
+set_plugin_output_buffer!("my_plugin.filter", 1);
+
+register_plugin_sink!("my_sink", MySink);
+register_plugin_sink!("queue_sink", QueueSink);
+
+register_plugin_preprocessor!("defaults", DefaultsPreprocessor);
+register_plugin_udf!(BytesToHexFunc);
+
+init_plugin_with_async_runtime!();
+```
+
+Rules:
+- **Exactly one** `init_plugin_with_async_runtime!()`, at the bottom, regardless of how many components you registered.
+- `set_plugin_output_buffer!`/`set_plugin_input_buffer!` are optional, per-component, and take the **full** `plugin.id`.
+- Keep each component in its own module/file; only the registration list lives in `lib.rs`.
+
+## Low-level manual FFI (escape hatch)
+
+When the registration macros can't express what you need (a component constructed outside the standard closure, custom channel wiring), drop to the raw `PluginModule` ABI. This is advanced — prefer the macros whenever they fit. Shape (from the `low_level` example):
+
+```rust
+mod sink;
+
+use abi_stable::std_types::{RNone, ROption, RResult, RString, RVec};
+use abi_stable::{export_root_module, prefix_type::PrefixTypeTrait};
+use streamling_plugin::api::PluginStateBackendFactory;
+use streamling_plugin::r#async::PluginAsyncRuntimeObj;
+use streamling_plugin::ffi::SafeArrowSchema;
+use streamling_plugin::{
+    PluginChannels, PluginInitializationError, PluginLogging, PluginModule, PluginModuleRef,
+    PluginOptions, PluginResult, PluginRuntimeConfiguration, PluginUdfDescriptor,
+    PluginSideOutputDescriptor, RootModule, sink_generator,
+};
+use streamling_plugin::IntoSinkPluginResult;
+
+use crate::sink::MySink;
+
+extern "C" fn init(logging: PluginLogging) -> RResult<PluginRuntimeConfiguration, PluginInitializationError> {
+    logging.init_logger();
+    RResult::ROk(PluginRuntimeConfiguration { /* ... */ })
+}
+
+extern "C" fn create(
+    plugin_id: RString,
+    input_schema: ROption<SafeArrowSchema>,
+    options: PluginOptions,
+    runtime: PluginAsyncRuntimeObj,
+    state_backend_config: streamling_plugin::PluginStateBackendConfig,
+    message_channels: PluginChannels,
+) -> RResult<PluginResult, PluginInitializationError> {
+    let schema: arrow_schema::SchemaRef = input_schema.into_rust().unwrap().into();  // for sinks/transforms
+    sink_generator(
+        plugin_id,
+        |schema, rt, state, metrics, opts| {
+            IntoSinkPluginResult::into_sink_result(MySink::new(schema, rt, state, metrics, opts))
+        },
+        options,
+        runtime,
+        state_backend_config,
+        message_channels,
+    )
+}
+
+extern "C" fn udf_descriptors() -> RResult<RVec<PluginUdfDescriptor>, PluginInitializationError> {
+    RResult::ROk(RVec::new())
+}
+extern "C" fn side_output_descriptors() -> RResult<RVec<PluginSideOutputDescriptor>, PluginInitializationError> {
+    RResult::ROk(RVec::new())
+}
+
+#[export_root_module]
+pub fn get_module() -> PluginModuleRef {
+    PluginModule::new(init, create, udf_descriptors, side_output_descriptors)
+}
+```
+
+Use the low-level path only when you must hand-route `create` or channel handling; otherwise the macros generate this boilerplate correctly and keep you ABI-safe.
+
+## Common mistakes
+
+- **Preprocessor overwrites a user field.** Always check before writing; users must be able to override your defaults.
+- **UDF `invoke` panics on bad arity/types.** Validate and return a `DataFusionError`.
+- **Side output returns `PluginError`.** It returns `Result<(), String>` — different signature from the other kinds.
+- **Two `init_plugin_with_async_runtime!()` calls, or none.** Exactly one per crate.
+- **Reaching for low-level FFI when a macro works.** The macros handle ABI-stability details you can easily get wrong by hand.
+
+## Related skills
+
+- [`streamling-plugin-basics`](skill://streamling-plugin-basics) — crate setup, registration, lifecycle, options/secrets, errors.
+- [`streamling-source-plugin`](skill://streamling-source-plugin) / [`streamling-sink-plugin`](skill://streamling-sink-plugin) / [`streamling-transform-plugin`](skill://streamling-transform-plugin) — the main three kinds.
+- [`streamling-udf-plugin`](skill://streamling-udf-plugin) — custom SQL functions via DataFusion `ScalarUDFImpl`.
+- [`sql-transform`](skill://sql-transform) — SQL transform, the no-code alternative to a transform plugin or a UDF.

--- a/skills/streamling-plugin-basics/SKILL.md
+++ b/skills/streamling-plugin-basics/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: streamling-plugin-basics
+description: Use when creating a new streamling plugin crate in Rust (source, sink, transform, preprocessor, UDF, or side output), or when wiring up registration macros, constructor contracts, the plugin lifecycle, the async runtime, error types, or option/secret handling. Start here before the type-specific skills.
+---
+
+# streamling plugin basics — Agent Skill
+
+A streamling **plugin** is an independently compiled `cdylib` loaded at runtime via a stable ABI (`abi_stable`). A plugin crate can register any mix of six component kinds: **source**, **transform**, **sink**, **preprocessor**, **UDF**, and **side output**. This skill covers the crate skeleton, registration, the lifecycle every component shares, and the cross-cutting utilities (options, metrics, state, async runtime, errors). For the per-kind trait patterns, see the sibling skills.
+
+**Read this first**, then jump to the specific skill:
+- [`streamling-source-plugin`](skill://streamling-source-plugin)
+- [`streamling-sink-plugin`](skill://streamling-sink-plugin)
+- [`streamling-transform-plugin`](skill://streamling-transform-plugin)
+- [`streamling-udf-plugin`](skill://streamling-udf-plugin) — custom SQL functions (DataFusion UDFs).
+- [`streamling-advanced-plugins`](skill://streamling-advanced-plugins) — preprocessor, UDF, side output, multi-plugin crate, low-level FFI.
+
+## Crate setup
+
+A plugin is a Cargo crate compiled to `cdylib` (+ `rlib` so tests work) that depends on `streamling-plugin`.
+
+```toml
+# Cargo.toml
+[package]
+name = "my_plugins"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+name = "my_plugins"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+streamling-plugin = "0.2.0"          # or path = "../crates/streamling-plugin"
+abi_stable = "0.11.3"                # required by the init macro
+async-trait = "0.1.83"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tracing = "0.1"
+arrow = "55.2.0"
+arrow-schema = "55.2.0"
+serde = { version = "1", features = ["derive"] }
+```
+
+`crate-type = ["cdylib", "rlib"]` is mandatory — `cdylib` is what streamling loads; `rlib` lets unit tests link against your code.
+
+## Registration (lib.rs)
+
+Register every component with a macro, then invoke **exactly one** init macro at the bottom:
+
+```rust
+mod sink;
+mod source;
+
+use crate::sink::MySink;
+use crate::source::MySource;
+use streamling_plugin::{
+    init_plugin_with_async_runtime, register_plugin_sink, register_plugin_source,
+};
+
+// id can be "namespace.name" (two string args) or just "name" (one string arg).
+register_plugin_source!("my_plugin", "rest_source", MySource);
+register_plugin_sink!("my_sink", MySink);
+
+init_plugin_with_async_runtime!();
+```
+
+### Macro reference
+
+| Macro | Form | Notes |
+|---|---|---|
+| `register_plugin_source!` | `("ns", "name", T)` or `("name", T)` | `T::new(rt, state, metrics, opts)` |
+| `register_plugin_transform!` | `("ns", "name", T)` or `("name", T)` | `T::new(schema, rt, state, metrics, opts)` |
+| `register_plugin_sink!` | `("ns", "name", T)` or `("name", T)` | `T::new(schema, rt, state, metrics, opts)` |
+| `register_plugin_preprocessor!` | `("ns", "name", T)` or `("name", T)` | `T::new(opts)` |
+| `register_plugin_udf!` | `(T)` | `T: ScalarUDFImpl + Default` |
+| `register_plugin_udf_fn!` | `(create_fn)` | `fn() -> ScalarUDF` |
+| `register_plugin_side_output!` | `("id", T)` or `(T)` | `T: SideOutputPlugin` |
+| `set_plugin_output_buffer!` | `("plugin.id", capacity)` | backpressure cap on the output channel |
+| `set_plugin_input_buffer!` | `("plugin.id", capacity)` | cap on the input channel |
+| `init_plugin_with_async_runtime!` | `()` | **required, exactly once**, at the bottom |
+
+**The `plugin.id` string** is `namespace.name` when you pass two args, else `name`. The buffer-setter macros take that exact full id (e.g. `set_plugin_output_buffer!("my_plugin.rest_source", 1)`).
+
+**Two init macros exist.** Use `init_plugin_with_async_runtime!()` — it embeds a real Tokio runtime (`DirectTokioProxy`), so your plugin can call `tokio::time::sleep`, `tokio::task::spawn_blocking`, etc. directly. The bare `init_plugin!()` variant expects the host to supply the runtime and is rarely what a standalone plugin wants.
+
+## Constructor contracts (exact)
+
+The registration macros generate a closure that calls your `new()` with a fixed argument order. **Match it exactly** or the macro will fail to compile:
+
+| Kind | `new(...)` arguments | Return |
+|---|---|---|
+| Source | `rt, state_backend_factory, metrics_recorder, options` | `Result<Self, PluginInitializationError>` or `Self` |
+| Transform | `schema, rt, state_backend_factory, metrics_recorder, options` | `Result<Self, _>` or `Self` |
+| Sink | `schema, rt, state_backend_factory, metrics_recorder, options` | `Result<Self, _>` or `Self` |
+| Preprocessor | `options` | `Result<Self, _>` |
+
+Where:
+- `rt: PluginAsyncRuntimeObj`
+- `state_backend_factory: PluginStateBackendFactory`
+- `metrics_recorder: PluginMetricsRecorder`
+- `schema: arrow_schema::SchemaRef` (the upstream input schema — **not** passed to sources, which define their own)
+- `options: HashMap<String, String>` (parsed from the pipeline YAML `options:` map)
+
+The `Result<Self, PluginInitializationError>` form is preferred — it lets you reject bad config at create time with a clear `Configuration(..)` message instead of panicking. (The generator already catches panics and converts them to `Configuration` errors, but an explicit `Result` is cleaner.)
+
+## Lifecycle
+
+Every source/transform/sink runs the same protocol, driven by streamling over message channels:
+
+```
+initialize()                          # once, before any data
+  └─ process_batch(...)               # repeated: source→generate_batch, transform/sink→process_batch
+       process_checkpoint_marker(E)   # a checkpoint epoch is starting
+       process_checkpoint_finalizer(E)# that epoch is durably committed — safe to flush/advance
+  terminate()                         # graceful shutdown
+```
+
+**Checkpoint semantics (load-bearing):**
+- `process_checkpoint_marker(epoch)` — a checkpoint *beginning*. Returning `Ok` propagates the marker downstream. For sinks this means "an ack should be sent upstream."
+- `process_checkpoint_finalizer(epoch)` — the epoch is **durably committed**. This is where you persist durable progress: advance a cursor, flush a buffer, save state. If you maintain resumable progress, do it here, not in `process_batch`.
+- `process_batch` returning `Err` fails the pipeline. Empty batches are a normal "no data right now" signal — see the source skill.
+
+`SupportsGracefulShutdown` is a required supertrait for source/transform/sink:
+```rust
+fn is_running(&self) -> bool;                 // false → engine stops polling
+async fn terminate(&self) -> Result<(), PluginError>;  // release resources, set running=false
+```
+The standard idiom is an `Arc<AtomicBool>` flipped to `false` in `terminate()`.
+
+## Async runtime
+
+`rt: PluginAsyncRuntimeObj` exposes FFI-safe async primitives:
+```rust
+rt.spawn(fut);                       // spawn a detached task
+rt.sleep(RDuration::from_millis(100)).await;   // non-blocking sleep
+rt.timeout(RDuration::from_secs(5), fut).await;
+rt.block_on(fut);                    // rare; block on a future
+rt.yield_now().await;
+```
+`RDuration` comes from `abi_stable::std_types`. Because `init_plugin_with_async_runtime!()` installs a real Tokio runtime, you can also use `tokio::time::sleep`, `tokio::task::spawn_blocking`, and `tokio::sync` types directly inside your methods.
+
+## Options & secrets
+
+`options: HashMap<String, String>` arrives flat from the pipeline YAML. For anything non-trivial, centralize parsing in a small helper struct with typed accessors. **Secrets must come from environment variables, not YAML** — adopt this `PluginOptions` helper (it checks `ENV_PREFIX__KEY` before the YAML value and warns on plaintext secrets):
+
+```rust
+use std::collections::HashMap;
+use streamling_plugin::PluginError;
+use tracing::warn;
+
+pub struct PluginOptions {
+    options: HashMap<String, String>,
+    env_prefix: String,
+    plugin_name: String,
+}
+
+impl PluginOptions {
+    pub fn new(options: HashMap<String, String>, plugin_name: &str, env_prefix: &str) -> Self {
+        Self { options, env_prefix: env_prefix.to_string(), plugin_name: plugin_name.to_string() }
+    }
+
+    /// Required value: env var wins, then YAML, else error.
+    pub fn get(&self, key: &str) -> Result<String, PluginError> {
+        let env_key = format!("{}__{}", self.env_prefix, key.to_uppercase());
+        if let Ok(v) = std::env::var(&env_key) { return Ok(v); }
+        self.options.get(key).cloned().ok_or_else(|| {
+            PluginError::Internal(format!("{}: required option '{}' is not set", self.plugin_name, key))
+        })
+    }
+
+    /// Optional value with default.
+    pub fn get_or(&self, key: &str, default: &str) -> String {
+        let env_key = format!("{}__{}", self.env_prefix, key.to_uppercase());
+        std::env::var(&env_key).ok().or_else(|| self.options.get(key).cloned())
+            .unwrap_or_else(|| default.to_string())
+    }
+
+    /// Secret: env var only; warn if found in plaintext YAML.
+    pub fn get_secret(&self, key: &str) -> Option<String> {
+        let env_key = format!("{}__{}", self.env_prefix, key.to_uppercase());
+        std::env::var(&env_key).ok().or_else(|| {
+            self.options.get(key).map(|v| {
+                warn!("{key} set in plaintext YAML — prefer env var {env_key}.");
+                v.clone()
+            })
+        })
+    }
+
+    pub fn get_usize(&self, key: &str, default: usize) -> usize {
+        self.options.get(key).and_then(|s| s.parse().ok()).unwrap_or(default)
+    }
+}
+```
+Convention: prefix is `STREAMLING__PLUGIN__<UPPER_NAME>` (e.g. `STREAMLING__PLUGIN__MY_SINK`). Parse numeric/bool options with `.parse()` and a sensible default — never `unwrap()` user input.
+
+## Metrics & identity labels
+
+`metrics_recorder: PluginMetricsRecorder` emits custom Prometheus series:
+
+| Method | Series type |
+|---|---|
+| `record_count(name, u64)` / `record_count_w_tags(name, u64, vec![("k","v")])` | counter |
+| `record_latency(name, Duration)` / `record_latency_w_tags(name, dur, tags)` | timing (ms) |
+| `record_gauge(name, u64)` / `record_gauge_w_tags(name, u64, tags)` | gauge |
+
+Metric dispatch is best-effort (channel `try_send`) — a full channel just logs a warning, never fails the batch.
+
+**Identity labels** (`labels()` override on source/transform/sink) declare *what this instance is* and attach to every built-in metric the node emits. Derive them from options at construction:
+```rust
+fn labels(&self) -> Vec<PluginLabel> {
+    vec![PluginLabel::new("dataset", self.dataset_name.clone())]
+}
+```
+`PluginLabel::new(key, value)`. Keep keys Prometheus-legal and avoid the reserved built-ins (`topic`, `table`, `url`, `type`, `id`, `operator_type`, …).
+
+## State backend
+
+`state_backend_factory.create::<V>()` returns an `Arc<PluginStateBackend<V>>` for checkpointed, resumable state. `V: Serialize + Deserialize + Send + Sync + Clone + Debug + 'static`.
+
+```rust
+let state: Arc<PluginStateBackend<MyState>> = state_backend_factory.create();
+let resume: Option<MyState> = state.get().await.map_err(PluginError::State)?;
+state.put(MyState { cursor: 123 }).await.map_err(PluginError::State)?;
+```
+- `get()` / `put(v)` / `remove()` — single value under the default key (`{reference_name}`).
+- `get_kv(k)` / `put_kv(k, v)` / `remove_kv(k)` — keyed values under `{prefix}:{k}`; `set_prefix(Some(""))` goes global.
+- Persist durable progress in `process_checkpoint_finalizer`, restore in `initialize`. See the source skill for the full resume pattern.
+
+## Errors
+
+Two error enums:
+
+```rust
+// Construction-time (returned from new()):
+pub enum PluginInitializationError {
+    NotImplemented,
+    Configuration(RString),   // bad options/config
+    Execution(RString),
+}
+
+// Runtime (returned from trait methods):
+pub enum PluginError {
+    ArrowError(ArrowError),
+    IoError(io::Error),
+    Internal(String),         // config/setup/programming errors
+    Execution(String),        // transient data-processing failures
+    State(StateBackendError),
+}
+```
+Rule of thumb: `Internal` for "this plugin is misconfigured / something is wrong with me," `Execution` for "this batch failed but the pipeline can retry." Map external errors with `.map_err(|e| PluginError::Internal(format!("..: {e}")))`.
+
+## Minimal end-to-end skeleton (sink)
+
+```rust
+// src/sink.rs
+use arrow::array::RecordBatch;
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use streamling_plugin::api::{PluginStateBackendFactory, SupportsGracefulShutdown};
+use streamling_plugin::r#async::PluginAsyncRuntimeObj;
+use streamling_plugin::ffi::PluginMetricsRecorder;
+use streamling_plugin::{CheckpointEpoch, PluginError, SinkPlugin};
+
+pub struct PrintSink {
+    schema: SchemaRef,
+    running: Arc<AtomicBool>,
+}
+
+impl PrintSink {
+    pub fn new(
+        schema: SchemaRef,
+        _rt: PluginAsyncRuntimeObj,
+        _state: PluginStateBackendFactory,
+        _metrics: PluginMetricsRecorder,
+        _options: HashMap<String, String>,
+    ) -> Self {
+        Self { schema, running: Arc::new(AtomicBool::new(true)) }
+    }
+}
+
+#[async_trait]
+impl SupportsGracefulShutdown for PrintSink {
+    fn is_running(&self) -> bool { self.running.load(Ordering::SeqCst) }
+    async fn terminate(&self) -> Result<(), PluginError> {
+        self.running.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SinkPlugin for PrintSink {
+    async fn initialize(&self) -> Result<(), PluginError> { Ok(()) }
+    async fn process_batch(&self, batch: RecordBatch) -> Result<(), PluginError> {
+        if batch.num_rows() == 0 { return Ok(()); }
+        tracing::info!(rows = batch.num_rows(), "received batch");
+        Ok(())
+    }
+    async fn process_checkpoint_marker(&self, _e: CheckpointEpoch) -> Result<(), PluginError> { Ok(()) }
+    async fn process_checkpoint_finalizer(&self, _e: CheckpointEpoch) -> Result<(), PluginError> { Ok(()) }
+}
+```
+
+## Common mistakes
+
+- **Wrong `new()` arity or order.** The macros call a fixed signature (see the table). A source that takes `schema` first, or a sink that omits it, won't compile.
+- **Forgetting `init_plugin_with_async_runtime!()`.** Without it the module exports nothing loadable.
+- **Panic in `process_batch`.** It crashes the worker thread. Return `Err(PluginError::..)` instead.
+- **Plaintext secrets in YAML.** Use the `get_secret` env-var pattern.
+- **`unwrap()` on user-supplied options.** Parse with defaults; reject bad config via `PluginInitializationError::Configuration`.
+- **Doing durable work in `process_batch` instead of `process_checkpoint_finalizer`.** Breaks exactly-once — the finalizer is the commit point.
+
+## Related skills
+
+- [`streamling-source-plugin`](skill://streamling-source-plugin) — sources, `_gs_op`, resume, backpressure.
+- [`streamling-sink-plugin`](skill://streamling-sink-plugin) — sinks, batching, retry, partial failure.
+- [`streamling-transform-plugin`](skill://streamling-transform-plugin) — transforms, arrow compute.
+- [`streamling-udf-plugin`](skill://streamling-udf-plugin) — custom SQL functions (DataFusion UDFs).
+- [`streamling-advanced-plugins`](skill://streamling-advanced-plugins) — preprocessors, side outputs, multi-kind crates, low-level FFI.

--- a/skills/streamling-sink-plugin/SKILL.md
+++ b/skills/streamling-sink-plugin/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: streamling-sink-plugin
+description: Use when implementing a streamling SinkPlugin — lazy client initialization in initialize(), the empty-batch guard, converting RecordBatch to NDJSON for outbound writes, batched writes with retry and exponential backoff, partial-batch-failure handling that avoids silent data loss, and checkpoint-ack semantics for exactly-once. Assumes streamling-plugin-basics.
+---
+
+# streamling sink plugin — Agent Skill
+
+A **sink** consumes `RecordBatch`es at the tail of a pipeline and writes them to an external system (a database, queue, object store, webhook). Sinks receive an upstream schema, do heavy I/O, and must preserve exactly-once semantics through the checkpoint protocol.
+
+**Prerequisite:** [`streamling-plugin-basics`](skill://streamling-plugin-basics) (crate setup, registration, lifecycle, errors).
+
+## The trait
+
+```rust
+#[async_trait]
+pub trait SinkPlugin: SupportsGracefulShutdown + Send + Sync {
+    async fn initialize(&self) -> Result<(), PluginError>;
+    fn labels(&self) -> Vec<PluginLabel> { Vec::new() }            // optional identity
+    async fn process_batch(&self, data: RecordBatch) -> Result<(), PluginError>;
+    async fn process_checkpoint_marker(&self, epoch: CheckpointEpoch) -> Result<(), PluginError>;
+    async fn process_checkpoint_finalizer(&self, epoch: CheckpointEpoch) -> Result<(), PluginError>;
+}
+```
+
+Constructor (called by `register_plugin_sink!` — **schema first**, it's the upstream input schema):
+```rust
+pub fn new(
+    schema: SchemaRef,
+    rt: PluginAsyncRuntimeObj,
+    state_backend_factory: PluginStateBackendFactory,
+    metrics_recorder: PluginMetricsRecorder,
+    options: HashMap<String, String>,
+) -> Result<Self, PluginInitializationError>   // or Self
+```
+
+Note: sinks do **not** implement `output_schema` — they produce no batches.
+
+## Lazy client init in `initialize()`
+
+Construct network clients (DB pools, queue clients, HTTP clients) in `initialize()`, **not** `new()`. `new()` should only parse options and store handles. Use `OnceLock` so `initialize` is idempotent and so the client lives for the instance:
+
+```rust
+pub struct QueueSink {
+    opts: PluginOptions,
+    client: OnceLock<QueueClient>,
+    queue_url: OnceLock<String>,
+    running: Arc<AtomicBool>,
+}
+
+impl QueueSink {
+    pub fn new(schema: SchemaRef, _rt: PluginAsyncRuntimeObj, _state: PluginStateBackendFactory,
+               _metrics: PluginMetricsRecorder, options: HashMap<String, String>) -> Self {
+        Self {
+            opts: PluginOptions::new(options, "queue_sink", "STREAMLING__PLUGIN__QUEUE_SINK"),
+            client: OnceLock::new(),
+            queue_url: OnceLock::new(),
+            running: Arc::new(AtomicBool::new(true)),
+        }
+    }
+}
+
+#[async_trait]
+impl SinkPlugin for QueueSink {
+    async fn initialize(&self) -> Result<(), PluginError> {
+        if self.client.get().is_some() { return Ok(()); }          // idempotent
+
+        let endpoint = self.opts.get("endpoint_url")?;              // env var > YAML > error
+        let queue_url = self.opts.get("queue_url")?;
+        let access_key = self.opts.get_secret("access_key_id");    // env var only
+        let secret = self.opts.get_secret("secret_access_key");
+
+        let mut client = QueueClient::builder().endpoint(endpoint);
+        if let (Some(id), Some(sec)) = (access_key, secret) {
+            client = client.credentials(id, sec);
+        }
+        let client = client.build().await
+            .map_err(|e| PluginError::Internal(format!("client build: {e}")))?;
+
+        let _ = self.client.set(client);
+        let _ = self.queue_url.set(queue_url.clone());
+        Ok(())
+    }
+    // ...
+}
+```
+Rationale: `new()` is cheap and synchronous-ish (config parsing); `initialize()` is the async, fallible, network-touching setup. This also makes the struct unit-testable without a live network.
+
+## The empty-batch guard
+
+Always short-circuit empty batches first — the engine legitimately sends them (idle upstream, checkpoint-only epochs):
+```rust
+async fn process_batch(&self, batch: RecordBatch) -> Result<(), PluginError> {
+    if !self.is_running() {
+        return Err(PluginError::Internal("sink not running".into()));
+    }
+    if batch.num_rows() == 0 {
+        return Ok(());                   // nothing to do — do NOT treat as error
+    }
+    // ... actual write
+}
+```
+
+## RecordBatch → NDJSON
+
+Most sinks serialize rows to newline-delimited JSON. Use `arrow_json::LineDelimitedWriter` over a projected schema:
+
+```rust
+use arrow_json::LineDelimitedWriter;
+
+/// One JSON object per row, returned as owned byte buffers.
+pub fn record_batch_to_ndjson(batch: &RecordBatch) -> Result<Vec<Vec<u8>>, arrow_schema::ArrowError> {
+    let mut buf = Vec::new();
+    {
+        let mut w = LineDelimitedWriter::new(&mut buf);
+        w.write_batch(batch)?;
+        w.finish()?;
+    }
+    // split the single buffer into per-row slices at newlines
+    Ok(buf.split(|&b| b == b'\n')
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_vec())
+        .collect())
+}
+```
+
+**Gotcha — wide integers:** `arrow_json` renders `FixedSizeBinary(32)` (the streamling U256 extension type) as hex. If your dataset carries large numeric columns tagged with the `streamling.u256` extension metadata, pre-cast those columns to decimal-string `Utf8` before writing, so downstream JSON consumers get decimal strings. For ordinary (`Int*`, `Utf8`, `Float64`, `Boolean`, timestamps) columns, the default writer output is correct.
+
+## Batched writes with retry + partial-failure
+
+External APIs cap batch size (e.g. message-queue APIs commonly cap at 10 entries per call) and may fail *some* entries of a batch while succeeding others. A correct sink chunks, retries the failed subset with exponential backoff, and treats unrecoverable failures as fatal. This pattern — mined from production queue sinks — is the single most important thing to get right, because naive handling silently loses data.
+
+```rust
+const MAX_BATCH_SIZE: usize = 10;          // service limit
+const MAX_RETRIES: u32 = 5;
+
+async fn process_batch(&self, batch: RecordBatch) -> Result<(), PluginError> {
+    if batch.num_rows() == 0 { return Ok(()); }
+
+    let client = self.client.get()
+        .ok_or_else(|| PluginError::Internal("client not initialized".into()))?;
+    let queue_url = self.queue_url.get().unwrap();
+
+    let rows = record_batch_to_ndjson(&batch)
+        .map_err(|e| PluginError::Internal(format!("to json: {e}")))?;
+    let messages: Vec<String> = rows.into_iter()
+        .map(|b| String::from_utf8(b)
+            .map_err(|e| PluginError::Internal(format!("utf8: {e}"))).unwrap())
+        .collect::<Result<_, _>>()?;
+    if messages.is_empty() { return Ok(()); }
+
+    self.send_all(client, queue_url, &messages).await?;
+    Ok(())
+}
+
+/// Send every message, chunking to the service limit, retrying only failures.
+async fn send_all(&self, client: &QueueClient, url: &str, msgs: &[String]) -> Result<usize, PluginError> {
+    let mut total = 0;
+    // track original index with each message so partial-failure results map back
+    let mut pending: Vec<(usize, String)> = msgs.iter().enumerate().map(|(i, s)| (i, s.clone())).collect();
+    while !pending.is_empty() {
+        let chunk: Vec<_> = pending.drain(..std::cmp::min(MAX_BATCH_SIZE, pending.len())).collect();
+        let (sent, failed) = self.send_chunk_with_retry(client, url, &chunk).await?;
+        total += sent;
+        pending.extend(failed);       // only the still-failing subset loops again
+    }
+    Ok(total)
+}
+
+async fn send_chunk_with_retry(
+    &self, client: &QueueClient, url: &str, chunk: &[(usize, String)],
+) -> Result<(usize, Vec<(usize, String)>), PluginError> {
+    let chunk_len = chunk.len();
+    let mut to_retry: Vec<(usize, String)> = chunk.to_vec();
+    let mut backoff_ms: u64 = 100;
+
+    for attempt in 0..=MAX_RETRIES {
+        let entries = to_retry.iter().enumerate().map(|(i, (_, body))| {
+            client.build_entry(format!("msg_{i}"), body.clone())   // stable id = position in to_retry
+        }).collect::<Result<Vec<_>, _>>()?;
+
+        let result = client.send_batch(url, entries).await
+            .map_err(|e| PluginError::Internal(format!("send: {e}")))?;
+
+        let failed = result.failed_entries();
+        if failed.is_empty() {
+            return Ok((chunk_len, vec![]));                         // all sent
+        }
+
+        // Sender faults are non-retryable — the request itself is malformed.
+        for f in failed.iter() {
+            if f.sender_fault() {
+                return Err(PluginError::Internal(format!(
+                    "unrecoverable sender fault: {}", f.message())));
+            }
+        }
+
+        // Map failed ids back to the messages they referred to.
+        let mut retry = Vec::new();
+        for f in failed.iter() {
+            let i = f.id().strip_prefix("msg_").and_then(|s| s.parse::<usize>().ok());
+            match i.filter(|&i| i < to_retry.len()) {
+                Some(i) => retry.push(to_retry[i].clone()),
+                None => return Err(PluginError::Internal(format!(
+                    "could not map failed entry id {} back to a message — possible data loss", f.id()))),
+            }
+        }
+
+        if attempt == MAX_RETRIES {
+            return Err(PluginError::Internal(format!(
+                "{} messages failed after {MAX_RETRIES} retries", retry.len())));
+        }
+
+        tracing::warn!(failed = retry.len(), attempt, "partial failure; retrying");
+        tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+        backoff_ms = std::cmp::min(backoff_ms * 2, 5_000);          // capped exponential
+        to_retry = retry;
+    }
+    Ok((0, vec![]))
+}
+```
+
+The three things that make this safe:
+1. **Stable per-attempt ids** (`msg_{index-into-to_retry}`) so a partial-failure result can be mapped back to exact messages.
+2. **Unmapped id → hard error.** If a failed entry's id can't be mapped back, you don't know which message failed — treat it as data-loss and error out rather than silently dropping it.
+3. **Sender fault → fatal.** A sender fault means the request is malformed; retrying wastes the budget and masks a bug.
+
+For idempotent sinks (upsert by primary key), you can retry whole batches on transient errors without dedup worry. For append-only sinks (queues, webhooks), per-entry tracking as above is what prevents loss.
+
+## Checkpoint acks (exactly-once)
+
+Sinks ack upstream through the checkpoint protocol:
+- `process_checkpoint_marker(epoch)` — a checkpoint is starting. Return `Ok` to ack; this tells the source its data is safe to advance.
+- `process_checkpoint_finalizer(epoch)` — the epoch is durably committed. For a sink that buffers writes internally, **flush here** so a committed epoch is genuinely durable before the source advances past it.
+
+```rust
+async fn process_checkpoint_marker(&self, epoch: CheckpointEpoch) -> Result<(), PluginError> {
+    tracing::info!(epoch = epoch.0, "checkpoint marker acked");
+    Ok(())
+}
+async fn process_checkpoint_finalizer(&self, epoch: CheckpointEpoch) -> Result<(), PluginError> {
+    // If you buffer writes, flush/commit them now so the acked epoch is durable.
+    self.flush().await?;
+    Ok(())
+}
+```
+If `process_batch` already writes synchronously and the destination is durable per-call, the finalizer can be a no-op. The rule: **by the time the finalizer returns Ok, everything up to that epoch must survive a crash.**
+
+## Upsert sinks (DB-style)
+
+For database sinks with a primary key and `on_conflict: update`:
+- Read `primary_key` and `on_conflict` from options.
+- Use the `_gs_op` column to decide insert/update vs delete: rows with `"d"` issue a delete by key; `"i"`/`u"` issue an upsert.
+- Batch into multi-row `INSERT ... ON CONFLICT` statements chunked to a safe size; reuse the retry helper above for transient DB errors (deadlocks, connection blips). Distinguish retriable (connection, serialization) from fatal (constraint violation) errors.
+
+## Identity labels & metrics
+
+```rust
+fn labels(&self) -> Vec<PluginLabel> {
+    vec![PluginLabel::new("destination", self.opts.get_or("table", "default"))]
+}
+```
+Emit timing for the slow path:
+```rust
+let start = Instant::now();
+self.send_all(client, url, &messages).await?;
+self.metrics_recorder.record_latency_w_tags(
+    "sink_send_latency", start.elapsed(), vec![("table", &table)]);
+```
+
+## Common mistakes
+
+- **Building the client in `new()`.** Do it in `initialize()` behind a `OnceLock`. `new()` must stay cheap.
+- **Treating empty batches as errors.** They're normal; guard and return `Ok(())`.
+- **Retrying the whole batch on partial failure.** Re-sends the successful entries; for non-idempotent destinations that's duplicates or loss. Retry only the failed subset with stable id mapping.
+- **Silently dropping unmappable failures.** Error out — "possible data loss" must be loud.
+- **Flushing in `process_batch` only.** If you buffer, the checkpoint finalizer is the commit point; not flushing there can lose buffered data on crash.
+- **Hex-encoded wide integers in JSON.** Pre-cast U256 extension columns to decimal strings.
+
+## Related skills
+
+- [`streamling-plugin-basics`](skill://streamling-plugin-basics) — registration, options/secrets (`PluginOptions`), state backend, error types.
+- [`streamling-source-plugin`](skill://streamling-source-plugin) — the producing half; source finalizers and sink acks are the two ends of the exactly-once contract.

--- a/skills/streamling-source-plugin/SKILL.md
+++ b/skills/streamling-source-plugin/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: streamling-source-plugin
+description: Use when implementing a streamling SourcePlugin — defining the output schema and _gs_op column, generate_batch and the empty-batch means-no-data contract, decomposing a source into fetcher/buffer/runner, resumable cursor or sequential pagination that survives restart via the checkpoint state backend, and output-channel backpressure. Assumes streamling-plugin-basics.
+---
+
+# streamling source plugin — Agent Skill
+
+A **source** is the head of a pipeline: it owns its schema, produces `RecordBatch`es on demand, and drives checkpointing. Sources are pull-based — streamling calls `generate_batch()` repeatedly and stops when `is_running()` is false or the pipeline drains.
+
+**Prerequisite:** [`streamling-plugin-basics`](skill://streamling-plugin-basics) (crate setup, registration, lifecycle, errors).
+
+## The trait
+
+```rust
+#[async_trait]
+pub trait SourcePlugin: SupportsGracefulShutdown + Send + Sync {
+    async fn initialize(&self) -> Result<(), PluginError>;
+    fn output_schema(&self) -> Result<SchemaRef, PluginError>;
+    fn labels(&self) -> Vec<PluginLabel> { Vec::new() }            // optional identity
+    async fn generate_batch(&self) -> Result<RecordBatch, PluginError>;
+    async fn process_checkpoint_marker(&self, epoch: CheckpointEpoch) -> Result<(), PluginError>;
+    async fn process_checkpoint_finalizer(&self, epoch: CheckpointEpoch) -> Result<(), PluginError>;
+}
+```
+
+Constructor (called by `register_plugin_source!` — **no schema arg**, the source owns it):
+```rust
+pub fn new(
+    rt: PluginAsyncRuntimeObj,
+    state_backend_factory: PluginStateBackendFactory,
+    metrics_recorder: PluginMetricsRecorder,
+    options: HashMap<String, String>,
+) -> Result<Self, PluginInitializationError>
+```
+
+## Output schema and the `_gs_op` column
+
+A source emits change-data with a per-row operation column. Import the canonical name and include it:
+
+```rust
+use streamling_plugin::api::STREAMLING_COLUMN_NAME_OP; // == "_gs_op"
+
+let schema = Arc::new(Schema::new(vec![
+    Field::new("id", DataType::Utf8, false),
+    Field::new("value", DataType::Int64, false),
+    Field::new(STREAMLING_COLUMN_NAME_OP, DataType::Utf8, false),  // "i" | "u" | "d"
+]));
+```
+
+`_gs_op` values: `"i"` insert, `"u"` update, `"d"` delete. Downstream sinks use it to apply upsert/delete semantics. If your source is append-only, emit `"i"` for every row — but the column is still expected by the engine.
+
+`output_schema()` must return the **same** schema for the life of the instance. Build it once in `new()` and clone it.
+
+## `generate_batch` — the pull contract
+
+- Return a **non-empty** `RecordBatch` when you have data.
+- Return an **empty batch** (`RecordBatch::new_empty(self.schema.clone())`) when there is no data right now. The engine treats this as "not done, just idle" and will poll again. Do **not** block indefinitely inside `generate_batch` — sleep briefly then return empty if still waiting, so shutdown stays responsive.
+- Return `Err(PluginError::..)` to fail the pipeline.
+
+Building a batch with Arrow builders:
+```rust
+async fn generate_batch(&self) -> Result<RecordBatch, PluginError> {
+    let rows = self.buffer.next_batch().await;
+    if rows.is_empty() {
+        return Ok(RecordBatch::new_empty(self.schema.clone()));
+    }
+    let mut ids = arrow::array::StringBuilder::new();
+    let mut vals = arrow::array::Int64Builder::new();
+    let mut ops = arrow::array::StringBuilder::new();
+    for r in &rows {
+        ids.append_value(&r.id);
+        vals.append_value(r.value);
+        ops.append_value("u");                 // or "i"/"d"
+    }
+    Ok(RecordBatch::try_new(self.schema.clone(), vec![
+        Arc::new(ids.finish()), Arc::new(vals.finish()), Arc::new(ops.finish()),
+    ]).map_err(|e| PluginError::ArrowError(e))?)
+}
+```
+
+## Fetcher / buffer / runner decomposition
+
+Anything beyond a toy source should be split into three pieces (this is the shape every non-trivial production source converges on):
+
+- **Fetcher** — pure async `fetch_page(cursor) -> (Vec<Item>, next_cursor)`. No streamling types; trivially unit-testable against a mock HTTP client.
+- **Buffer** — an ordered, bounded queue that the runner fills and `generate_batch` drains. Caps memory and provides backpressure.
+- **Runner** (the `SourcePlugin` impl) — wires fetcher + buffer + checkpoint state to the streamling lifecycle: starts a background poll loop in `initialize`, drains in `generate_batch`, persists progress in `process_checkpoint_finalizer`, stops in `terminate`.
+
+Keep the streamling trait impl thin; push logic into the fetcher/buffer so you can test it without the FFI.
+
+## Resumable pagination via the state backend
+
+The durable-resume pattern: store a cursor/offset in `PluginStateBackend`, advance it only on `process_checkpoint_finalizer` (the commit point), and restore it in `initialize`.
+
+```rust
+#[derive(Serialize, Deserialize, Clone, Debug)]
+struct Cursor { last_ts_ms: i64, token: Option<String> }
+
+pub struct ApiSource {
+    schema: SchemaRef,
+    client: ApiClient,
+    buffer: Arc<OrderedBuffer<Row>>,        // shared with the poll loop
+    state: Arc<PluginStateBackend<Cursor>>,
+    running: Arc<AtomicBool>,
+    cursor: OnceLock<Cursor>,               // set in initialize
+}
+
+#[async_trait]
+impl SourcePlugin for ApiSource {
+    async fn initialize(&self) -> Result<(), PluginError> {
+        // Restore committed progress; fall back to the configured start.
+        let mut cursor = self.state.get().await.map_err(PluginError::State)?
+            .unwrap_or_else(|| Cursor { last_ts_ms: self.start_ts, token: None });
+        // never regress past the configured start
+        if cursor.last_ts_ms < self.start_ts { cursor.last_ts_ms = self.start_ts; }
+
+        let buf = self.buffer.clone();
+        let client = self.client.clone();
+        let running = self.running.clone();
+        // background poll loop (detached; Arcs keep it alive)
+        tokio::spawn(async move {
+            while running.load(Ordering::SeqCst) {
+                let page = match client.fetch_page(&cursor).await {
+                    Ok(p) => p,
+                    Err(e) => { tracing::warn!(error=%e, "fetch failed; will retry"); continue; }
+                };
+                if page.items.is_empty() {
+                    tokio::time::sleep(Duration::from_millis(60_000)).await;
+                    continue;
+                }
+                cursor = page.next_cursor();          // monotonic advance
+                buf.push(page.items).await;
+            }
+        });
+        let _ = self.cursor.set(cursor);
+        Ok(())
+    }
+
+    async fn generate_batch(&self) -> Result<RecordBatch, PluginError> {
+        let rows = self.buffer.next_batch().await;    // drains up to batch_size
+        if rows.is_empty() { return Ok(RecordBatch::new_empty(self.schema.clone())); }
+        // advance an in-memory high-water mark (never regress)
+        if let Some(last) = rows.last() {
+            self.last_ts_ms.fetch_max(last.ts_ms, Ordering::AcqRel);
+        }
+        build_batch(&self.schema, &rows)
+    }
+
+    async fn process_checkpoint_marker(&self, _e: CheckpointEpoch) -> Result<(), PluginError> { Ok(()) }
+
+    async fn process_checkpoint_finalizer(&self, _e: CheckpointEpoch) -> Result<(), PluginError> {
+        // THE commit point: persist durable progress here, never in generate_batch.
+        let cursor = Cursor {
+            last_ts_ms: self.last_ts_ms.load(Ordering::Acquire),
+            token: self.cursor.get().and_then(|c| c.token.clone()),
+        };
+        self.state.put(cursor).await.map_err(PluginError::State)
+    }
+}
+```
+
+**Why finalizer, not `process_batch`:** the finalizer fires only after the epoch is durably committed across the whole pipeline. Writing the cursor here gives exactly-once resume — a restart replays from the last committed cursor, never skipping data or emitting it twice durably.
+
+**Monotonic cursor:** always `fetch_max`/max — never let a late or reordered page move the high-water mark backwards.
+
+### Two pagination flavors
+
+- **Numeric/height pagination** (keyed by a monotonic `u64`, e.g. a sequence number or block height): use a *sequential* source — pages are `height..height+N`, dedup by height, resume stores the last height.
+- **Opaque cursor + timestamp** (server-issued `next_page` token plus a monotonic timestamp): use a *cursor* source — resume stores `{last_ts_ms, token}`, and on restart you re-request from the token or re-scan from `last_ts_ms`. Catalog/reference APIs that change in place (a row's fields update over time) benefit from **content-hash dedup**: hash each row excluding its observed-at field, and only forward rows whose hash changed since last emit (in-process map, cleared on restart → one at-least-once re-emit, which is the documented tradeoff).
+
+### Snapshot-then-tail (hybrid) sources
+
+When a dataset has a finite historical snapshot and then a live tail, run the snapshot to completion first, record the handoff point in state, then switch to polling the tail from that point. Keep both phases writing the same schema and `_gs_op`. The same source can expose both phases under one `SourcePlugin`; streamling also has a native `hybrid` source type if you'd rather compose two providers.
+
+## Backpressure
+
+If your source can produce faster than the downstream can consume, bound the output channel:
+
+```rust
+register_plugin_source!("my_plugin", "api_source", ApiSource);
+set_plugin_output_buffer!("my_plugin.api_source", 1);   // capacity 1: strict backpressure
+```
+
+A capacity of `1` makes the source block (cooperative, via the channel) until the downstream drains — useful for heavy transforms that can't keep up. Larger capacities decouple producer/consumer at the cost of memory. Pair with a bounded internal buffer so your poll loop naturally stalls instead of allocating unbounded memory.
+
+## Shutdown
+
+```rust
+#[async_trait]
+impl SupportsGracefulShutdown for ApiSource {
+    fn is_running(&self) -> bool { self.running.load(Ordering::SeqCst) }
+    async fn terminate(&self) -> Result<(), PluginError> {
+        self.running.store(false, Ordering::SeqCst);   // poll loop exits on next check
+        Ok(())
+    }
+}
+```
+Keep `is_running()` returning `true` until `initialize` has run (e.g. gate on a `OnceLock` being set), so the engine doesn't bail before you've started.
+
+## Heavy row-building: use `spawn_blocking`
+
+If converting fetched items into an Arrow batch is CPU-heavy (wide rows, many columns), move it off the async thread:
+```rust
+let schema = self.schema.clone();
+let batch = tokio::task::spawn_blocking(move || build_batch(&schema, &items))
+    .await
+    .map_err(|e| PluginError::Internal(format!("blocking task: {e}")))??;
+```
+
+## Common mistakes
+
+- **Blocking forever in `generate_batch`.** Sleep-then-empty when idle, so `terminate` is prompt.
+- **Persisting cursor in `process_batch`.** Breaks exactly-once. Use `process_checkpoint_finalizer`.
+- **Regressing the cursor.** Use `fetch_max`/max on restore and on each batch.
+- **No `_gs_op` column.** The engine and CDC-aware sinks expect it.
+- **Schema drift.** `output_schema()` must be stable for the instance's lifetime.
+- **Unbounded buffer under backpressure.** Cap the channel with `set_plugin_output_buffer!` and the internal buffer together.
+
+## Related skills
+
+- [`streamling-plugin-basics`](skill://streamling-plugin-basics) — registration, lifecycle, options/secrets, state backend API.
+- [`streamling-sink-plugin`](skill://streamling-sink-plugin) — the consuming half; sink checkpoint acks mirror source finalizers.

--- a/skills/streamling-transform-plugin/SKILL.md
+++ b/skills/streamling-transform-plugin/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: streamling-transform-plugin
+description: Use when implementing a streamling TransformPlugin — process_batch with RecordBatch in and RecordBatch out, declaring output_schema, filtering or projecting with Arrow compute (boolean masks, filter_record_batch), handling empty batches, and passing checkpoints through. Use this instead of the built-in sql transform when row logic needs custom Rust or external calls. Assumes streamling-plugin-basics.
+---
+
+# streamling transform plugin — Agent Skill
+
+A **transform** sits in the middle of a pipeline: it receives an upstream `RecordBatch`, returns a (possibly reshaped) `RecordBatch`, and propagates checkpoints. Transforms are stateless-by-default row pipelines — use one when the built-in `sql` transform can't express the logic (custom Rust, per-row external calls, non-SQL projections).
+
+**Prerequisite:** [`streamling-plugin-basics`](skill://streamling-plugin-basics) (crate setup, registration, lifecycle, errors).
+
+**When NOT to write a transform:** if the work is column projection/renaming, a `UNION ALL`, or a `JOIN`, the built-in `type: sql` transform (DataFusion) is simpler and faster — see [`sql-transform`](skill://sql-transform). Reach for a plugin transform only when you need imperative Rust or side effects the SQL engine can't do.
+
+## The trait
+
+```rust
+#[async_trait]
+pub trait TransformPlugin: SupportsGracefulShutdown + Send + Sync {
+    async fn initialize(&self) -> Result<(), PluginError>;
+    fn output_schema(&self) -> Result<SchemaRef, PluginError>;
+    fn labels(&self) -> Vec<PluginLabel> { Vec::new() }
+    async fn process_batch(&self, data: RecordBatch) -> Result<RecordBatch, PluginError>;
+    async fn process_checkpoint_marker(&self, epoch: CheckpointEpoch) -> Result<(), PluginError>;
+    async fn process_checkpoint_finalizer(&self, epoch: CheckpointEpoch) -> Result<(), PluginError>;
+}
+```
+
+Constructor (called by `register_plugin_transform!` — **schema first**):
+```rust
+pub fn new(
+    schema: SchemaRef,                       // upstream input schema
+    rt: PluginAsyncRuntimeObj,
+    state_backend_factory: PluginStateBackendFactory,
+    metrics_recorder: PluginMetricsRecorder,
+    options: HashMap<String, String>,
+) -> Result<Self, PluginInitializationError>   // or Self
+```
+
+## `output_schema` — pass-through vs reshape
+
+- **Pass-through** (filter, enrich-in-place): return the input schema unchanged.
+- **Reshape** (drop/add/rename columns): return a *different* schema, built once in `new()`. Downstream stages see whatever you return here.
+
+```rust
+fn output_schema(&self) -> Result<SchemaRef, PluginError> {
+    Ok(self.output_schema.clone())     // precomputed in new()
+}
+```
+
+## `process_batch` — the core contract
+
+- Receive a `RecordBatch`, return a `RecordBatch`.
+- **Empty in → empty out.** Always handle `num_rows() == 0` first (return the empty batch unchanged) so you never build zero-length arrays by accident.
+- Returning `Err` fails the pipeline. For per-row soft failures, emit a null or drop the row rather than erroring the whole batch.
+
+## Pattern: row filter with a boolean mask
+
+Filtering is the canonical transform. Build a `BooleanArray` mask and apply it with `filter_record_batch`:
+
+```rust
+use arrow::array::{Array, BooleanArray, StringArray, RecordBatch};
+use arrow::compute::{and, filter_record_batch};
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use streamling_plugin::api::{PluginStateBackendFactory, SupportsGracefulShutdown};
+use streamling_plugin::r#async::PluginAsyncRuntimeObj;
+use streamling_plugin::ffi::PluginMetricsRecorder;
+use streamling_plugin::{CheckpointEpoch, PluginError, TransformPlugin};
+
+pub struct FilterTransform {
+    schema: SchemaRef,
+    column: String,                       // parsed from options
+    keep_value: String,
+    running: Arc<AtomicBool>,
+}
+
+impl FilterTransform {
+    pub fn new(
+        schema: SchemaRef,
+        _rt: PluginAsyncRuntimeObj,
+        _state: PluginStateBackendFactory,
+        _metrics: PluginMetricsRecorder,
+        options: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            schema,
+            column: options.get("column").cloned().unwrap_or_default(),
+            keep_value: options.get("keep").cloned().unwrap_or_default(),
+            running: Arc::new(AtomicBool::new(true)),
+        }
+    }
+}
+
+#[async_trait]
+impl SupportsGracefulShutdown for FilterTransform {
+    fn is_running(&self) -> bool { self.running.load(Ordering::SeqCst) }
+    async fn terminate(&self) -> Result<(), PluginError> {
+        self.running.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl TransformPlugin for FilterTransform {
+    async fn initialize(&self) -> Result<(), PluginError> { Ok(()) }
+
+    fn output_schema(&self) -> Result<SchemaRef, PluginError> { Ok(self.schema.clone()) }
+
+    async fn process_batch(&self, batch: RecordBatch) -> Result<RecordBatch, PluginError> {
+        if batch.num_rows() == 0 { return Ok(batch); }            // empty in → empty out
+
+        let idx = batch.schema().index_of(&self.column)
+            .map_err(|e| PluginError::Execution(format!("missing column {}: {e}", self.column)))?;
+        let col = batch.column(idx);
+
+        // Start with all-true, AND in each predicate (extend to multiple conditions).
+        let mut mask = BooleanArray::from(vec![true; batch.num_rows()]);
+        if let Some(strings) = col.as_any().downcast_ref::<StringArray>() {
+            let values: Vec<bool> = (0..strings.len())
+                .map(|i| strings.value(i) == self.keep_value.as_str())
+                .collect();
+            let pred = BooleanArray::from(values);
+            mask = and(&mask, &pred).map_err(PluginError::ArrowError)?;
+        }
+        // For other column types, downcast to Int64Array/Float64Array/etc. and compare.
+
+        filter_record_batch(&batch, &mask).map_err(PluginError::ArrowError)
+    }
+
+    async fn process_checkpoint_marker(&self, _e: CheckpointEpoch) -> Result<(), PluginError> { Ok(()) }
+    async fn process_checkpoint_finalizer(&self, _e: CheckpointEpoch) -> Result<(), PluginError> { Ok(()) }
+}
+```
+
+Register it:
+```rust
+register_plugin_transform!("my_plugin", "filter", FilterTransform);
+set_plugin_output_buffer!("my_plugin.filter", 1);   // optional backpressure cap
+```
+
+### Multi-condition masks
+
+Start from all-true and fold each predicate with `and(&mask, &pred)`. Build each predicate by downcasting the column to its concrete array type (`StringArray`, `Int64Array`, `Float64Array`, `BooleanArray`, …) and producing a `Vec<bool>` per row. Nulls are falsy by default — handle them explicitly if your logic differs.
+
+## Pattern: project / add a derived column
+
+To produce a **different** schema, build new arrays and assemble a fresh `RecordBatch` against your `output_schema`. Common builders: `StringBuilder`, `Int64Builder`, `Float64Builder`, `BooleanBuilder`, `ListBuilder`. For derived columns, iterate the source columns, compute, append, then `RecordBatch::try_new(self.output_schema.clone(), vec![...])`.
+
+## Pattern: stateful transforms
+
+If the transform must remember something across batches (a running aggregate, a de-dup set), use the state backend (see [`streamling-plugin-basics.md`](./streamling-plugin-basics.md#state-backend)). Restore in `initialize`, mutate in `process_batch`, and persist anything that must survive restart in `process_checkpoint_finalizer`. Keep in-memory state behind the same `Arc<AtomicBool>` shutdown discipline as sources/sinks.
+
+## Checkpoints: pass them through
+
+Unless your transform owns durable state, both checkpoint methods are no-ops — just return `Ok(())`. Returning `Ok` propagates the marker downstream; the transform is transparent to the checkpoint protocol.
+
+## Backpressure
+
+If a downstream stage is slower than the transform (e.g. the transform fans out to a heavy enricher), cap the output channel:
+```rust
+set_plugin_output_buffer!("my_plugin.filter", 1);
+```
+
+## Common mistakes
+
+- **Forgetting the empty-batch guard.** Building arrays from a zero-row batch can panic or produce schema-mismatched output. Return it unchanged.
+- **Wrong output schema.** If you drop/add columns, `output_schema()` must match the batches you actually return, or the downstream stage errors at runtime.
+- **Panicking on a bad row.** Downcast failures and index lookups should become `PluginError::Execution(..)`, not panics — a panic crashes the worker.
+- **Erroring the whole batch for one bad row.** Prefer nulling/skipping the row; reserve batch-level errors for unrecoverable problems.
+- **Re-implementing SQL.** If it's a projection/union/join, use [`sql-transform`](skill://sql-transform).
+
+## Related skills
+
+- [`streamling-plugin-basics`](skill://streamling-plugin-basics) — registration, lifecycle, options, state backend, errors.
+- [`sql-transform`](skill://sql-transform) — the built-in DataFusion transform; prefer it for projection/union/join.
+- [`streamling-udf-plugin`](skill://streamling-udf-plugin) — custom SQL functions; a lighter alternative to a full transform for a single derived column.

--- a/skills/streamling-udf-plugin/SKILL.md
+++ b/skills/streamling-udf-plugin/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: streamling-udf-plugin
+description: Use when implementing a streamling DataFusion scalar UDF — a custom function callable from pipeline SQL (SELECT my_func(col) FROM ...). Covers the ScalarUDFImpl trait, the modern invoke_with_args / ScalarFunctionArgs API, argument validation and downcasting, null propagation, return_type vs return_field_from_args, volatility, both registration macros, and the create_udf legacy path. Assumes streamling-plugin-basics.
+---
+
+# streamling UDF plugin — Agent Skill
+
+A **UDF** (user-defined function) is a DataFusion scalar function your plugin exposes, so pipeline SQL can call it: `SELECT truncate(body, 280) FROM stream`. It is the lightest way to add a derived column — no batch pipeline of your own, no `process_batch`. DataFusion calls your function inside its plan.
+
+**Prerequisites:** [`streamling-plugin-basics`](skill://streamling-plugin-basics) (crate setup, registration). To *use* the UDF once registered, see [`sql-transform`](skill://sql-transform).
+
+**API version:** these skills target DataFusion **49** / Arrow **55** (the `invoke_with_args` + `ScalarFunctionArgs` era). If your `Cargo.toml` pins an older DataFusion, the method may be `invoke(&self, args: Vec<ColumnarValue>)` instead — adapt accordingly.
+
+## Two ways to author a UDF
+
+| Form | Register with | When |
+|---|---|---|
+| `struct MyFunc impl ScalarUDFImpl` (+ `Default`) | `register_plugin_udf!(MyFunc)` | Default — type-safe, structured, the modern recommendation |
+| closure via `create_udf(..)` returning a `ScalarUDF` | `register_plugin_udf_fn!(create_my_func)` | Legacy / quick — a `fn() -> ScalarUDF` factory |
+
+Both live alongside any source/sink/transform/preprocessor in the same `cdylib`.
+
+## A complete UDF: `truncate(text, max_len)`
+
+`truncate(text: Utf8, max_len: Int64) -> Utf8` — clip a string to `max_len` characters, char-boundary safe. Null text or null/egative limit → null.
+
+```rust
+use arrow::array::{Array, ArrayRef, Int64Array, StringArray, StringBuilder};
+use arrow_schema::{DataType, Field, FieldRef};
+use datafusion::common::{DataFusionError, Result};
+use datafusion::logical_expr::{
+    ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
+use std::any::Any;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct TruncateFunc {
+    signature: Signature,
+}
+
+impl Default for TruncateFunc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TruncateFunc {
+    pub fn new() -> Self {
+        // Exact signature: two arguments, fixed types, pure function.
+        Self {
+            signature: Signature::exact(
+                vec![DataType::Utf8, DataType::Int64],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for TruncateFunc {
+    fn as_any(&self) -> &dyn Any { self }
+
+    fn name(&self) -> &str { "truncate" }                       // the SQL name you call
+
+    fn signature(&self) -> &Signature { &self.signature }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    /// Preferred on modern DataFusion: declare the nullable output field.
+    fn return_field_from_args(&self, _args: ReturnFieldArgs) -> Result<FieldRef> {
+        Ok(Arc::new(Field::new(self.name(), DataType::Utf8, true)))
+    }
+
+    /// Modern entry point. `args.args` is a `Vec<ColumnarValue>`.
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let inputs = args.args;
+        if inputs.len() != 2 {
+            return Err(DataFusionError::Plan(format!(
+                "{} expects exactly 2 arguments, got {}",
+                self.name(),
+                inputs.len()
+            )));
+        }
+        let text = columnar_to_array(&inputs[0])?;
+        let max_len = columnar_to_array(&inputs[1])?;
+
+        let text = text
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| DataFusionError::Plan(format!("{}: arg 0 must be Utf8", self.name())))?;
+        let max_len = max_len.as_any().downcast_ref::<Int64Array>()
+            .ok_or_else(|| DataFusionError::Plan(format!("{}: arg 1 must be Int64", self.name())))?;
+
+        let n = text.len().max(max_len.len());
+        let mut out = StringBuilder::with_capacity(n, n * 8);
+        for i in 0..n {
+            let t = (i < text.len() && !text.is_null(i)).then(|| text.value(i));
+            let m = (i < max_len.len() && !max_len.is_null(i)).then(|| max_len.value(i));
+            match (t, m) {
+                (Some(s), Some(m)) if m >= 0 => {
+                    let end = usize::try_from(m).unwrap_or(0).min(s.chars().count());
+                    out.append_value(s.chars().take(end).collect::<String>());
+                }
+                _ => out.append_null(),
+            }
+        }
+        Ok(ColumnarValue::Array(Arc::new(out.finish())))
+    }
+}
+
+/// Column arguments arrive as `ColumnarValue::Array`; a literal (scalar) needs
+/// broadcasting to the batch length. `ScalarValue::to_array_of_size(len)` does that.
+fn columnar_to_array(cv: &ColumnarValue) -> Result<ArrayRef> {
+    match cv {
+        ColumnarValue::Array(a) => Ok(a.clone()),
+        ColumnarValue::Scalar(s) => Ok(s.to_array_of_size(1)?),
+    }
+}
+```
+
+## Register it
+
+```rust
+register_plugin_udf!(TruncateFunc);   // requires TruncateFunc: ScalarUDFImpl + Default
+```
+
+You do **not** call `init_plugin_with_async_runtime!()` per UDF — one call per crate, at the bottom of `lib.rs`, covers every component.
+
+## Use it in a pipeline
+
+Once the plugin cdylib is on `STREAMLING__PLUGIN__PATH`, the function is callable in any `type: sql` transform:
+
+```yaml
+transforms:
+  clipped:
+    type: sql
+    primary_key: id
+    sql: |
+      SELECT id, truncate(body, 280) AS snippet FROM posts
+```
+
+No `from:` on the SQL transform; `posts` must be an existing source/transform name. See [`sql-transform`](skill://sql-transform).
+
+## The `invoke_with_args` API in detail
+
+```rust
+fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue>;
+```
+
+- `args.args: Vec<ColumnarValue>` — one entry per call argument, in declared order.
+- `ColumnarValue::Array(ArrayRef)` is the normal case (a column); `ColumnarValue::Scalar(ScalarValue)` appears for literals — broadcast with `to_array_of_size(len)`.
+- Return `ColumnarValue::Array(Arc::new(your_array))` for column output, or `ColumnarValue::Scalar(..)` for a single value broadcast across the batch.
+
+**Validate, don't panic.** Arity and type checks must return `Err(DataFusionError::Plan(..))`. A panic inside `invoke_with_args` aborts the whole query.
+
+### Argument helpers (idiomatic toolkit)
+
+Production UDF crates factor these into a `util` module. Adopt the same shape:
+
+```rust
+// util.rs
+use datafusion::common::{DataFusionError, Result};
+use datafusion::logical_expr::{ColumnarValue, ScalarFunctionArgs};
+use arrow::array::{Array, ArrayRef};
+
+pub fn validate_arg_count(args: &ScalarFunctionArgs, min: usize, max: Option<usize>, name: &str) -> Result<()> {
+    let n = args.args.len();
+    if n < min || max.map_or(false, |mx| n > mx) {
+        return Err(DataFusionError::Plan(format!("{name}: expected {min:?}..{max:?} args, got {n}")));
+    }
+    Ok(())
+}
+
+pub fn get_array_from_arg(arg: &ColumnarValue) -> Result<ArrayRef> {
+    match arg {
+        ColumnarValue::Array(a) => Ok(a.clone()),
+        ColumnarValue::Scalar(s) => Ok(s.to_array_of_size(1)?),
+    }
+}
+
+/// One typed array argument: validates arity (1) + downcasts in one call.
+pub fn get_single_arg<T: Array + 'static>(args: &ScalarFunctionArgs, name: &str, type_label: &str) -> Result<std::sync::Arc<T>> {
+    validate_arg_count(args, 1, Some(1), name)?;
+    let a = get_array_from_arg(&args.args[0])?;
+    a.as_any().downcast_ref::<T>().ok_or_else(|| {
+        DataFusionError::Plan(format!("{name}: argument must be {type_label}"))
+    }).map(std::sync::Arc::clone) // note: clone the Arc, not the array
+}
+```
+
+Then `invoke_with_args` shrinks to:
+```rust
+fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+    let text = get_single_arg::<StringArray>(&args, self.name(), "Utf8")?;
+    // ...
+}
+```
+
+> Note the downcast pitfall: `downcast_ref::<T>()` borrows; to hand back an `Arc<T>` you clone the **`Arc`**, never the underlying array.
+
+## Return type
+
+Implement **both** on modern DataFusion:
+- `return_type(&self, arg_types) -> Result<DataType>` — legacy planner path.
+- `return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef>` — preferred; lets you declare nullability and depend on input nullability. Return a `Field::new(name, dtype, nullable)`.
+
+Keep them consistent (same `DataType`). For a fixed output type, both just return `Utf8`/`Int64`/etc.; for variable-shape outputs (e.g. `List<Struct<...>>`), build the nested `DataType`/`Field` once and reuse.
+
+## Volatility
+
+Set it in the `Signature`:
+- **`Immutable`** — pure function of its inputs (default; planner may cache/constant-fold). Almost all UDFs.
+- **`Stable`** — same result within a query but varies across (e.g. depends on session timezone).
+- **`Volatile`** — may differ row-to-row (e.g. reads external state, network, `now()`). Disables caching; use sparingly.
+
+## Nulls and allocation
+
+- **Propagate nulls explicitly.** Check `arr.is_null(i)` each row and append a null to the output builder (`append_null()` / `append(false)` for nullable list entries). DataFusion does not auto-propagate.
+- **Build, don't push.** Operate on whole arrays with builders (`StringBuilder`, `PrimitiveBuilder`, `ListBuilder`, `StructBuilder`), pre-sized with `with_capacity` — far cheaper than growing `Vec<String>` and converting.
+- **Char-safe string ops.** Slice by `chars()`, never byte indices, to avoid UTF-8 boundary panics.
+
+## The legacy `create_udf` path
+
+When you'd rather write a closure than a struct:
+
+```rust
+use datafusion::logical_expr::{ColumnarValue, ScalarUDF, Volatility, create_udf};
+use arrow_schema::DataType;
+
+pub fn create_double_udf() -> ScalarUDF {
+    create_udf(
+        "double",
+        vec![DataType::Int64],            // input types
+        DataType::Int64,                  // return type
+        Volatility::Immutable,
+        std::sync::Arc::new(|args: &[ColumnarValue]| {
+            // older signature: closure takes &[ColumnarValue]
+            use arrow::array::Int64Array;
+            use datafusion::common::Result;
+            use std::sync::Arc;
+            let col = args[0].clone();
+            let arr = col.into_array(1)?;
+            let a = arr.as_any().downcast_ref::<Int64Array>().unwrap();
+            let out: Int64Array = a.iter().map(|v| v.map(|x| x * 2)).collect();
+            Ok(ColumnarValue::Array(Arc::new(out)))
+        }),
+    )
+}
+```
+Register with the factory form:
+```rust
+register_plugin_udf_fn!(create_double_udf);   // fn() -> ScalarUDF
+```
+Prefer the `ScalarUDFImpl` struct form for new code — it's typed, testable, and tracks the modern API.
+
+## Common mistakes
+
+- **Using the old `invoke(&self, args: Vec<ColumnarValue>)`.** On DataFusion 49+ it's `invoke_with_args(&self, args: ScalarFunctionArgs)`; access arguments via `args.args`.
+- **Panicking on bad arity/types.** Return `DataFusionError::Plan(..)`; a panic aborts the query.
+- **Forgetting null propagation.** Null inputs must yield null outputs — check `is_null(i)` per row.
+- **Slicing strings by byte index.** Use `chars()` to stay UTF-8-safe.
+- **Inconsistent `return_type` vs `return_field_from_args`.** They must agree on the `DataType`.
+- **Marking a deterministic function `Volatile`.** It disables planner optimizations unnecessarily.
+
+## Related skills
+
+- [`streamling-plugin-basics`](skill://streamling-plugin-basics) — crate setup, registration, the single `init_plugin_with_async_runtime!()` per crate.
+- [`sql-transform`](skill://sql-transform) — how to call your UDF from pipeline SQL.
+- [`streamling-transform-plugin`](skill://streamling-transform-plugin) — when a UDF isn't enough and you need full `process_batch` control.
+- [`streamling-advanced-plugins`](skill://streamling-advanced-plugins) — registering UDFs alongside other kinds in one crate.


### PR DESCRIPTION
## Summary

Adds a pack of **Agent Skills** (in `skills/`) that teach a coding agent how to build Streamling plugins correctly — grounded in the plugin ABI, anonymized (no blockchain specifics) — plus a README **table of contents**.

## Skills added (`skills/<name>/SKILL.md`)

| Skill | Covers |
|---|---|
| `streamling-plugin-basics` | cdylib setup, registration macros, exact constructor contracts, lifecycle, async runtime, error types, options/secrets, metrics, state backend — **start here** |
| `streamling-source-plugin` | `SourcePlugin`, `_gs_op`, `generate_batch` + empty-means-idle, fetcher/buffer/runner split, resumable cursor pagination, backpressure |
| `streamling-sink-plugin` | `SinkPlugin`, lazy client init, empty-batch guard, NDJSON, batched writes with retry + partial-failure handling, checkpoint acks |
| `streamling-transform-plugin` | `TransformPlugin`, `process_batch`, `output_schema`, arrow-compute filtering |
| `streamling-udf-plugin` | DataFusion `ScalarUDFImpl`, modern `invoke_with_args`/`ScalarFunctionArgs` API, argument helpers, volatility, calling UDFs from SQL |
| `streamling-advanced-plugins` | preprocessors (YAML rewrite), side outputs, multi-kind crate registration, low-level manual FFI |

Every signature/contract is verified against the live API (`api.rs`, `ffi.rs`, `async.rs`, the derive macros) and the reference plugin repos. The UDF skill documents the **modern `invoke_with_args`** API (DataFusion 49) — a complete worked example, not a stub.

## README changes

- **`## Contents`** table of contents after the intro (rebuilt against the current 15 top-level sections; all anchors verified).
- **`### AI Authoring Skills`** subsection under `## Plugin System` with a skill table and install instructions for the main coding agents:
  - Claude Code → `~/.claude/skills/`
  - Codex / GitHub Copilot CLI / Gemini CLI → `~/.agents/skills/` (cross-runtime alias)
  - Antigravity (`agy`)
  - A one-shot dual-directory symlink script + copy fallback.

`skills/README.md` has the full per-agent path table and verification steps.

## Install (one shot)

```bash
cd /path/to/streamling
for d in skills/streamling-*; do
  for dir in ~/.claude/skills ~/.agents/skills; do
    mkdir -p "$dir" && ln -sf "$(pwd)/$d" "$dir/$(basename "$d")"
  done
done
```

## Notes

- Docs/skills only — no runtime Rust changed, so `just fix`/`just lint` (clippy+format) don't apply to this change.
- Branched from latest `main`; README conflict from the upstream README cleanup (#31) was resolved by keeping main's reorg and rebuilding the TOC against the new section structure.