### PR TITLE
ci: quote allowedTools in ai-review so gh pr tools load

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -132,7 +132,7 @@ jobs:
           claude_args: |
             --model ${{ steps.config.outputs.model }}
             --max-turns ${{ steps.config.outputs.max_turns }}
-            --allowedTools Bash(gh pr diff:*),Bash(gh pr comment:*),Read(*),codebase-memory:*
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr comment:*),Read(*),codebase-memory:*"
             --mcp-config '{"mcpServers": {"codebase-memory": {"command": "npx", "args": ["-y", "codebase-memory-mcp"]}}}'
           prompt: |
             You are an expert Rust code reviewer for the Streamling project — a data


### PR DESCRIPTION
## Summary

The AI Code Review workflow is unreliable (e.g. run 28090976387 failed): the Claude agent often can't run its `gh pr` tools, so it spends its turn budget on denied calls instead of reading the diff and posting a review. This quotes the `--allowedTools` value so all tools load.

## Root cause

`claude-code-action@v1` parses `claude_args` with `shell-quote`. The `--allowedTools` value contains spaces and shell-special characters:

```
Bash(gh pr diff:*),Bash(gh pr comment:*),Read(*),codebase-memory:*
```

Unquoted, `shell-quote` splits on whitespace and treats `(`, `)`, and `*` as operators and globs, so `--allowedTools` receives only a mangled `Bash(gh` fragment. The `gh pr diff` / `gh pr comment` tools are dropped, the agent hits permission denials, and the review fails or degrades.

## Fix

Wrap the value in double quotes so `shell-quote` emits it as a single token. Verified with `shell-quote@1.8.3` (the parser the action bundles) that the quoted form yields the intended 4-tool list and the adjacent `--mcp-config` JSON is unaffected.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Opus 4.8](https://img.shields.io/badge/Opus_4.8-D97757?logo=claude&logoColor=white)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI workflow quoting change with no runtime or application code impact.
> 
> **Overview**
> **Fixes unreliable AI PR reviews** by ensuring `claude-code-action` receives the full `--allowedTools` list instead of a broken fragment.
> 
> In `.github/workflows/ai-review.yml`, the `--allowedTools` argument value is now wrapped in **double quotes**. Unquoted, `shell-quote` (used when parsing `claude_args`) splits on spaces and treats `()`, `*`, etc. as shell syntax, so only something like `Bash(gh` was passed through and **`Bash(gh pr diff:*)` / `Bash(gh pr comment:*)` were dropped**. The reviewer agent then hit permission denials and burned its turn budget without posting a proper review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 712c0d9cde28365ed368a29fa424a3b7ac0be302. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->