### PR TITLE
fix: fail fast on wedged broadcast consumer to force restart

### DIFF
--- a/crates/streamling-core/src/operators/broadcast/broadcast_stream.rs
+++ b/crates/streamling-core/src/operators/broadcast/broadcast_stream.rs
@@ -8,20 +8,41 @@ use datafusion::{
 use futures::StreamExt;
 use futures::future;
 use futures::stream::Stream;
+use parking_lot::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 use std::{
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::Arc,
     task::{Context, Poll},
 };
 use tokio::sync::mpsc::{Receiver, Sender, channel, error::TrySendError};
-use tracing::{info, warn};
+use tracing::{error, info, warn};
+
+/// Outcome of trying to deliver one batch to a single consumer.
+enum SendOutcome {
+    /// Accepted into the consumer's channel.
+    Sent,
+    /// The consumer's receiver was dropped — that branch has already ended.
+    Closed,
+    /// The channel stayed full past `stuck_timeout`: the consumer is alive but
+    /// not draining. `run_broadcast` treats this as fatal.
+    Stuck,
+}
+
+/// A consumer that cannot accept a single batch within this budget is treated
+/// as wedged (not merely slow) and triggers a pipeline restart.
+// ponytail: fixed 60s budget; promote to a config/env knob only if a legitimately
+// slow sink ever needs longer to accept one batch.
+const DEFAULT_STUCK_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Debug)]
 pub struct BroadcastStream {
     inner: Arc<BroadcastState>,
     stopped: Arc<AtomicBool>,
     channel_capacity: usize,
+    /// Per-batch delivery budget before a non-draining consumer is fatal.
+    stuck_timeout: Duration,
 }
 
 #[derive(Debug)]
@@ -34,6 +55,15 @@ impl BroadcastStream {
     /// Create a new broadcast handle without starting the background task.
     /// Call `start()` after adding all consumers to avoid dropping batches.
     pub fn new(schema: SchemaRef, channel_capacity: usize) -> Self {
+        Self::with_stuck_timeout(schema, channel_capacity, DEFAULT_STUCK_TIMEOUT)
+    }
+
+    /// Same as `new`, with an explicit stuck-consumer timeout (used by tests).
+    pub(crate) fn with_stuck_timeout(
+        schema: SchemaRef,
+        channel_capacity: usize,
+        stuck_timeout: Duration,
+    ) -> Self {
         BroadcastStream {
             inner: Arc::new(BroadcastState {
                 schema,
@@ -41,6 +71,7 @@ impl BroadcastStream {
             }),
             stopped: Arc::new(AtomicBool::new(false)),
             channel_capacity,
+            stuck_timeout,
         }
     }
 
@@ -53,11 +84,15 @@ impl BroadcastStream {
         });
     }
 
