### PR TITLE
docs: fix broken README links and add plugin inclusion guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Streamling runs as a **single-node engine**. It can scale horizontally via Kafka
 
 ## Quick start
 
-This is the simplest path to a running pipeline. Most production flows add plugin stages and multiple transforms. See [Building data flows](#building-data-flows).
+This is the simplest path to a running pipeline. Most production flows add plugin stages and multiple transforms. See [Common patterns](#common-patterns).
 
 ```bash
 # 1. Install the runtime (macOS/Linux)
@@ -150,7 +150,7 @@ Mix the built-in connectors with [plugins](#plugin-system), SQL, WASM, and HTTP 
 
 | Flow                                 | Stages                                                                                                       | What the runtime provides                                                                                   |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| Plugin → SQL → handler → WASM → sink | plugin source + sql + [HTTP handler](#http-handler-transform) + [WASM](#webassembly-script-transform) + sink | Ordered processing and at-least-once delivery through all stages. See [hero example](#building-data-flows). |
+| Plugin → SQL → handler → WASM → sink | plugin source + sql + [HTTP handler](#http-handler-transform) + [WASM](#webassembly-script-transform) + sink | Ordered processing and at-least-once delivery through all stages. See [Plugin examples](#plugin-examples). |
 | Plugin → plugin → sink               | custom source + custom transform + custom sink                                                               | Same guarantees on fully custom I/O (e.g. poll an API, apply domain logic, push to a partner system)        |
 | Kafka → plugin transform → sink      | built-in source + plugin transform + built-in sink                                                           | Built-in source convenience + custom compute (decoding, external lookups, multi-record logic)               |
 | Multi-source via hybrid              | bounded backfill in a datalake + live stream through kafka                                                   | Phase-ordered processing with checkpoint continuity. See [Hybrid Source](#hybrid-source).                   |
@@ -223,7 +223,7 @@ sinks:
       mode: batch
 ```
 
-**Community plugins are available in the [streamling-community-plugins](https://github.com/goldsky-io/streamling-community-plugins) repository**.
+**Community plugins are available in the [streamling-community-plugins](https://github.com/goldsky-io/streamling-community-plugins) repository — see [Including Plugins](#including-plugins) for setup**.
 
 ## Development setup
 
@@ -1422,6 +1422,51 @@ Each plugin configuration requires:
 
 - `type`: Unique plugin id, consisting of the plugin namespace (optional) and an operator name, separated by a dot (e.g., `basic_plugin.random_source`)
 - `options`: Key-value pairs for plugin-specific configuration
+
+### Including Plugins
+
+A plugin is a shared library (`.so` on Linux, `.dylib` on macOS, `.dll` on Windows) built against the Streamling plugin ABI. To make a plugin usable in a pipeline, point the runtime at it before startup via `STREAMLING__PLUGIN__PATH`. The path may be a single library file or a directory — every file in a directory is loaded:
+
+```bash
+# a single plugin library
+export STREAMLING__PLUGIN__PATH=/opt/streamling-plugins/libcommunity_plugins.so
+
+# or a directory holding several plugins (all files are loaded)
+export STREAMLING__PLUGIN__PATH=/opt/streamling-plugins
+```
+
+Loaded plugins are then referenced by id as the `type` of any source, transform, or sink (see [Plugin Pipeline Configuration](#plugin-pipeline-configuration)). Plugin ids may be bare (`s3_sink`) or namespaced (`basic_plugin.random_source`).
+
+#### Community plugins
+
+The [streamling-community-plugins](https://github.com/goldsky-io/streamling-community-plugins) repository is a single workspace crate that compiles several sinks — `s3_sink`, `mysql_sink`, `sqs`, and `s2_sink` — into one shared library (`libcommunity_plugins.so` / `.dylib` / `community_plugins.dll`). Each release publishes prebuilt binaries for common platforms, so prefer those over building from source.
+
+1. Get the prebuilt library for your platform from the [releases page](https://github.com/goldsky-io/streamling-community-plugins/releases) and extract it:
+   ```bash
+   # latest release — swap linux-x86_64 for darwin-aarch64, darwin-x86_64,
+   # linux-aarch64, or windows-x86_64 (.zip) as needed
+   curl -L -o community-plugins.tar.gz \
+     https://github.com/goldsky-io/streamling-community-plugins/releases/latest/download/community-plugins-linux-x86_64.tar.gz
+   tar xzf community-plugins.tar.gz   # → libcommunity_plugins.so
+   ```
+   No prebuilt binary for your platform? Build from source: `git clone https://github.com/goldsky-io/streamling-community-plugins && cd streamling-community-plugins && just build-release` → `target/release/libcommunity_plugins.so`.
+2. Point the runtime at the library:
+   ```bash
+   export STREAMLING__PLUGIN__PATH=./libcommunity_plugins.so
+   ```
+3. Reference a plugin by its id in your pipeline. For example, write to S3 as Parquet:
+   ```yaml
+   sinks:
+     to_s3:
+       type: s3_sink
+       from: my_source
+       options:
+         bucket: my-bucket
+         region: us-east-1
+   ```
+   AWS credentials are required and best passed via the `STREAMLING__PLUGIN__S3_SINK__ACCESS_KEY_ID` / `...SECRET_ACCESS_KEY` environment variables (they take precedence over YAML). See the community-plugins README for the full option tables of each sink.
+
+To write and distribute your own plugin, see [Building Plugins](#building-plugins).
 
 ### Message-based Interface
 


### PR DESCRIPTION
## What

Fixes two broken anchor links in the README and adds a consumer-facing `Including Plugins` section (community plugins prefer prebuilt binaries).

## Why

On `main`, two links target `#building-data-flows`, but no such heading exists, so they 404:
- `Quick start` → "See [Building data flows](#building-data-flows)"
- `Common patterns` data-flows table → "See [hero example](#building-data-flows)"

There was also no consolidated "how do I include/load a plugin" section, and the community-plugins note pointed users at the repo with no setup instructions, when prebuilt release binaries are available.

> **Note on scope:** an earlier force-push of this branch shipped a stale README rewrite (+175/−198) that had been authored against an old `main` and reverted recent README work (the table of contents from #32, file source #28, JSON Kafka source #41, Quick Start #29). This has been rebuilt as a **targeted +48/−3** change on top of the current `main`. The stale rewrite is preserved in tag `readme-rewrite-backup` in case any of its restructuring is wanted later.

## Changes (targeted, +48/−3, README only)

- **Broken links fixed** (retargeted to real sections; no new headings, TOC unchanged):
  - `Quick start` → `[Common patterns](#common-patterns)`
  - data-flows table row → `[Plugin examples](#plugin-examples)` (link text reworded from "hero example", since Plugin examples holds building-block snippets, not a combined multi-stage flow)
- **New `### Including Plugins` section** (under Plugin System, after Plugin Pipeline Configuration): load a plugin via `STREAMLING__PLUGIN__PATH` (single file or directory — every file loaded), reference it by id (bare `s3_sink` or namespaced `basic_plugin.random_source`).
- **Community plugins prefer prebuilt binaries**: non-stale `releases/latest/download/<asset>` URL (verified → v0.1.1); each per-platform archive extracts to one `libcommunity_plugins.so` / `.dylib` / `.dll`. Build-from-source (`git clone … && just build-release`) is the fallback. Real plugin ids used: `s3_sink`, `mysql_sink`, `sqs`, `s2_sink`.
- Plugin-examples community-plugins note now links to the new section.

Verified against the live `streamling-community-plugins` repo (README, `Cargo.toml [lib] name`, `justfile`, GitHub Releases API) and the plugin-loading code (`crates/streamling-core/src/plugin.rs`). Full README link audit: 0 broken internal links.

Doc-only change; no Rust touched.