### PR TITLE
ci: ignore "already exists" error for cargo publish

### DIFF
--- a/.github/workflows/streamling-release.yml
+++ b/.github/workflows/streamling-release.yml
@@ -383,7 +383,7 @@ jobs:
             streamling-common
             streamling-flink-compat
             streamling-plugin-derive
-            streamling-state          
+            streamling-state
             streamling-plugin
             streamling-core
             streamling-connectors
@@ -392,6 +392,16 @@ jobs:
           )
           for crate in "${crates[@]}"; do
             echo "::group::cargo publish -p $crate"
-            cargo publish -p "$crate" --locked
+            if output="$(cargo publish -p "$crate" --locked 2>&1)"; then
+              echo "$output"
+            else
+              echo "$output"
+              if grep -q "already exists on crates.io index" <<<"$output"; then
+                echo "::notice::$crate version already published; skipping."
+              else
+                echo "::error::cargo publish failed for $crate."
+                exit 1
+              fi
+            fi
             echo "::endgroup::"
           done


### PR DESCRIPTION
We don't always need to bump versions for all crates in case of a release, e.g. `streamling-plugin`'s version has special meaning for plugin compatibility. 

`cargo publish` doesn't have a built-in "ignore if exists" flag, so adding an additional check. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to release publishing behavior; real publish failures still fail the workflow, and crates.io publishes remain unchanged.
> 
> **Overview**
> The **streamling-release** `publish-crates` job no longer fails when `cargo publish` reports that a crate version is **already on crates.io**.
> 
> Each crate in the dependency-ordered list still runs `cargo publish -p … --locked`, but output is captured. If publish fails with `already exists on crates.io index`, the workflow logs a notice and continues; any other failure still aborts the job. This supports releases where some workspace crates (e.g. `streamling-plugin`) are intentionally left at an unchanged version.
> 
> Also fixes trailing whitespace on the `streamling-state` entry in the crate list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 995d1333784650a097822f9c927c316c4f71bd8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->