-    /// Retry sending with fixed delay until success or channel closed.
-    async fn try_send_batch_with_retry_forever(
+    /// Retry sending until the batch is accepted, the channel closes, or the
+    /// per-batch `stuck_timeout` elapses. A channel that never drains resolves
+    /// to `SendOutcome::Stuck` instead of blocking the fan-out forever.
+    async fn try_send_batch_bounded(
         tx: &Sender<DFResult<RecordBatch>>,
         batch_result: &DFResult<RecordBatch>,
-    ) -> Result<(), ()> {
+        stuck_timeout: Duration,
+    ) -> SendOutcome {
+        let deadline = Instant::now() + stuck_timeout;
         loop {
             let to_send = match batch_result {
                 Ok(batch) => Ok(batch.clone()),
@@ -65,13 +100,14 @@ impl BroadcastStream {
             };
 
             match tx.try_send(to_send) {
-                Ok(()) => return Ok(()),
+                Ok(()) => return SendOutcome::Sent,
                 Err(TrySendError::Full(_)) => {
-                    tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+                    if Instant::now() >= deadline {
+                        return SendOutcome::Stuck;
+                    }
+                    tokio::time::sleep(Duration::from_millis(1)).await;
                 }
-                Err(TrySendError::Closed(_)) => {
-                    return Err(());
-                }
+                Err(TrySendError::Closed(_)) => return SendOutcome::Closed,
             }
         }
     }
@@ -85,20 +121,38 @@ impl BroadcastStream {
 
             match source_stream.next().await {
                 Some(batch_result) => {
-                    // Concurrent retry sends to avoid deadlocks during consumer startup
-                    let consumers = self.inner.consumers.lock().unwrap().clone();
-                    let send_futures: Vec<_> = consumers
-                        .iter()
-                        .map(|tx| Self::try_send_batch_with_retry_forever(tx, &batch_result))
-                        .collect();
+                    // Concurrent bounded sends so a slow consumer at startup can't deadlock.
+                    let consumers = self.inner.consumers.lock().clone();
+                    let outcomes = future::join_all(consumers.iter().map(|tx| {
+                        Self::try_send_batch_bounded(tx, &batch_result, self.stuck_timeout)
+                    }))
+                    .await;
 
-                    let results = future::join_all(send_futures).await;
-                    for result in results {
-                        if result.is_err() {
-                            warn!(
-                                "Consumer channel closed, removing from broadcast. If this happens outside of a shutdown, this is a bug."
-                            );
-                        }
+                    // A consumer full past the timeout is wedged, not slow. One
+                    // stuck consumer would otherwise freeze the whole shared source
+                    // (head-of-line block, BDA: prod-oasis-consensus-raw-source), so
+                    // fail the pipeline and let the process exit non-zero -> restart.
+                    if outcomes.iter().any(|o| matches!(o, SendOutcome::Stuck)) {
+                        error!(
+                            timeout_secs = self.stuck_timeout.as_secs(),
+                            "Broadcast consumer stopped draining past the stuck-timeout; \
+                             failing the pipeline to force a restart."
+                        );
+                        self.fail_consumers().await;
+                        break;
+                    }
+
+                    // A closed consumer's branch already ended (its own error, if
+                    // any, propagated through its own sink). Actually prune it so it
+                    // stops being retried and re-warned on every subsequent batch.
+                    if !self.stopped.load(Ordering::SeqCst)
+                        && outcomes.iter().any(|o| matches!(o, SendOutcome::Closed))
+                    {
+                        warn!(
+                            "Consumer channel closed outside shutdown; removing it from the \
+                             broadcast. A downstream branch ended abnormally."
+                        );
+                        self.inner.consumers.lock().retain(|tx| !tx.is_closed());
                     }
                 }
                 None => {
@@ -107,9 +161,27 @@ impl BroadcastStream {
             }
         }
 
-        // Cleanup: clear all consumers so they see an end-of-stream
-        let mut guard = self.inner.consumers.lock().unwrap();
-        guard.clear(); // dropping all senders => all receivers get None
+        // Cleanup: clear all consumers so they see an end-of-stream.
+        self.inner.consumers.lock().clear(); // dropping all senders => receivers get None
+    }
+
+    /// Deliver a fatal error to every consumer that can still receive it. A
+    /// healthy (draining) consumer accepts it and its sink propagates the error,
+    /// tearing the pipeline down (non-zero exit -> orchestrator restart). A stuck
+    /// consumer times out here and is dropped by the caller's cleanup.
+    // ponytail: best-effort — if *every* consumer is wedged simultaneously none
+    // can receive it; that all-stuck case is the watchdog's job, not this path.
+    async fn fail_consumers(&self) {
+        self.stopped.store(true, Ordering::SeqCst);
+        let consumers = self.inner.consumers.lock().clone();
+        let sends = consumers.iter().map(|tx| async move {
+            let err = DataFusionError::Execution(
+                "broadcast: a consumer stopped draining; failing the pipeline to force a restart"
+                    .to_string(),
+            );
+            let _ = tokio::time::timeout(self.stuck_timeout, tx.send(Err(err))).await;
+        });
+        future::join_all(sends).await;
     }
 
     /// Add a new consumer. Returns a handle that can receive from this broadcast.
@@ -117,7 +189,7 @@ impl BroadcastStream {
         // Each consumer gets its own bounded receiver
         let (tx, rx) = channel(self.channel_capacity);
 
-        let mut consumers = self.inner.consumers.lock().unwrap();
+        let mut consumers = self.inner.consumers.lock();
         consumers.push(tx);
 
         BroadcastConsumer {
@@ -172,7 +244,7 @@ impl BroadcastStream {
         self.stopped.store(true, Ordering::SeqCst);
 
         // Also drop all consumers immediately
-        let mut guard = self.inner.consumers.lock().unwrap();
+        let mut guard = self.inner.consumers.lock();
         guard.clear(); // dropping all senders => each consumer sees a `None` and shuts down
     }
 }
@@ -326,5 +398,51 @@ mod tests {
             "retriable flag should survive clone"
         );
         assert_eq!(recovered.to_string(), "bad input");
+    }
+
+    // Regression for the June-29 prod-oasis-consensus-raw-source wedge: one
+    // consumer that stops draining must not freeze the fan-out. The healthy
+    // consumer should be failed (fatal error) rather than starved forever.
+    #[tokio::test]
+    async fn stuck_consumer_fails_pipeline_instead_of_starving_others() {
+        use datafusion::arrow::datatypes::Schema;
+        use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+        use futures::stream;
+        use std::time::Duration;
+
+        let schema: SchemaRef = Arc::new(Schema::empty());
+        let batches: Vec<DFResult<RecordBatch>> = (0..1000)
+            .map(|_| Ok(RecordBatch::new_empty(schema.clone())))
+            .collect();
+        let source: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            stream::iter(batches),
+        ));
+
+        // Short stuck-timeout so the test doesn't wait the 60s production budget.
+        let broadcast =
+            BroadcastStream::with_stuck_timeout(schema.clone(), 1, Duration::from_millis(200));
+        let mut consumer_a = broadcast.add_consumer(); // healthy, drained below
+        let _consumer_b = broadcast.add_consumer(); // never drained -> goes Stuck
+        broadcast.start(source);
+
+        // Drain A to completion. It must terminate (no head-of-line hang) and see
+        // the fatal error before end-of-stream.
+        let outcome = tokio::time::timeout(Duration::from_secs(5), async {
+            let mut saw_err = false;
+            while let Some(item) = consumer_a.next().await {
+                saw_err |= item.is_err();
+            }
+            saw_err
+        })
+        .await;
+
+        match outcome {
+            Ok(saw_err) => assert!(
+                saw_err,
+                "healthy consumer A should receive a fatal error when sibling B wedges"
+            ),
+            Err(_) => panic!("broadcast still head-of-line blocked: healthy consumer A hung"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

A production pipeline wedged and only a manual restart recovered it. Root cause is a head-of-line block in the shared-source broadcast fan-out: one consumer that stopped draining froze the entire source for every consumer, with no error and no exit.

## Problem

A shared source is scanned once and fanned out to N consumers (`BroadcastingExec` / `MultiSinkExec` -> `BroadcastStream`). The fan-out loop is serial: pull one batch, then deliver it to every consumer before pulling the next. Delivery (`try_send_batch_with_retry_forever`) retried a `Full` channel **forever**, giving up only on `Closed`.

When one consumer stopped draining its 10-slot channel (a downstream sink stalled), that channel stayed full, its send retried forever, `join_all` never resolved, and the source was never polled again. Every other consumer starved and the upstream fetch loop blocked.

The broadcast task is a detached `tokio::spawn`, not part of the top-level `select!` over plugin/sink futures. So the wedge produced no error and no completion: the process stayed alive but frozen, which is why only a manual restart cleared it.

```mermaid
graph TB
  SRC[shared source scan] --> LOOP[run_broadcast serial loop]
  LOOP -->|batch| A[consumer A: healthy]
  LOOP -->|batch| B[consumer B: stopped draining]
  LOOP -. retries B forever .-> B
  B -. join_all never resolves .-> LOOP
  A -. starved .-> A
```

The `Consumer channel closed, removing from broadcast` warnings from the incident are a second defect: the log claimed removal but nothing was ever removed, so a dead consumer re-warned on every batch.

## Fix

Bound the per-batch send with a stuck-timeout (60s default). A consumer that cannot accept a batch within the budget is wedged, not merely slow, so:

1. Deliver a fatal error to the healthy (draining) consumers. Their sink propagates it, the sink future fails, `run_pipeline` returns `Err`, and `main` exits non-zero, so the orchestrator restarts the pod and alerts fire.
2. Closed consumers are now actually pruned (`retain`), so a dead branch stops being retried and re-warned.

Chose fail-fast over silently dropping the slow consumer: dropping would stop writing one dataset with no signal (silent divergence on a raw chain source). A loud crash-loop is the safer failure for correctness-critical data, and matches the known recovery (restart).

| Consumer state | Before | After |
|---|---|---|
| Full past 60s (stuck) | retry forever, whole source frozen | fatal error, non-zero exit, restart |
| Closed (receiver dropped) | warn every batch, never removed | pruned, warned once |

## Reviewer notes

- Happy path is unchanged: consumers that drain within 60s per batch still get `SendOutcome::Sent` exactly as before. Only the stuck and closed paths change.
- All-consumers-stuck-at-once cannot deliver the fatal error to anyone; that residual case is left to a future watchdog (noted with a `ponytail:` comment). The observed incident (one stuck consumer among healthy siblings) is fully handled.
- Migrated this file's `consumers` mutex to `parking_lot` per repo rule (no guard is held across `.await`).

## Test

`stuck_consumer_fails_pipeline_instead_of_starving_others` reproduces the wedge: with one non-draining consumer the healthy consumer previously hung (2s+ timeout), now it receives the fatal error and the stream terminates in ~0.2s. Ran `cargo fmt` and `cargo clippy -p streamling-core --all-targets` (clean with the repo's sanctioned `-A clippy::result_large_err`). e2e not run locally (requires the k3s env, and forcing a consumer wedge end-to-end is impractical), hence draft for review.

## Follow-up (not in this PR)

Fail-fast is a strict improvement over the silent hang, but it is a blunt instrument: restarting the whole shared source (every dataset) because a single sink stalled for 60s is too aggressive when that sink would have self-healed. Open items before softening the behavior:

1. **Prefer connector self-heal over restart.** The wedge is backpressure, not a broken broadcast link. If a consumer wedges because its sink's connection dropped, the correct cure is the sink reconnecting (`CONN-001`), which drains the channel and clears the backpressure with no restart. Investigate whether the sinks downstream of the affected source actually retry their connection or hang. Fixing that prevents the wedge from forming at all, and we never confirmed the original root cause (slow write vs dropped connection vs lock).
2. **Do not fail fast on a single recoverable consumer.** Give one stuck consumer room to self-heal (its sink reconnects and drains, which unblocks the source on its own) instead of immediately failing the pipeline.
3. **Reserve restart for genuinely unrecoverable progress loss** (for example all consumers wedged, a shared downstream dependency down). This is exactly the case the current in-band error-injection cannot signal, since there is no live consumer to receive the poison pill. It needs an out-of-band watchdog: a task tracking time-since-last-delivered-batch that force-exits when the source has made no progress past a deadline.
4. **True branch-level recovery** (re-attach a wedged consumer without a full restart) requires a per-consumer replay buffer or independently-checkpointed consumers, because the broadcast is a live, non-replayable tee: a re-attached consumer would resume from "now" and miss everything delivered while it was down. Bigger change, and it carries OOM risk (see the prior unbounded-source-buffer OOM incident).

Target end-state: single stuck consumer -> tolerate/self-heal; all consumers wedged or no source progress past the deadline -> restart.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Opus 4](https://img.shields.io/badge/Claude_Opus_4-D97757?logo=claude&logoColor=white)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core multi-sink fan-out failure behavior for production pipelines; mis-tuned timeouts could restart jobs on legitimately slow sinks, though the happy path for draining consumers is unchanged.
> 
> **Overview**
> **`BroadcastStream` no longer retries a full consumer channel forever.** Per-batch delivery uses a **60s stuck timeout** (`try_send_batch_bounded`); if a consumer still cannot accept a batch, the fan-out treats it as wedged, logs an error, and **`fail_consumers`** pushes a fatal `DataFusionError` to draining branches so the pipeline exits and can restart instead of head-of-line blocking every sibling.
> 
> **Closed consumers are actually removed** from the registry (`retain` on non-closed senders) instead of only warning on every batch. The consumer list mutex moves to **`parking_lot::Mutex`**, and a **`with_stuck_timeout`** constructor supports tests. A regression test asserts a non-draining consumer causes a healthy peer to see the fatal error rather than hanging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a50fb83ef2d99175b8c49e7da213d417017e1a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
