### PR TITLE
feat: add JSON support to the Kafka source

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@ serialization. It's implemented as a custom DataFusion Table Provider (`TablePro
     - The size of the batches is controlled by the `record_batch_size` and `record_batch_interval_ms` parameters.
   - Adds operation type column (`_gs_op`) to track INSERT/UPDATE/DELETE operations (see `Upsert Semantics` section
     below). The operation type is determined by the `dbz.op` header value.
+  - Tombstone records (null/empty payloads, e.g. CDC deletes-as-tombstones) are **not supported** in any format
+    and fail the source. Represent deletes with a non-empty payload plus a `dbz.op=d` header instead.
 
 Kafka Source uses
 high-level [StreamConsumer](https://docs.rs/rdkafka/latest/rdkafka/consumer/struct.StreamConsumer.html) which handles

--- a/README.md
+++ b/README.md
@@ -317,12 +317,14 @@ Sources return a `SendableRecordBatchStream` as a result.
 
 #### Kafka Source
 
-The Kafka source allows consuming data from Kafka topics using Avro serialization with Schema Registry integration. It's
-implemented as a custom DataFusion Table Provider (`TableProvider`) with the following key features:
+The Kafka source allows consuming data from Kafka topics using Avro (with Schema Registry integration) or JSON
+serialization. It's implemented as a custom DataFusion Table Provider (`TableProvider`) with the following key features:
 
-- **Schema Management**: Automatically fetches and converts Avro schemas from Schema Registry to Arrow schemas.
+- **Schema Management**:
+  - For Avro, automatically fetches and converts Avro schemas from Schema Registry to Arrow schemas.
+  - For JSON, uses the input schema declared in the source's `schema` field (Schema Registry is not used).
 - **Message Processing**:
-  - Converts Avro-encoded messages to Arrow `RecordBatch`es.
+  - Converts Avro- or JSON-encoded messages to Arrow `RecordBatch`es.
     - The size of the batches is controlled by the `record_batch_size` and `record_batch_interval_ms` parameters.
   - Adds operation type column (`_gs_op`) to track INSERT/UPDATE/DELETE operations (see `Upsert Semantics` section
     below). The operation type is determined by the `dbz.op` header value.
@@ -348,6 +350,27 @@ sources:
     type: kafka
     topic: app.events
 ```
+
+**JSON format.** Set `data_format: json` (the default is `avro`) and declare the input schema as a `column → type` map.
+Each Kafka message payload is treated as a single UTF-8 JSON object (one row); Schema Registry is not used.
+
+```yaml
+sources:
+  raw_events:
+    type: kafka
+    topic: app.events
+    data_format: json
+    schema:
+      id: int64
+      name: string
+      amount: float64
+```
+
+Supported type names match Arrow's (`int8`..`int64`, `uint8`..`uint64`, `float32`/`float64`, `string`, `boolean`,
+`timestamp`, etc.). Decimals are written as `decimal128(precision, scale)` or `decimal256(precision, scale)`; the bare
+names `decimal128`/`decimal256` (alias `decimal`) default to `(38, 9)`. All declared columns are nullable. If the
+payload does not already contain `_gs_op`, it is added from the `dbz.op` header (defaulting to insert), exactly as for
+Avro.
 
 **Connection settings** — override the embedded defaults (local Kafka and Schema Registry) with these environment variables:
 

--- a/crates/streamling-common/src/formats/json.rs
+++ b/crates/streamling-common/src/formats/json.rs
@@ -421,6 +421,29 @@ mod tests {
         assert_from_json_to_arrow_conversion(batch);
     }
 
+    /// A schema covering only a subset of the JSON object's fields decodes just those
+    /// columns and ignores the rest. The Kafka JSON source relies on this to apply column
+    /// projection by decoding against a projected payload schema.
+    #[test]
+    fn test_json_to_arrow_converter_subset_schema_ignores_extra_fields() {
+        let subset_schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+
+        let mut converter = JsonToArrowConverter::new(subset_schema, true, None);
+        converter.buffer(r#"{"a":1,"b":"foo"}"#.to_string());
+        converter.buffer(r#"{"a":2,"b":"bar"}"#.to_string());
+
+        let batch = converter.convert_to_batch().unwrap();
+
+        assert_eq!(batch.num_columns(), 1);
+        assert_eq!(batch.num_rows(), 2);
+        let a = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(a, &Int32Array::from(vec![1, 2]));
+    }
+
     #[test]
     fn test_json_to_arrow_converter_batch_with_envelope() {
         let schema = create_test_schema();

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -236,7 +236,7 @@ impl HybridTableProvider {
         telemetry: Option<&Telemetry>,
     ) -> DataFusionResult<Self> {
         use crate::table_providers::clickhouse::ClickHouseTableProvider;
-        use crate::table_providers::kafka::KafkaSourceTableProvider;
+        use crate::table_providers::kafka::{KafkaFormat, KafkaSourceTableProvider};
         use datafusion::common::ScalarValue;
 
         let mut bounded_table_providers = Vec::new();
@@ -270,6 +270,10 @@ impl HybridTableProvider {
                             unbounded_source
                                 .skip_schema_resolution_for_reader_schema_ids
                                 .unwrap_or_default(),
+                            // Hybrid sources are Avro-only; JSON is supported on the
+                            // standalone Kafka source.
+                            KafkaFormat::Avro,
+                            None,
                         )
                         .streamling_with_context(|| {
                             format!(

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -407,7 +407,12 @@ impl KafkaSourceConverter<'_> {
 }
 
 /// Decode a Kafka JSON payload into a UTF-8 string, failing with message coordinates for
-/// empty payloads (tombstones) and invalid UTF-8.
+/// empty payloads and invalid UTF-8.
+///
+/// The Kafka source does not support tombstone records (null/empty payloads, e.g. CDC
+/// deletes-as-tombstones) in any format — the Avro decoder rejects them too. An empty payload
+/// is a hard error that terminates the source; represent deletes with a non-empty payload plus
+/// a `dbz.op=d` header instead.
 fn json_payload_to_string(
     payload: &[u8],
     topic: &str,
@@ -415,8 +420,8 @@ fn json_payload_to_string(
     offset: i64,
 ) -> Result<String> {
     if payload.is_empty() {
-        return Err(streamling_err!(
-            "JSON source received an empty payload (tombstone?)\n  topic: {}\n  partition: {}\n  offset: {}",
+        return Err(streamling_user_err!(
+            "JSON source received an empty payload; tombstone records are not supported\n  topic: {}\n  partition: {}\n  offset: {}",
             topic,
             partition,
             offset

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -1098,9 +1098,18 @@ impl ExecutionPlan for KafkaSourceExec {
                     schema_id_overrides: avro.schema_id_overrides.clone(),
                 }))
             }
-            KafkaSourceDecoding::Json => KafkaSourceConverter::Json(Box::new(
-                JsonToArrowConverter::new(self.payload_schema.clone(), true, None),
-            )),
+            KafkaSourceDecoding::Json => {
+                // Apply the same column projection Avro does, so the decoded batch lines up
+                // with `full_schema_projected`. The schema-driven JSON decoder reads fields
+                // by name and ignores any payload keys not in the (projected) schema.
+                let projected_payload_schema =
+                    project_schema(&self.payload_schema, self.payload_projection.as_ref())?;
+                KafkaSourceConverter::Json(Box::new(JsonToArrowConverter::new(
+                    projected_payload_schema,
+                    true,
+                    None,
+                )))
+            }
         };
 
         let full_schema = self.full_schema_projected.clone();

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -43,9 +43,10 @@ use streamling_core::formats::avro::{
     AvroToArrowConverter, FromArrowToAvroConverter, convert_avro_schema_to_arrow,
     post_process_avro_schema_for_writing, to_avro,
 };
-use streamling_core::formats::json::FromArrowToJsonConverter;
+use streamling_core::formats::json::{FromArrowToJsonConverter, JsonToArrowConverter};
 use streamling_core::formats::{FromArrowConverter, ToArrowConverter};
 use streamling_core::operators::filter::StreamingFilterExec;
+use streamling_core::schema::arrow_schema_from_type_map;
 use streamling_core::session::SessionManager;
 use streamling_core::topology::SchemaIdOverride;
 use streamling_state::StateKey;
@@ -61,7 +62,7 @@ use futures::StreamExt;
 use once_cell::sync::OnceCell;
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
 use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
-use rdkafka::message::{BorrowedHeaders, Header, Headers, OwnedHeaders, ToBytes};
+use rdkafka::message::{BorrowedHeaders, BorrowedMessage, Header, Headers, OwnedHeaders, ToBytes};
 use rdkafka::producer::{BaseRecord, Producer, ThreadedProducer};
 use rdkafka::util::Timeout;
 use rdkafka::{
@@ -281,6 +282,134 @@ impl FromStr for KafkaFormat {
     }
 }
 
+/// Format-specific state needed to decode Kafka source payloads, resolved at source
+/// construction. Grouping it behind an enum keeps the Avro-only state (schema registry
+/// client, resolution settings) off the JSON path, where it is meaningless.
+#[derive(Clone)]
+pub(crate) enum KafkaSourceDecoding {
+    Avro(Box<AvroSourceDecoding>),
+    Json,
+}
+
+#[derive(Clone)]
+pub(crate) struct AvroSourceDecoding {
+    avro_schema: AvroSchema,
+    reader_schema_id: u32,
+    versions_client: Arc<SubjectVersionsClient>,
+    validate_writer_schema_ordering: bool,
+    schema_id_overrides: HashMap<u32, u32>,
+    skip_schema_resolution: bool,
+}
+
+/// Per-stream payload decoder, built from [`KafkaSourceDecoding`] when the consumer task
+/// starts. Mirrors the sink-side `KafkaSinkConverter`: each variant owns exactly the state
+/// its format needs. The Avro state is boxed to keep the variant sizes balanced.
+enum KafkaSourceConverter<'a> {
+    Avro(Box<AvroStreamConverter<'a>>),
+    Json(Box<JsonToArrowConverter>),
+}
+
+struct AvroStreamConverter<'a> {
+    converter: AvroToArrowConverter,
+    decoder: AvroDecoder<'a>,
+    versions_client: Arc<SubjectVersionsClient>,
+    subject: String,
+    reader_schema_id: u32,
+    reader_avro_schema: AvroSchema,
+    skip_schema_resolution: bool,
+    validate_writer_schema_ordering: bool,
+    schema_id_overrides: HashMap<u32, u32>,
+}
+
+impl KafkaSourceConverter<'_> {
+    /// Decode a single Kafka message payload and buffer it for the next batch.
+    async fn decode_and_buffer(&mut self, message: &BorrowedMessage<'_>) -> Result<()> {
+        match self {
+            KafkaSourceConverter::Avro(avro) => {
+                let AvroStreamConverter {
+                    converter,
+                    decoder,
+                    versions_client,
+                    subject,
+                    reader_schema_id,
+                    reader_avro_schema,
+                    skip_schema_resolution,
+                    validate_writer_schema_ordering,
+                    schema_id_overrides,
+                } = avro.as_mut();
+                let payload = message.payload();
+                let patched = patch_schema_id_with_overrides(payload, schema_id_overrides);
+                let decoded = decoder
+                    .decode_with_schema(patched.as_deref().or(payload))
+                    .await
+                    .streamling_with_context(|| {
+                        format!(
+                            "Avro decoding failed\n  topic: {}\n  partition: {}\n  offset: {}\n  patched: {}",
+                            message.topic(),
+                            message.partition(),
+                            message.offset(),
+                            patched.is_some()
+                        )
+                    })?
+                    .ok_or_else(|| {
+                        streamling_err!(
+                            "Avro decoder returned None (empty payload?)\n  topic: {}\n  partition: {}\n  offset: {}",
+                            message.topic(),
+                            message.partition(),
+                            message.offset()
+                        )
+                    })?;
+
+                let resolved_value = if *skip_schema_resolution {
+                    decoded.value
+                } else {
+                    match resolve_schema(
+                        decoded.value,
+                        subject.as_str(),
+                        versions_client.as_ref(),
+                        decoded.schema.id,
+                        *reader_schema_id,
+                        reader_avro_schema,
+                        *validate_writer_schema_ordering,
+                    )
+                    .await
+                    {
+                        Ok(value) => value,
+                        Err(e) => {
+                            // fail fast to terminate and fetch latest schema
+                            // TODO: look into graceful shutdown
+                            error!(topic = %message.topic(), "Schema resolution failed: {e}");
+                            std::process::exit(1);
+                        }
+                    }
+                };
+                converter.buffer(resolved_value);
+            }
+            KafkaSourceConverter::Json(converter) => {
+                let payload = message.payload().unwrap_or_default();
+                let json = String::from_utf8(payload.to_vec()).map_err(|e| {
+                    streamling_user_err!(
+                        "Kafka JSON payload is not valid UTF-8\n  topic: {}\n  partition: {}\n  offset: {}\n  error: {}",
+                        message.topic(),
+                        message.partition(),
+                        message.offset(),
+                        e
+                    )
+                })?;
+                converter.buffer(json);
+            }
+        }
+        Ok(())
+    }
+
+    fn convert_to_batch(&mut self) -> Result<RecordBatch> {
+        match self {
+            KafkaSourceConverter::Avro(avro) => avro.converter.convert_to_batch(),
+            KafkaSourceConverter::Json(converter) => converter.convert_to_batch(),
+        }
+    }
+}
+
 struct KafkaCommon {}
 
 impl KafkaCommon {
@@ -369,8 +498,7 @@ struct KafkaSourceExec {
     payload_schema: SchemaRef,
     full_schema_projected: SchemaRef,
     payload_projection: Option<Vec<usize>>,
-    avro_schema: AvroSchema,
-    reader_schema_id: u32,
+    decoding: KafkaSourceDecoding,
     should_enrich_op_column: bool,
     kafka_config: KafkaConfig,
     topic: String,
@@ -384,10 +512,6 @@ struct KafkaSourceExec {
     state_backend: Arc<dyn StateOperatorBackend<TopicPartitionOffset>>,
     shutdown_rx: watch::Receiver<bool>,
     num_records_before_stop: Option<u64>,
-    versions_client: Arc<SubjectVersionsClient>,
-    validate_writer_schema_ordering: bool,
-    schema_id_overrides: HashMap<u32, u32>,
-    skip_schema_resolution: bool,
 }
 
 impl Debug for KafkaSourceExec {
@@ -428,8 +552,7 @@ impl KafkaSourceExec {
         topic: String,
         start_at: Option<String>,
         filter: Option<String>,
-        avro_schema: AvroSchema,
-        reader_schema_id: u32,
+        decoding: KafkaSourceDecoding,
         should_enrich_op_column: bool,
         record_batch_interval_ms: u64,
         record_batch_size: u32,
@@ -439,10 +562,6 @@ impl KafkaSourceExec {
         shutdown_rx: watch::Receiver<bool>,
         num_records_before_stop: Option<u64>,
         metric_metadata_id: String,
-        versions_client: Arc<SubjectVersionsClient>,
-        validate_writer_schema_ordering: bool,
-        schema_id_overrides: HashMap<u32, u32>,
-        skip_schema_resolution: bool,
     ) -> Self {
         let full_schema_projected = project_schema(&full_schema, projections).unwrap();
         let cached_properties = Self::compute_properties(full_schema_projected.clone());
@@ -450,7 +569,7 @@ impl KafkaSourceExec {
         let payload_projection = projections.cloned().map(|vec| {
             // Filter to only include indices valid for the payload schema.
             // Metadata columns (partition, offset, timestamp) are handled separately
-            // after Avro conversion, so they should not be included in the Avro projection.
+            // after payload conversion, so they should not be included in the payload projection.
             let max_valid_index = payload_schema.fields.len();
             vec.into_iter().filter(|&i| i < max_valid_index).collect()
         });
@@ -462,8 +581,7 @@ impl KafkaSourceExec {
             payload_schema,
             full_schema_projected,
             payload_projection,
-            avro_schema,
-            reader_schema_id,
+            decoding,
             should_enrich_op_column,
             kafka_config: config,
             topic,
@@ -477,10 +595,6 @@ impl KafkaSourceExec {
             state_backend,
             shutdown_rx,
             num_records_before_stop,
-            versions_client,
-            validate_writer_schema_ordering,
-            schema_id_overrides,
-            skip_schema_resolution,
         }
     }
 
@@ -964,12 +1078,30 @@ impl ExecutionPlan for KafkaSourceExec {
         // local cache for the state backend
         let mut committed_offsets: Option<KafkaTopicPartitionList> = None;
 
-        let mut converter = Self::create_converter(
-            self.payload_schema.clone(),
-            self.avro_schema.clone(),
-            self.payload_projection.clone(),
-        );
-        let decoder = Self::create_decoder(self.kafka_config.clone());
+        let mut converter = match &self.decoding {
+            KafkaSourceDecoding::Avro(avro) => {
+                KafkaSourceConverter::Avro(Box::new(AvroStreamConverter {
+                    converter: Self::create_converter(
+                        self.payload_schema.clone(),
+                        avro.avro_schema.clone(),
+                        self.payload_projection.clone(),
+                    ),
+                    decoder: Self::create_decoder(self.kafka_config.clone()),
+                    versions_client: avro.versions_client.clone(),
+                    // Subject convention: TopicNameStrategy with is_key=false yields "{topic}-value".
+                    // See SubjectNameStrategy::get_subject in schema_registry_converter.
+                    subject: format!("{}-value", self.topic),
+                    reader_schema_id: avro.reader_schema_id,
+                    reader_avro_schema: avro.avro_schema.clone(),
+                    skip_schema_resolution: avro.skip_schema_resolution,
+                    validate_writer_schema_ordering: avro.validate_writer_schema_ordering,
+                    schema_id_overrides: avro.schema_id_overrides.clone(),
+                }))
+            }
+            KafkaSourceDecoding::Json => KafkaSourceConverter::Json(Box::new(
+                JsonToArrowConverter::new(self.payload_schema.clone(), true, None),
+            )),
+        };
 
         let full_schema = self.full_schema_projected.clone();
 
@@ -998,16 +1130,7 @@ impl ExecutionPlan for KafkaSourceExec {
             &self.reference_name,
             true,
         );
-        let reader_avro_schema = self.avro_schema.clone();
-        let reader_schema_id = self.reader_schema_id;
         let topic = self.topic.clone();
-        // Subject convention: TopicNameStrategy with is_key=false yields "{topic}-value".
-        // See SubjectNameStrategy::get_subject in schema_registry_converter.
-        let subject = format!("{}-value", topic);
-        let versions_client = self.versions_client.clone();
-        let validate_writer_schema_ordering = self.validate_writer_schema_ordering;
-        let schema_id_overrides = self.schema_id_overrides.clone();
-        let skip_schema_resolution = self.skip_schema_resolution;
         let stall_watchdog_timeout = Duration::from_secs(Self::stall_watchdog_timeout_sec());
         builder.spawn(async move {
             let (max_lag_tx, max_lag_rx) = watch::channel(None);
@@ -1224,51 +1347,7 @@ impl ExecutionPlan for KafkaSourceExec {
                                         meta.extract_metadata(&message);
                                     }
 
-                                    let payload = message.payload();
-
-                                    let patched = patch_schema_id_with_overrides(
-                                        payload,
-                                        &schema_id_overrides,
-                                    );
-                                    let decoded = decoder
-                                        .decode_with_schema(patched.as_deref().or(payload))
-                                        .await
-                                        .streamling_with_context(|| format!(
-                                            "Avro decoding failed\n  topic: {}\n  partition: {}\n  offset: {}\n  patched: {}",
-                                            message.topic(),
-                                            message.partition(),
-                                            message.offset(),
-                                            patched.is_some()
-                                        ))?
-                                        .ok_or_else(|| streamling_err!(
-                                            "Avro decoder returned None (empty payload?)\n  topic: {}\n  partition: {}\n  offset: {}",
-                                            message.topic(),
-                                            message.partition(),
-                                            message.offset()
-                                        ))?;
-
-                                    let resolved_value = if skip_schema_resolution {
-                                        decoded.value
-                                    } else {
-                                        match resolve_schema(
-                                            decoded.value,
-                                            &subject,
-                                            &versions_client,
-                                            decoded.schema.id,
-                                            reader_schema_id,
-                                            &reader_avro_schema,
-                                            validate_writer_schema_ordering,
-                                        ).await {
-                                            Ok(value) => value,
-                                            Err(e) => {
-                                                // fail fast to crash k8s pod and fetch latest schema
-                                                // TODO: look into graceful shutdown
-                                                tracing::error!(topic = %topic, "Schema resolution failed: {e}");
-                                                std::process::exit(1);
-                                            }
-                                        }
-                                    };
-                                    converter.buffer(resolved_value);
+                                    converter.decode_and_buffer(&message).await?;
                                     watchdog.on_record();
                                     batch_row_count += 1;
                                     metrics_recorder.record_count("input_rows", 1, metric_metadata_id.as_str());
@@ -1494,8 +1573,7 @@ pub struct KafkaSourceTableProvider {
     filter: Option<String>,
     full_schema: SchemaRef,
     payload_schema: SchemaRef,
-    avro_schema: AvroSchema,
-    reader_schema_id: u32,
+    decoding: KafkaSourceDecoding,
     should_enrich_op_column: bool,
     record_batch_interval_ms: u64,
     record_batch_size: u32,
@@ -1507,10 +1585,6 @@ pub struct KafkaSourceTableProvider {
     shutdown_rx: watch::Receiver<bool>,
     num_records_before_stop: Option<u64>,
     extracted_primary_key: Option<String>,
-    versions_client: Arc<SubjectVersionsClient>,
-    validate_writer_schema_ordering: bool,
-    schema_id_overrides: HashMap<u32, u32>,
-    skip_schema_resolution: bool,
 }
 
 impl Debug for KafkaSourceTableProvider {
@@ -1523,7 +1597,6 @@ impl Debug for KafkaSourceTableProvider {
             .field("filter", &self.filter)
             .field("full_schema", &self.full_schema)
             .field("payload_schema", &self.payload_schema)
-            .field("avro_schema", &self.avro_schema)
             .field("should_enrich_op_column", &self.should_enrich_op_column)
             .field("record_batch_interval_ms", &self.record_batch_interval_ms)
             .field("record_batch_size", &self.record_batch_size)
@@ -1570,26 +1643,65 @@ impl KafkaSourceTableProvider {
         schema_id_overrides: Vec<SchemaIdOverride>,
         skip_schema_resolution_unconditional: bool,
         skip_schema_resolution_for_reader_schema_ids: Vec<u32>,
+        format: KafkaFormat,
+        json_schema: Option<BTreeMap<String, String>>,
     ) -> Result<Self> {
-        let (avro_schema, reader_schema_id) = KafkaCommon::fetch_avro_schema(&config, &topic)?;
-        let payload_schema = convert_avro_schema_to_arrow(avro_schema.clone());
+        let (payload_schema, decoding, extracted_primary_key) = match format {
+            KafkaFormat::Avro => {
+                if json_schema.is_some() {
+                    return Err(streamling_user_err!(
+                        "`schema` is only supported with data_format: json"
+                    )
+                    .into());
+                }
 
-        let schema_id_overrides = build_schema_id_overrides_map(&topic, schema_id_overrides)?;
-        let skip_schema_resolution = skip_schema_resolution_unconditional
-            || skip_schema_resolution_for_reader_schema_ids.contains(&reader_schema_id);
+                let (avro_schema, reader_schema_id) =
+                    KafkaCommon::fetch_avro_schema(&config, &topic)?;
+                let payload_schema = convert_avro_schema_to_arrow(avro_schema.clone());
 
-        let extracted_primary_key = Self::extract_primary_key(avro_schema.clone())
-            .map_err(|e| {
-                warn!("Could not extract primary key from Avro schema: {}", e);
-                e
-            })
-            .ok();
+                let schema_id_overrides =
+                    build_schema_id_overrides_map(&topic, schema_id_overrides)?;
+                let skip_schema_resolution = skip_schema_resolution_unconditional
+                    || skip_schema_resolution_for_reader_schema_ids.contains(&reader_schema_id);
 
-        if let Some(ref pk) = extracted_primary_key {
-            debug!("Extracted primary key from Avro schema: {}", pk);
-        } else {
-            debug!("No primary key found in Avro schema");
-        }
+                let extracted_primary_key = Self::extract_primary_key(avro_schema.clone())
+                    .map_err(|e| {
+                        warn!("Could not extract primary key from Avro schema: {}", e);
+                        e
+                    })
+                    .ok();
+                if let Some(ref pk) = extracted_primary_key {
+                    debug!("Extracted primary key from Avro schema: {}", pk);
+                } else {
+                    debug!("No primary key found in Avro schema");
+                }
+
+                let versions_client = Arc::new(SubjectVersionsClient::new(
+                    config.get_schema_registry_settings().ok_or_else(|| {
+                        streamling_user_err!("schema_registry_url is required for Avro format")
+                    })?,
+                ));
+
+                let decoding = KafkaSourceDecoding::Avro(Box::new(AvroSourceDecoding {
+                    avro_schema,
+                    reader_schema_id,
+                    versions_client,
+                    validate_writer_schema_ordering,
+                    schema_id_overrides,
+                    skip_schema_resolution,
+                }));
+
+                (payload_schema, decoding, extracted_primary_key)
+            }
+            KafkaFormat::Json => {
+                let schema_map = json_schema.ok_or_else(|| {
+                    streamling_user_err!("`schema` is required when data_format is json")
+                })?;
+                let payload_schema = arrow_schema_from_type_map(&schema_map)?;
+                // JSON payloads carry no embedded primary key; it comes from the source config.
+                (payload_schema, KafkaSourceDecoding::Json, None)
+            }
+        };
 
         let mut should_enrich_op_column = false;
         let mut enriched_schema_fields = payload_schema.fields.to_vec();
@@ -1620,12 +1732,6 @@ impl KafkaSourceTableProvider {
 
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-        let versions_client = Arc::new(SubjectVersionsClient::new(
-            config.get_schema_registry_settings().ok_or_else(|| {
-                streamling_user_err!("schema_registry_url is required for Avro format")
-            })?,
-        ));
-
         Ok(KafkaSourceTableProvider {
             reference_name,
             metric_metadata_id,
@@ -1635,8 +1741,7 @@ impl KafkaSourceTableProvider {
             filter,
             full_schema,
             payload_schema,
-            avro_schema,
-            reader_schema_id,
+            decoding,
             should_enrich_op_column,
             record_batch_interval_ms,
             record_batch_size,
@@ -1648,14 +1753,10 @@ impl KafkaSourceTableProvider {
             shutdown_rx,
             num_records_before_stop,
             extracted_primary_key,
-            versions_client,
-            validate_writer_schema_ordering,
-            schema_id_overrides,
-            skip_schema_resolution,
         })
     }
 
-    /// Get the payload schema (Avro data columns only, without _gs_op or __kafka_* metadata)
+    /// Get the payload schema (data columns only, without _gs_op or __kafka_* metadata)
     pub fn payload_schema(&self) -> SchemaRef {
         self.payload_schema.clone()
     }
@@ -1743,8 +1844,7 @@ impl KafkaSourceTableProvider {
         topic: String,
         start_at: Option<String>,
         filter: Option<String>,
-        avro_schema: AvroSchema,
-        reader_schema_id: u32,
+        decoding: KafkaSourceDecoding,
         should_enrich_op_column: bool,
         record_batch_interval_ms: u64,
         record_batch_size: u32,
@@ -1761,8 +1861,7 @@ impl KafkaSourceTableProvider {
             topic,
             start_at,
             filter.clone(),
-            avro_schema,
-            reader_schema_id,
+            decoding,
             should_enrich_op_column,
             record_batch_interval_ms,
             record_batch_size,
@@ -1772,10 +1871,6 @@ impl KafkaSourceTableProvider {
             self.shutdown_rx.clone(),
             self.num_records_before_stop,
             self.metric_metadata_id.clone(),
-            self.versions_client.clone(),
-            self.validate_writer_schema_ordering,
-            self.schema_id_overrides.clone(),
-            self.skip_schema_resolution,
         ));
 
         if let Some(filter_expr) = &filter {
@@ -1932,8 +2027,7 @@ impl TableProvider for KafkaSourceTableProvider {
             self.topic.clone(),
             self.start_at.clone(),
             self.filter.clone(),
-            self.avro_schema.clone(),
-            self.reader_schema_id,
+            self.decoding.clone(),
             self.should_enrich_op_column,
             self.record_batch_interval_ms,
             self.record_batch_size,

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -386,16 +386,12 @@ impl KafkaSourceConverter<'_> {
                 converter.buffer(resolved_value);
             }
             KafkaSourceConverter::Json(converter) => {
-                let payload = message.payload().unwrap_or_default();
-                let json = String::from_utf8(payload.to_vec()).map_err(|e| {
-                    streamling_user_err!(
-                        "Kafka JSON payload is not valid UTF-8\n  topic: {}\n  partition: {}\n  offset: {}\n  error: {}",
-                        message.topic(),
-                        message.partition(),
-                        message.offset(),
-                        e
-                    )
-                })?;
+                let json = json_payload_to_string(
+                    message.payload().unwrap_or_default(),
+                    message.topic(),
+                    message.partition(),
+                    message.offset(),
+                )?;
                 converter.buffer(json);
             }
         }
@@ -408,6 +404,36 @@ impl KafkaSourceConverter<'_> {
             KafkaSourceConverter::Json(converter) => converter.convert_to_batch(),
         }
     }
+}
+
+/// Decode a Kafka JSON payload into a UTF-8 string, failing with message coordinates for
+/// empty payloads (tombstones) and invalid UTF-8.
+fn json_payload_to_string(
+    payload: &[u8],
+    topic: &str,
+    partition: i32,
+    offset: i64,
+) -> Result<String> {
+    if payload.is_empty() {
+        return Err(streamling_err!(
+            "JSON source received an empty payload (tombstone?)\n  topic: {}\n  partition: {}\n  offset: {}",
+            topic,
+            partition,
+            offset
+        )
+        .into());
+    }
+
+    String::from_utf8(payload.to_vec()).map_err(|e| {
+        streamling_user_err!(
+            "Kafka JSON payload is not valid UTF-8\n  topic: {}\n  partition: {}\n  offset: {}\n  error: {}",
+            topic,
+            partition,
+            offset,
+            e
+        )
+        .into()
+    })
 }
 
 struct KafkaCommon {}
@@ -2828,6 +2854,27 @@ impl TableProvider for KafkaSinkTableProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn json_payload_to_string_rejects_empty_payload() {
+        let err = json_payload_to_string(b"", "orders", 3, 42).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("empty payload"), "{msg}");
+        assert!(msg.contains("orders"), "should carry the topic: {msg}");
+        assert!(msg.contains("42"), "should carry the offset: {msg}");
+    }
+
+    #[test]
+    fn json_payload_to_string_rejects_invalid_utf8() {
+        let err = json_payload_to_string(&[0xff, 0xfe], "orders", 0, 0).unwrap_err();
+        assert!(err.to_string().contains("not valid UTF-8"));
+    }
+
+    #[test]
+    fn json_payload_to_string_passes_valid_payload() {
+        let json = json_payload_to_string(br#"{"id":1}"#, "orders", 0, 0).unwrap();
+        assert_eq!(json, r#"{"id":1}"#);
+    }
 
     fn test_kafka_config() -> KafkaConfig {
         KafkaConfig {

--- a/crates/streamling-core/src/dynamic_table.rs
+++ b/crates/streamling-core/src/dynamic_table.rs
@@ -524,6 +524,8 @@ mod tests {
                 telemetry: None,
                 batch_size: None,
                 batch_flush_interval: None,
+                data_format: None,
+                schema: None,
                 validate_writer_schema_ordering: None,
                 schema_id_overrides: None,
                 skip_schema_resolution: None,

--- a/crates/streamling-core/src/lib.rs
+++ b/crates/streamling-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod operators;
 pub mod optimizer;
 pub mod plugin;
 pub mod retry;
+pub mod schema;
 pub mod serde;
 pub mod session;
 pub mod side_output;

--- a/crates/streamling-core/src/operators/wasm_runner.rs
+++ b/crates/streamling-core/src/operators/wasm_runner.rs
@@ -41,13 +41,11 @@ use datafusion::physical_plan::{
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 use extism::{Manifest, Plugin, Pool, Wasm};
 use futures::StreamExt;
-use heck::ToUpperCamelCase;
 use std::any::Any;
 use std::cmp::{Eq, Ord, PartialEq, PartialOrd};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::Debug;
-use std::str::FromStr;
 use std::sync::Arc;
 use tracing::{self, debug, error, info};
 
@@ -197,39 +195,19 @@ impl WasmRunnerNode {
     pub fn create_arrow_schema_from_map(
         schema_map: &BTreeMap<String, String>,
     ) -> Result<SchemaRef> {
-        let fields: Result<Vec<Field>> = schema_map
-            .iter()
-            .map(|(name, type_str)| {
-                let type_str = if type_str.eq_ignore_ascii_case("string") {
-                    "Utf8".to_string()
-                } else {
-                    type_str.to_upper_camel_case()
-                };
-                let data_type = match DataType::from_str(&type_str) {
-                    Ok(dt) => Ok(dt),
-                    Err(_) => Err(DataFusionError::from(crate::streamling_user_err!(
-                        "unsupported data type '{}' in WASM schema; supported types: \
-                         int8, int16, int32, int64, uint8, uint16, uint32, uint64, \
-                         float16, float32, float64, string/utf8, binary, boolean, \
-                         date32, date64, timestamp, time32, time64, duration, interval, null",
-                        type_str
-                    ))),
-                }?;
-                Ok(Field::new(name, data_type, true))
-            })
-            .collect();
-
-        let mut fields = fields?;
+        let schema = crate::schema::arrow_schema_from_type_map(schema_map)?;
 
         // Always ensure _gs_op is present as a string type (non-nullable)
-        if !schema_map.contains_key(crate::data::COLUMN_NAME_OP) {
-            fields.push(Field::new(
-                crate::data::COLUMN_NAME_OP,
-                DataType::Utf8,
-                false, // non-nullable
-            ));
+        if schema_map.contains_key(crate::data::COLUMN_NAME_OP) {
+            return Ok(schema);
         }
 
+        let mut fields = schema.fields().to_vec();
+        fields.push(Arc::new(Field::new(
+            crate::data::COLUMN_NAME_OP,
+            DataType::Utf8,
+            false, // non-nullable
+        )));
         Ok(Arc::new(Schema::new(fields)))
     }
 }

--- a/crates/streamling-core/src/schema.rs
+++ b/crates/streamling-core/src/schema.rs
@@ -1,12 +1,12 @@
 //! Shared helpers for building Arrow schemas from user-provided topology config.
 
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
-use datafusion::common::{DataFusionError, Result};
 use heck::ToUpperCamelCase;
 use std::collections::BTreeMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use crate::error::Result;
 use crate::streamling_user_err;
 
 /// Default precision and scale for `decimal` types declared without parameters.
@@ -41,14 +41,14 @@ fn parse_data_type(type_str: &str) -> Result<DataType> {
         type_str.to_upper_camel_case()
     };
     DataType::from_str(&normalized).map_err(|_| {
-        DataFusionError::from(streamling_user_err!(
+        streamling_user_err!(
             "unsupported data type '{}' in schema; supported types: \
              int8, int16, int32, int64, uint8, uint16, uint32, uint64, \
              float16, float32, float64, string/utf8, binary, boolean, \
              date32, date64, timestamp, time32, time64, duration, interval, \
              decimal128(precision, scale), decimal256(precision, scale), null",
             type_str
-        ))
+        )
     })
 }
 
@@ -99,8 +99,7 @@ fn parse_decimal_type(type_str: &str) -> Result<Option<DataType>> {
                 return Err(streamling_user_err!(
                     "invalid decimal type '{}': expected at most precision and scale",
                     type_str
-                )
-                .into());
+                ));
             }
             (precision, scale)
         }

--- a/crates/streamling-core/src/schema.rs
+++ b/crates/streamling-core/src/schema.rs
@@ -1,0 +1,253 @@
+//! Shared helpers for building Arrow schemas from user-provided topology config.
+
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use datafusion::common::{DataFusionError, Result};
+use heck::ToUpperCamelCase;
+use std::collections::BTreeMap;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use crate::streamling_user_err;
+
+/// Default precision and scale for `decimal` types declared without parameters.
+/// Mirrors the Postgres `numeric` mapping in [`crate::utils::pg`].
+const DEFAULT_DECIMAL_PRECISION: u8 = 38;
+const DEFAULT_DECIMAL_SCALE: i8 = 9;
+
+/// Convert a `column name -> Arrow type string` map into an Arrow [`SchemaRef`].
+///
+/// Type strings are matched case-insensitively. `"string"` maps to `Utf8`;
+/// `decimal128`/`decimal256` (alias `decimal` -> 128-bit) accept an optional
+/// `(precision[, scale])` suffix and otherwise default to `(38, 9)`; every other value is
+/// upper-camel-cased (e.g. `"int64"` -> `Int64`) and parsed via [`DataType::from_str`].
+/// All fields are nullable.
+pub fn arrow_schema_from_type_map(schema_map: &BTreeMap<String, String>) -> Result<SchemaRef> {
+    let fields = schema_map
+        .iter()
+        .map(|(name, type_str)| Ok(Field::new(name, parse_data_type(type_str)?, true)))
+        .collect::<Result<Vec<Field>>>()?;
+
+    Ok(Arc::new(Schema::new(fields)))
+}
+
+fn parse_data_type(type_str: &str) -> Result<DataType> {
+    if let Some(decimal) = parse_decimal_type(type_str)? {
+        return Ok(decimal);
+    }
+
+    let normalized = if type_str.eq_ignore_ascii_case("string") {
+        "Utf8".to_string()
+    } else {
+        type_str.to_upper_camel_case()
+    };
+    DataType::from_str(&normalized).map_err(|_| {
+        DataFusionError::from(streamling_user_err!(
+            "unsupported data type '{}' in schema; supported types: \
+             int8, int16, int32, int64, uint8, uint16, uint32, uint64, \
+             float16, float32, float64, string/utf8, binary, boolean, \
+             date32, date64, timestamp, time32, time64, duration, interval, \
+             decimal128(precision, scale), decimal256(precision, scale), null",
+            type_str
+        ))
+    })
+}
+
+/// Parse `decimal128`/`decimal256` (alias `decimal` -> 128-bit) with an optional
+/// `(precision[, scale])` suffix. Returns `Ok(None)` when `type_str` is not a decimal. A
+/// bare name defaults to `(DEFAULT_DECIMAL_PRECISION, DEFAULT_DECIMAL_SCALE)`; a precision
+/// without a scale defaults the scale to 0.
+fn parse_decimal_type(type_str: &str) -> Result<Option<DataType>> {
+    let lower = type_str.trim().to_ascii_lowercase();
+    let (is_256, params) = if let Some(rest) = lower.strip_prefix("decimal256") {
+        (true, rest)
+    } else if let Some(rest) = lower.strip_prefix("decimal128") {
+        (false, rest)
+    } else if let Some(rest) = lower.strip_prefix("decimal") {
+        (false, rest)
+    } else {
+        return Ok(None);
+    };
+
+    let (precision, scale) = match params.trim() {
+        "" => (DEFAULT_DECIMAL_PRECISION, DEFAULT_DECIMAL_SCALE),
+        params => {
+            let inner = params
+                .strip_prefix('(')
+                .and_then(|p| p.strip_suffix(')'))
+                .ok_or_else(|| {
+                    streamling_user_err!(
+                        "invalid decimal type '{}': expected 'decimal128(precision, scale)'",
+                        type_str
+                    )
+                })?;
+            let mut parts = inner.split(',');
+            let precision = parts
+                .next()
+                .unwrap_or_default()
+                .trim()
+                .parse::<u8>()
+                .map_err(|_| {
+                    streamling_user_err!("invalid precision in decimal type '{}'", type_str)
+                })?;
+            let scale = match parts.next() {
+                Some(scale) => scale.trim().parse::<i8>().map_err(|_| {
+                    streamling_user_err!("invalid scale in decimal type '{}'", type_str)
+                })?,
+                None => 0,
+            };
+            if parts.next().is_some() {
+                return Err(streamling_user_err!(
+                    "invalid decimal type '{}': expected at most precision and scale",
+                    type_str
+                )
+                .into());
+            }
+            (precision, scale)
+        }
+    };
+
+    Ok(Some(if is_256 {
+        DataType::Decimal256(precision, scale)
+    } else {
+        DataType::Decimal128(precision, scale)
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_nullable_fields() {
+        let mut schema_map = BTreeMap::new();
+        schema_map.insert("id".to_string(), "int64".to_string());
+        schema_map.insert("name".to_string(), "string".to_string());
+        schema_map.insert("value".to_string(), "decimal128".to_string());
+
+        let schema = arrow_schema_from_type_map(&schema_map).unwrap();
+
+        assert_eq!(schema.fields().len(), 3);
+        // BTreeMap iterates in key order: id, name
+        let id = schema.field(0);
+        assert_eq!(id.name(), "id");
+        assert_eq!(id.data_type(), &DataType::Int64);
+        assert!(id.is_nullable());
+
+        let name = schema.field(1);
+        assert_eq!(name.name(), "name");
+        assert_eq!(name.data_type(), &DataType::Utf8);
+        assert!(name.is_nullable());
+
+        // Bare `decimal128` falls back to the default precision and scale.
+        let value = schema.field(2);
+        assert_eq!(value.name(), "value");
+        assert_eq!(
+            value.data_type(),
+            &DataType::Decimal128(DEFAULT_DECIMAL_PRECISION, DEFAULT_DECIMAL_SCALE)
+        );
+        assert!(value.is_nullable());
+
+        assert!(
+            schema
+                .fields()
+                .iter()
+                .all(|f| f.name() != crate::data::COLUMN_NAME_OP),
+            "_gs_op must not be appended by the shared helper"
+        );
+    }
+
+    #[test]
+    fn parses_decimal_precision_and_scale() {
+        let mut schema_map = BTreeMap::new();
+        schema_map.insert("a".to_string(), "decimal128(20, 4)".to_string());
+        schema_map.insert("b".to_string(), "decimal256(50, 8)".to_string());
+        schema_map.insert("c".to_string(), "decimal(10)".to_string());
+
+        let schema = arrow_schema_from_type_map(&schema_map).unwrap();
+
+        assert_eq!(schema.field(0).data_type(), &DataType::Decimal128(20, 4));
+        assert_eq!(schema.field(1).data_type(), &DataType::Decimal256(50, 8));
+        // A precision without a scale defaults the scale to 0.
+        assert_eq!(schema.field(2).data_type(), &DataType::Decimal128(10, 0));
+    }
+
+    /// Confirms a decimal declared in the schema actually decodes from a JSON payload.
+    #[test]
+    fn json_decode_decimal_field() {
+        use crate::formats::ToArrowConverter;
+        use crate::formats::json::JsonToArrowConverter;
+        use datafusion::arrow::array::Decimal128Array;
+
+        let mut schema_map = BTreeMap::new();
+        schema_map.insert("amount".to_string(), "decimal128(10, 2)".to_string());
+
+        let schema = arrow_schema_from_type_map(&schema_map).unwrap();
+        let mut converter = JsonToArrowConverter::new(schema, true, None);
+        converter.buffer(r#"{"amount":123.45}"#.to_string());
+
+        let batch = converter.convert_to_batch().unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        let amount = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .unwrap();
+        // 123.45 at scale 2 -> unscaled 12345.
+        assert_eq!(amount.value(0), 12345);
+    }
+
+    #[test]
+    fn rejects_malformed_decimal() {
+        let mut schema_map = BTreeMap::new();
+        schema_map.insert("x".to_string(), "decimal128(1, 2, 3)".to_string());
+
+        let err = arrow_schema_from_type_map(&schema_map).unwrap_err();
+        assert!(err.to_string().contains("decimal"));
+    }
+
+    #[test]
+    fn rejects_unknown_type() {
+        let mut schema_map = BTreeMap::new();
+        schema_map.insert("x".to_string(), "not_a_type".to_string());
+
+        let err = arrow_schema_from_type_map(&schema_map).unwrap_err();
+        assert!(err.to_string().contains("unsupported data type"));
+    }
+
+    /// Exercises the exact path the Kafka JSON source uses: config map -> Arrow schema ->
+    /// schema-driven JSON decode of one object per message.
+    #[test]
+    fn json_decode_uses_map_derived_schema() {
+        use crate::formats::ToArrowConverter;
+        use crate::formats::json::JsonToArrowConverter;
+        use datafusion::arrow::array::{Array, Int64Array, StringArray};
+
+        let mut schema_map = BTreeMap::new();
+        schema_map.insert("id".to_string(), "int64".to_string());
+        schema_map.insert("name".to_string(), "string".to_string());
+
+        let schema = arrow_schema_from_type_map(&schema_map).unwrap();
+        let mut converter = JsonToArrowConverter::new(schema, true, None);
+        converter.buffer(r#"{"id":1,"name":"foo"}"#.to_string());
+        converter.buffer(r#"{"id":2,"name":null}"#.to_string());
+
+        let batch = converter.convert_to_batch().unwrap();
+        assert_eq!(batch.num_rows(), 2);
+
+        let id = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(id.value(0), 1);
+        assert_eq!(id.value(1), 2);
+
+        let name = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(name.value(0), "foo");
+        assert!(name.is_null(1));
+    }
+}

--- a/crates/streamling-core/src/topology.rs
+++ b/crates/streamling-core/src/topology.rs
@@ -160,6 +160,12 @@ pub struct KafkaSource {
     pub telemetry: Option<Telemetry>,
     pub batch_size: Option<u32>,
     pub batch_flush_interval: Option<String>,
+    /// Message payload format: "avro" (default) or "json". Avro decodes via the Schema
+    /// Registry; JSON decodes each payload as a UTF-8 JSON object using `schema`.
+    pub data_format: Option<String>,
+    /// Input schema for JSON payloads: column name -> Arrow type string (e.g. `id: int64`,
+    /// `name: string`). Required when `data_format` is "json"; rejected for Avro.
+    pub schema: Option<BTreeMap<String, String>>,
     /// When true (default), the consumer compares writer/reader schema versions per subject
     /// and fails fast if the writer schema is newer than the reader's, so the pod restarts
     /// and refetches the latest schema. Set to false to skip the check

--- a/crates/streamling-core/src/topology.rs
+++ b/crates/streamling-core/src/topology.rs
@@ -162,6 +162,10 @@ pub struct KafkaSource {
     pub batch_flush_interval: Option<String>,
     /// Message payload format: "avro" (default) or "json". Avro decodes via the Schema
     /// Registry; JSON decodes each payload as a UTF-8 JSON object using `schema`.
+    ///
+    /// The Kafka source does not support tombstone records (null/empty payloads, e.g. CDC
+    /// deletes-as-tombstones) in any format — they fail the source. Represent deletes with a
+    /// non-empty payload plus a `dbz.op=d` header instead.
     pub data_format: Option<String>,
     /// Input schema for JSON payloads: column name -> Arrow type string (e.g. `id: int64`,
     /// `name: string`). Required when `data_format` is "json"; rejected for Avro.

--- a/crates/streamling-e2e/tests/kafka_source.rs
+++ b/crates/streamling-e2e/tests/kafka_source.rs
@@ -1,0 +1,141 @@
+//! Kafka source e2e tests.
+//!
+//! Verifies the Kafka source can decode JSON-encoded message payloads using a
+//! config-supplied input `schema` (no Schema Registry). Each message payload is a
+//! single UTF-8 JSON object produced via `produce_json_records`.
+
+use serde::Serialize;
+use streamling_e2e::{init_tracing, PipelineOpts, TestContext};
+
+/// Test record serialized as a plain JSON object into the Kafka payload.
+#[derive(Debug, Clone, Serialize)]
+struct JsonRecord {
+    id: i64,
+    name: String,
+    amount: f64,
+    active: bool,
+}
+
+/// Basic happy path: produce JSON messages, decode them via `data_format: json`
+/// plus an explicit schema, and verify the decoded rows on a print sink.
+#[tokio::test]
+async fn kafka_json_source_decodes_payloads() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("Failed to create test context");
+
+    // JSON source needs no Schema Registry — produce raw JSON objects (no dbz.op header).
+    let records: Vec<JsonRecord> = vec![
+        JsonRecord {
+            id: 1,
+            name: "alpha".to_string(),
+            amount: 10.5,
+            active: true,
+        },
+        JsonRecord {
+            id: 2,
+            name: "beta".to_string(),
+            amount: 20.0,
+            active: false,
+        },
+        JsonRecord {
+            id: 3,
+            name: "gamma".to_string(),
+            amount: 30.25,
+            active: true,
+        },
+    ];
+
+    ctx.kafka
+        .produce_json_records(&records)
+        .await
+        .expect("Failed to produce JSON records");
+
+    let pipeline = format!(
+        r#"
+sources:
+  kafka_source:
+    type: kafka
+    topic: {topic}
+    starting_offsets: earliest
+    primary_key: id
+    data_format: json
+    schema:
+      id: int64
+      name: string
+      amount: float64
+      active: boolean
+
+transforms: {{}}
+
+sinks:
+  print_sink:
+    type: print
+    from: kafka_source
+    sample_every: 1
+"#,
+        topic = ctx.kafka_topic,
+    );
+
+    let output = ctx
+        .run_pipeline_with_capture(
+            &pipeline,
+            PipelineOpts::new()
+                .record_limit(records.len() as u64)
+                // One row per batch so the print sink emits every decoded row.
+                .env("STREAMLING__RECORD_BATCH_SIZE", "1")
+                .timeout(std::time::Duration::from_secs(60)),
+        )
+        .await
+        .expect("Pipeline execution failed");
+
+    assert_eq!(output.len(), 3, "expected 3 decoded JSON rows");
+
+    // Every declared column plus the synthesized _gs_op should be present.
+    for column in ["id", "name", "amount", "active", "_gs_op"] {
+        assert!(
+            output.has_column(column),
+            "missing column '{}'; got {:?}",
+            column,
+            output.column_names()
+        );
+    }
+
+    // No dbz.op header was set, so each row defaults to an insert.
+    for row in output.rows() {
+        assert_eq!(row.row_kind, "Insert", "JSON rows must default to inserts");
+    }
+    for op in output.column_values("_gs_op") {
+        assert_eq!(op.as_str(), Some("i"), "synthesized _gs_op must be 'i'");
+    }
+
+    // Values round-trip from the JSON payloads (order is preserved on a single partition,
+    // but assert by id to stay robust).
+    let mut ids: Vec<i64> = output
+        .column_values("id")
+        .iter()
+        .filter_map(|v| v.as_i64())
+        .collect();
+    ids.sort();
+    assert_eq!(ids, vec![1, 2, 3]);
+
+    let row_two = output
+        .rows()
+        .iter()
+        .find(|r| r.data.get("id").and_then(|v| v.as_i64()) == Some(2))
+        .expect("row with id=2");
+    assert_eq!(
+        row_two.data.get("name").and_then(|v| v.as_str()),
+        Some("beta")
+    );
+    assert_eq!(
+        row_two.data.get("amount").and_then(|v| v.as_f64()),
+        Some(20.0)
+    );
+    assert_eq!(
+        row_two.data.get("active").and_then(|v| v.as_bool()),
+        Some(false)
+    );
+}

--- a/crates/streamling-e2e/tests/kafka_source.rs
+++ b/crates/streamling-e2e/tests/kafka_source.rs
@@ -139,3 +139,115 @@ sinks:
         Some(false)
     );
 }
+
+/// Test for column projection. When a downstream query prunes payload columns,
+/// the JSON source must decode only the projected columns so the batch stays aligned with
+/// the projected schema. Before the JSON path applied the column projection, this pipeline
+/// failed with a `RecordBatch` column-count mismatch.
+#[tokio::test]
+async fn kafka_json_source_respects_column_projection() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("Failed to create test context");
+
+    let records: Vec<JsonRecord> = vec![
+        JsonRecord {
+            id: 1,
+            name: "alpha".to_string(),
+            amount: 10.5,
+            active: true,
+        },
+        JsonRecord {
+            id: 2,
+            name: "beta".to_string(),
+            amount: 20.0,
+            active: false,
+        },
+        JsonRecord {
+            id: 3,
+            name: "gamma".to_string(),
+            amount: 30.25,
+            active: true,
+        },
+    ];
+
+    ctx.kafka
+        .produce_json_records(&records)
+        .await
+        .expect("Failed to produce JSON records");
+
+    // The SQL transform selects a subset, pruning `amount` and `active` from the source scan.
+    let pipeline = format!(
+        r#"
+sources:
+  kafka_source:
+    type: kafka
+    topic: {topic}
+    starting_offsets: earliest
+    primary_key: id
+    data_format: json
+    schema:
+      id: int64
+      name: string
+      amount: float64
+      active: boolean
+
+transforms:
+  pick_columns:
+    type: sql
+    sql: "SELECT id, name FROM kafka_source"
+    primary_key: id
+
+sinks:
+  print_sink:
+    type: print
+    from: pick_columns
+    sample_every: 1
+"#,
+        topic = ctx.kafka_topic,
+    );
+
+    let output = ctx
+        .run_pipeline_with_capture(
+            &pipeline,
+            PipelineOpts::new()
+                .record_limit(records.len() as u64)
+                .env("STREAMLING__RECORD_BATCH_SIZE", "1")
+                .timeout(std::time::Duration::from_secs(60)),
+        )
+        .await
+        .expect("Pipeline execution failed");
+
+    assert_eq!(output.len(), 3, "expected 3 projected rows");
+
+    // The selected columns (plus the propagated _gs_op) survive...
+    for column in ["id", "name", "_gs_op"] {
+        assert!(
+            output.has_column(column),
+            "missing column '{}'; got {:?}",
+            column,
+            output.column_names()
+        );
+    }
+    // ...and the pruned payload columns are gone.
+    assert!(
+        !output.has_column("amount"),
+        "amount should be projected out; got {:?}",
+        output.column_names()
+    );
+    assert!(
+        !output.has_column("active"),
+        "active should be projected out; got {:?}",
+        output.column_names()
+    );
+
+    let mut ids: Vec<i64> = output
+        .column_values("id")
+        .iter()
+        .filter_map(|v| v.as_i64())
+        .collect();
+    ids.sort();
+    assert_eq!(ids, vec![1, 2, 3]);
+}

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -15,7 +15,7 @@ use streamling_connectors::table_providers::file::{
 };
 use streamling_connectors::table_providers::http::HttpTableProvider;
 use streamling_connectors::table_providers::hybrid::HybridTableProvider;
-use streamling_connectors::table_providers::kafka::KafkaSourceTableProvider;
+use streamling_connectors::table_providers::kafka::{KafkaFormat, KafkaSourceTableProvider};
 use streamling_connectors::table_providers::memory::MemoryTableProvider;
 use streamling_connectors::table_providers::postgres::PostgresSinkTableProvider;
 use streamling_connectors::table_providers::postgres::query_builder::validate_update_where;
@@ -553,6 +553,8 @@ impl Streamling {
                             .unwrap_or(app_config.record_batch_interval_ms);
                     let record_batch_size =
                         kafka.batch_size.unwrap_or(app_config.record_batch_size);
+                    let data_format: KafkaFormat =
+                        kafka.data_format.as_deref().unwrap_or("avro").parse()?;
                     let kafka_source_provider = Arc::new(
                         KafkaSourceTableProvider::new(
                             reference_name.clone(),
@@ -575,6 +577,8 @@ impl Streamling {
                                 .skip_schema_resolution_for_reader_schema_ids
                                 .clone()
                                 .unwrap_or_default(),
+                            data_format,
+                            kafka.schema.clone(),
                         )
                         .streamling_with_context(|| {
                             format!("{}: failed to create Kafka source", ctx.format())


### PR DESCRIPTION
Closes #40 

Implements support for the JSON format for the Kafka source. Current syntax looks like this:

```
sources:
  raw_transactions:
    type: kafka
    data_format: json
    topic: test-json-topic
    primary_key: id
    schema:
      id: int32
      amount: int32
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot Kafka consumer decode path and batch/schema alignment; misconfiguration or schema mismatch fails the source at runtime, but Avro behavior is largely preserved behind the refactor.
> 
> **Overview**
> Adds **JSON** as an optional Kafka source payload format via `data_format: json` and a required `schema` map (column → Arrow type). Avro remains the default and unchanged; hybrid Kafka legs stay **Avro-only**.
> 
> The Kafka source refactors Avro-specific state into `KafkaSourceDecoding` / `KafkaSourceConverter`, decodes JSON with `JsonToArrowConverter` (including **projected** payload schemas so SQL column pruning stays aligned), and **rejects tombstone / empty payloads** for JSON with explicit errors. `_gs_op` still comes from `dbz.op` when missing from the payload.
> 
> Shared **`arrow_schema_from_type_map`** (with decimal parsing) replaces duplicated schema parsing in WASM and backs the JSON source schema. README documents JSON config; **e2e tests** cover decode and projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd5df060ccd2c65973d8a30ae81331faf200b42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->