### PR TITLE
feat: streamling-bench

### DIFF
--- a/.github/workflows/streamling-bench.yml
+++ b/.github/workflows/streamling-bench.yml
@@ -1,0 +1,130 @@
+name: streamling-bench
+
+# Manual end-to-end throughput benchmark.
+#   - Preloads Kafka (Avro/CDC) and runs kafka -> sql transform -> blackhole sink.
+#   - Compares each scenario to its committed baseline and uploads the results JSON.
+#
+# Trigger:
+#   gh workflow run streamling-bench.yml --ref main
+#
+# Baselines are keyed by runner label (blacksmith-8vcpu). Only compare runs from
+# the same runner — absolute throughput is machine-specific. Re-seed a baseline
+# by committing the uploaded results JSON to bench/baselines/blacksmith-8vcpu/.
+
+on:
+  workflow_dispatch:
+    inputs:
+      records:
+        description: "Source records preloaded per iteration"
+        required: false
+        default: "5000000"
+      iterations:
+        description: "Measured iterations (excludes warmup)"
+        required: false
+        default: "5"
+      warmup:
+        description: "Warmup iterations (discarded)"
+        required: false
+        default: "1"
+
+concurrency:
+  group: streamling-bench
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    runs-on: blacksmith-8vcpu-ubuntu-2204
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      BENCH_RUNNER_LABEL: blacksmith-8vcpu
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Rust toolchain
+        uses: dtolnay/rust-toolchain@1.90.0
+      - name: Setup rust cache
+        uses: useblacksmith/rust-cache@v3
+        with:
+          shared-key: "v0-streamling-bench"
+          cache-targets: true
+          cache-on-failure: true
+
+      # Build the release binary the benchmark drives (the harness runs it as a
+      # subprocess). streamling-bench itself is built by `cargo run` below, which
+      # also runs streamling from crates/streamling — identical to `just bench`.
+      - name: Build streamling (release)
+        run: cargo build --release -p streamling
+
+      # Infrastructure setup (mirrors the e2e job).
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Builder
+        uses: useblacksmith/setup-docker-builder@v1
+      - name: Pre-pull benchmark images
+        run: |
+          set -euo pipefail
+          images=(
+            "postgres:15-alpine"
+            "redpandadata/redpanda:v24.2.4"
+            "prom/prometheus:latest"
+            "rancher/k3s:v1.28.4-k3s1"
+          )
+          for image in "${images[@]}"; do
+            echo "Pulling $image"
+            for attempt in 1 2 3; do
+              if docker pull "$image"; then
+                break
+              fi
+              echo "Retrying $image pull (attempt $attempt/3)..."
+              sleep 5
+            done
+          done
+      - name: Install k3d
+        run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+      - name: Setup k3s cluster
+        run: ./scripts/k3s-setup.sh
+        timeout-minutes: 5
+
+      - name: Run benchmark
+        run: |
+          set -euo pipefail
+          eval "$(./scripts/k3s-setup.sh --env-only)"
+          export E2E_STREAMLING_BIN="$(pwd)/target/release/streamling"
+          export E2E_SHOW_STREAMLING_OUTPUT=0
+          export BENCH_GIT_SHA="${GITHUB_SHA}"
+          mkdir -p bench-results
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cargo run -q --release -p streamling-bench -- \
+            --records "${{ inputs.records }}" \
+            --iterations "${{ inputs.iterations }}" \
+            --warmup "${{ inputs.warmup }}" \
+            --out-dir bench-results \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+        env:
+          # Keep stdout to the human report; silence info-level harness logs.
+          RUST_LOG: warn
+          STREAMLING__PLUGIN__PATH: ""
+          STREAMLING__PLUGIN__PREPROCESSOR_IDS: ""
+        timeout-minutes: 30
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-results
+          path: bench-results/
+
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          echo "=== Pod Status ==="
+          kubectl get pods -n streamling-e2e -o wide
+          echo ""
+          echo "=== Pod Events ==="
+          kubectl get events -n streamling-e2e --sort-by='.lastTimestamp' | tail -30
+          echo ""
+          echo "=== Pod Logs ==="
+          for pod in $(kubectl get pods -n streamling-e2e -o name); do
+            echo "--- $pod ---"
+            kubectl logs $pod -n streamling-e2e --tail=100 || true
+          done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6891,6 +6891,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "streamling-bench"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "streamling-e2e",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "streamling-common"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/streamling",
     "crates/streamling-flink-compat",
     "crates/streamling-e2e",
+    "crates/streamling-bench",
 ]
 exclude = [
     "plugin_examples",

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Install with one command (see [Quick start](#quick-start)) or read more at [stre
 - [Upsert Semantics](#upsert-semantics)
 - [Plugin System](#plugin-system)
 - [Profiling](#profiling)
+- [Benchmarking](#benchmarking)
 - [Telemetry and Metrics](#telemetry-and-metrics)
 
 ## Why Streamling
@@ -1992,6 +1993,69 @@ The project can be configured to be profiled with `perf`:
 Note: the `perf` binary may need to be compiled from scratch for the version of the linux kernel used in the Kubernetes cluster.
 
 Instructions for compiling can be found [here](https://gist.github.com/sap1ens/827558883e1bd01709a52a4dedd2f10a).
+
+## Benchmarking
+
+An end-to-end throughput benchmark drives the real `streamling` binary through `Kafka (Avro/CDC) → SQL transform → blackhole sink` against the local k3s stack and reports records/sec. It is meant to catch performance regressions between releases, not to microbenchmark individual operators.
+
+The harness lives in the `streamling-bench` crate and reuses the e2e stack (Redpanda + Prometheus). It runs two scenarios:
+
+- `avro_cdc_projection` — projects/computes every row (selectivity 1.0).
+- `avro_cdc_filter` — a predicate that passes ~10% of rows (selectivity 0.1).
+
+### Running locally
+
+First bring up the local environment (see [Using k3s for Local Development](#using-k3s-for-local-development)):
+
+```bash
+just env-setup
+```
+
+Then run the benchmark. It is **report-only** — it prints a comparison against the baseline but never fails on a regression:
+
+```bash
+# Both scenarios with defaults (5M records, 5 measured iterations + 1 warmup).
+just bench
+
+# A quick run with fewer records/iterations.
+just bench --records 500000 --iterations 3 --warmup 1
+
+# A single scenario.
+just bench --scenario avro_cdc_filter
+```
+
+Each measured iteration re-reads the topic and reports:
+
+- **Input throughput** — `records / wall_clock` (the headline) plus MB/s.
+- **`compute_us_per_input_record`** — per-record compute time (microseconds) derived from `streamling_elapsed_compute_milliseconds_sum`. It excludes process startup and Kafka I/O wait, making it the most noise-resistant regression signal.
+
+Pass `--out-dir <dir>` to also write a `<scenario>.json` result file per scenario.
+
+### Baselines
+
+Baselines are committed JSON files, one per scenario, under `bench/baselines/<runner_label>/<scenario>.json`. A run compares its median against the matching baseline and flags any metric that moved past `--regression-threshold` (default `0.10`, i.e. 10%).
+
+Absolute throughput is machine-specific, so baselines are keyed by a **runner label** (`BENCH_RUNNER_LABEL`, defaults to `local`) — only compare runs from the same machine. If no baseline exists yet, the run just prints its numbers. To (re)seed the local baseline from a fresh run:
+
+```bash
+# Writes bench/baselines/local/<scenario>.json for every scenario.
+just bench-update-baseline
+
+# Or a single scenario.
+just bench-update-baseline --scenario avro_cdc_projection
+```
+
+Commit the generated files to make them the reference for future local runs.
+
+### In CI
+
+The `streamling-bench.yml` workflow runs the same benchmark manually on a fixed runner (`blacksmith-8vcpu`) so its numbers are comparable across releases:
+
+```bash
+gh workflow run streamling-bench.yml --ref main
+```
+
+It writes the comparison to the job summary and uploads the results JSON as an artifact. To update the CI baseline, download that artifact and commit its files to `bench/baselines/blacksmith-8vcpu/`.
 
 ## Telemetry and Metrics
 

--- a/crates/streamling-bench/Cargo.toml
+++ b/crates/streamling-bench/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "streamling-bench"
+version = "0.2.0"
+edition = "2021"
+description = "End-to-end throughput benchmark harness for streamling"
+license-file.workspace = true
+repository.workspace = true
+# Internal tooling: never published to crates.io (and absent from the release
+# publish list in streamling-release.yml).
+publish = false
+
+[dependencies]
+# Reuses the e2e harness (TestContext, KafkaResource, PrometheusResource) to
+# drive the real streamling binary against the shared k3s stack.
+streamling-e2e = { workspace = true }
+
+tokio = { workspace = true, features = ["macros", "time"] }
+clap = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+# Forces the decimal field to serialize as Avro `bytes` (not an int array) so it
+# resolves to an Avro decimal logical type.
+serde_bytes = "0.11"
+anyhow = { workspace = true }
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/streamling-bench/src/main.rs
+++ b/crates/streamling-bench/src/main.rs
@@ -1,0 +1,403 @@
+//! End-to-end throughput benchmark for streamling.
+//!
+//! Drives the real streamling binary through `Kafka (Avro/CDC) → SQL transform →
+//! blackhole sink` against the shared k3s stack, measures steady-state
+//! throughput, and compares it to a committed per-runner baseline (report-only).
+//!
+//! It reuses the `streamling-e2e` harness for resource isolation, binary
+//! execution, and Prometheus metric queries.
+//!
+//! Summary:
+//! - Preload `--records` Avro messages into an isolated topic **once**.
+//! - For each scenario, run the pipeline `--warmup + --iterations` times, each
+//!   iteration with a fresh consumer group (re-reads the topic from `earliest`)
+//!   and a distinct metrics instance (OTel counters are cumulative per process).
+//! - Headline metric: input throughput `records / wall_clock`. Robust secondary:
+//!   `compute_us_per_input_record` from `streamling_elapsed_compute_milliseconds_sum`,
+//!   which excludes process startup and Kafka I/O wait.
+
+mod report;
+mod scenario;
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use streamling_e2e::resources::PrometheusResource;
+use streamling_e2e::{init_tracing, PipelineOpts, TestContext, TestContextOptions};
+use tracing::info;
+
+use report::{compare, print_report};
+use scenario::{Scenario, SCENARIOS};
+
+/// Size of the pre-encoded payload pool cycled during bulk load. A multiple of
+/// 10 so `sel_key = index % 10` yields exactly 10% selectivity when cycled.
+const DISTINCT_PAYLOADS: u32 = 1_000;
+const DEFAULT_RECORDS: u64 = 5_000_000;
+const DEFAULT_ITERATIONS: u32 = 5;
+const DEFAULT_WARMUP: u32 = 1;
+const DEFAULT_REGRESSION_THRESHOLD: f64 = 0.10;
+/// Time to let the final OTel batch reach Prometheus after a run exits. Matches
+/// the 3s flush window the e2e metrics tests use with a 1s batch interval.
+const METRICS_FLUSH_WAIT: Duration = Duration::from_secs(3);
+/// Upper bound on a single pipeline run; a hang (e.g. an empty topic) fails
+/// loudly instead of blocking forever.
+const RUN_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Avro schema for the benchmark payload. Field types map to Arrow as:
+/// long→int64, string→utf8, double→float64, int→int32, and the `bytes` decimal
+/// logical type → Decimal128(20, 4) (precision ≤ 38).
+const BENCH_SCHEMA: &str = r#"{
+    "type": "record",
+    "name": "BenchRecord",
+    "fields": [
+        {"name": "id", "type": "long"},
+        {"name": "user_id", "type": "string"},
+        {"name": "email", "type": "string"},
+        {"name": "country", "type": "string"},
+        {"name": "device", "type": "string"},
+        {"name": "amount", "type": "double"},
+        {"name": "price", "type": {"type": "bytes", "logicalType": "decimal", "precision": 20, "scale": 4}},
+        {"name": "ts", "type": "long"},
+        {"name": "sel_key", "type": "int"}
+    ]
+}"#;
+
+const COUNTRIES: &[&str] = &["US", "CA", "GB", "DE", "FR", "JP", "BR", "IN", "AU", "NL"];
+const DEVICES: &[&str] = &["ios", "android", "web", "desktop"];
+
+#[derive(Debug, Serialize)]
+struct BenchRecord {
+    id: i64,
+    user_id: String,
+    email: String,
+    country: String,
+    device: String,
+    amount: f64,
+    /// Avro decimal, encoded as the big-endian two's-complement bytes of the
+    /// unscaled integer. `serde_bytes` forces Avro `bytes` (an int array would
+    /// not resolve to the decimal logical type).
+    #[serde(with = "serde_bytes")]
+    price: Vec<u8>,
+    ts: i64,
+    /// Drives deterministic filter selectivity: `WHERE sel_key = 0` matches 10%.
+    sel_key: i32,
+}
+
+fn generate_record(index: u64) -> BenchRecord {
+    let user_num = index % 100_000;
+    // Unscaled integer for the `price` decimal; the schema's scale of 4 makes
+    // this ~0.0000..9999.9999. The generator is scale-agnostic — the bytes are
+    // just a big-endian integer, and the schema owns the interpretation.
+    let price_unscaled = (index % 100_000_000) as i128;
+    BenchRecord {
+        id: index as i64,
+        user_id: format!("user_{}", user_num),
+        email: format!("user_{}@example.com", user_num),
+        country: COUNTRIES[(index % COUNTRIES.len() as u64) as usize].to_string(),
+        device: DEVICES[(index % DEVICES.len() as u64) as usize].to_string(),
+        amount: (index % 1_000) as f64 + 0.5,
+        price: price_unscaled.to_be_bytes().to_vec(),
+        ts: 1_700_000_000 + index as i64,
+        sel_key: (index % 10) as i32,
+    }
+}
+
+#[derive(Parser, Debug)]
+#[command(about = "Streamling end-to-end throughput benchmark (report-only)")]
+struct Cli {
+    /// Scenario name to run; omit to run every scenario.
+    #[arg(long)]
+    scenario: Option<String>,
+
+    /// Source records preloaded and consumed per iteration.
+    #[arg(long, default_value_t = DEFAULT_RECORDS)]
+    records: u64,
+
+    /// Measured iterations (excludes warmup).
+    #[arg(long, default_value_t = DEFAULT_ITERATIONS)]
+    iterations: u32,
+
+    /// Warmup iterations, discarded from the aggregate.
+    #[arg(long, default_value_t = DEFAULT_WARMUP)]
+    warmup: u32,
+
+    /// Directory to write `<scenario>.json` result files (skipped if unset).
+    #[arg(long)]
+    out_dir: Option<PathBuf>,
+
+    /// Directory holding `<scenario>.json` baselines. Defaults to
+    /// `bench/baselines/<runner_label>`.
+    #[arg(long)]
+    baseline_dir: Option<PathBuf>,
+
+    /// Regression flagged when input throughput drops (or compute time rises)
+    /// by more than this fraction versus the baseline.
+    #[arg(long, default_value_t = DEFAULT_REGRESSION_THRESHOLD)]
+    regression_threshold: f64,
+
+    /// Write current results as the new baseline instead of comparing.
+    #[arg(long)]
+    update_baseline: bool,
+}
+
+/// One benchmark result, serialized to JSON and used as the baseline schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchResult {
+    pub scenario: String,
+    pub format: String,
+    pub selectivity: f64,
+    pub records: u64,
+    pub payload_bytes: u64,
+    pub iterations: u32,
+    pub wall_clock_seconds_median: f64,
+    pub wall_clock_seconds_min: f64,
+    pub input_rows: u64,
+    pub throughput_input_records_per_sec_median: f64,
+    pub throughput_output_records_per_sec_median: f64,
+    pub throughput_mb_per_sec_median: f64,
+    pub compute_us_per_input_record_median: f64,
+    /// Rows the source emitted, from Prometheus — a sanity check, not the
+    /// throughput basis (filter pushdown can make this the post-filter count).
+    pub source_output_rows_observed: u64,
+    pub runner_label: String,
+    pub version: String,
+    pub timestamp_unix_secs: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    init_tracing();
+    let cli = Cli::parse();
+
+    let runner_label = std::env::var("BENCH_RUNNER_LABEL").unwrap_or_else(|_| "local".to_string());
+    let version = std::env::var("BENCH_GIT_SHA").unwrap_or_else(|_| "dev".to_string());
+    let baseline_dir = cli
+        .baseline_dir
+        .clone()
+        .unwrap_or_else(|| PathBuf::from(format!("bench/baselines/{}", runner_label)));
+
+    let scenarios = select_scenarios(cli.scenario.as_deref())?;
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_prometheus())
+        .await
+        .context(
+            "failed to create test context (is the k3s stack up and are E2E_* env vars set?)",
+        )?;
+    if ctx.prometheus.is_none() {
+        anyhow::bail!("Prometheus is not configured (E2E_PROMETHEUS_URL must be set)");
+    }
+
+    ctx.kafka
+        .register_schema(BENCH_SCHEMA)
+        .await
+        .context("failed to register Avro schema")?;
+
+    info!(
+        "Preloading {} Avro records into topic {}",
+        cli.records, ctx.kafka_topic
+    );
+    let payload_bytes = ctx
+        .kafka
+        .produce_avro_bulk(cli.records, DISTINCT_PAYLOADS, generate_record)
+        .await
+        .context("failed to preload Kafka topic")?;
+
+    let mut any_regression = false;
+    for scenario in scenarios {
+        let result = run_scenario(&ctx, scenario, &cli, payload_bytes, &runner_label, &version)
+            .await
+            .with_context(|| format!("scenario '{}' failed", scenario.name))?;
+
+        if let Some(dir) = &cli.out_dir {
+            write_json(&dir.join(format!("{}.json", scenario.name)), &result)?;
+        }
+
+        let baseline_path = baseline_dir.join(format!("{}.json", scenario.name));
+        if cli.update_baseline {
+            write_json(&baseline_path, &result)?;
+            info!("Wrote baseline {}", baseline_path.display());
+            print_report(&result, &[]);
+        } else {
+            let baseline = load_baseline(&baseline_path)?;
+            let comparison = match &baseline {
+                Some(b) => compare(&result, b, cli.regression_threshold),
+                None => Vec::new(),
+            };
+            any_regression |= comparison.iter().any(|c| c.regressed);
+            print_report(&result, &comparison);
+            if baseline.is_none() {
+                println!(
+                    "  (no baseline at {} — run `just bench-update-baseline` to seed it)",
+                    baseline_path.display()
+                );
+            }
+        }
+    }
+
+    // Report-only: a regression is surfaced but never fails the process.
+    if any_regression {
+        println!("\n⚠️  One or more metrics regressed beyond the threshold (report-only).");
+    }
+    Ok(())
+}
+
+fn select_scenarios(name: Option<&str>) -> Result<Vec<&'static Scenario>> {
+    match name {
+        None => Ok(SCENARIOS.iter().collect()),
+        Some(n) => {
+            let scenario = SCENARIOS.iter().find(|s| s.name == n).with_context(|| {
+                let names: Vec<&str> = SCENARIOS.iter().map(|s| s.name).collect();
+                format!("unknown scenario '{}'; available: {}", n, names.join(", "))
+            })?;
+            Ok(vec![scenario])
+        }
+    }
+}
+
+async fn run_scenario(
+    ctx: &TestContext,
+    scenario: &Scenario,
+    cli: &Cli,
+    payload_bytes: u64,
+    runner_label: &str,
+    version: &str,
+) -> Result<BenchResult> {
+    let prometheus = ctx.prometheus.as_ref().expect("prometheus checked in main");
+    let stop = (scenario.selectivity * cli.records as f64).ceil() as u64;
+
+    let pipeline_yaml = format!(
+        r#"
+sources:
+  kafka_source:
+    type: kafka
+    topic: {topic}
+    starting_offsets: earliest
+    primary_key: id
+
+transforms:
+  projected:
+    type: sql
+    primary_key: id
+    sql: "{sql}"
+
+sinks:
+  sink:
+    type: blackhole
+    from: projected
+"#,
+        topic = ctx.kafka_topic,
+        sql = scenario.sql,
+    );
+
+    let short_id = &ctx.test_id[..8];
+    let total_iters = cli.warmup + cli.iterations;
+    let mut measured: Vec<(String, f64)> = Vec::new();
+
+    for iter in 0..total_iters {
+        // Distinct per iteration so (a) OTel counters don't accumulate across
+        // runs and (b) a fresh consumer group re-reads the topic from earliest.
+        let instance = format!("bench-{}-{}-{}", scenario.name, short_id, iter);
+        let is_warmup = iter < cli.warmup;
+        info!(
+            "scenario={} iter={}/{} ({}) stop={} instance={}",
+            scenario.name,
+            iter + 1,
+            total_iters,
+            if is_warmup { "warmup" } else { "measured" },
+            stop,
+            instance,
+        );
+
+        let start = Instant::now();
+        ctx.run_pipeline_with_opts(
+            &pipeline_yaml,
+            PipelineOpts::new()
+                .record_limit(stop)
+                .timeout(RUN_TIMEOUT)
+                .env("STREAMLING__APPLICATION_ID", instance.clone())
+                .env(
+                    "STREAMLING__KAFKA_SOURCE__CONSUMER_GROUP_ID",
+                    instance.clone(),
+                ),
+        )
+        .await
+        .with_context(|| format!("pipeline run failed (iter {})", iter))?;
+        let wall = start.elapsed().as_secs_f64();
+
+        if !is_warmup {
+            measured.push((instance, wall));
+        }
+    }
+
+    tokio::time::sleep(METRICS_FLUSH_WAIT).await;
+
+    let mut input_tps = Vec::new();
+    let mut output_tps = Vec::new();
+    let mut compute_us = Vec::new();
+    let mut source_rows_observed = 0u64;
+
+    for (instance, wall) in &measured {
+        let compute_query = format!(
+            "sum(streamling_elapsed_compute_milliseconds_sum{{instance=\"{}\"}})",
+            instance
+        );
+        let compute_ms = prometheus.query(&compute_query).await?.unwrap_or(0.0);
+        let source_query = PrometheusResource::output_rows_query("kafka_source", Some(instance));
+        let src_rows = prometheus.query_count(&source_query).await?.unwrap_or(0);
+        source_rows_observed = source_rows_observed.max(src_rows);
+
+        input_tps.push(cli.records as f64 / wall);
+        output_tps.push(stop as f64 / wall);
+        compute_us.push(compute_ms * 1e3 / cli.records as f64);
+    }
+
+    let walls: Vec<f64> = measured.iter().map(|(_, w)| *w).collect();
+    let input_tps_median = report::median(&input_tps);
+
+    Ok(BenchResult {
+        scenario: scenario.name.to_string(),
+        format: "avro".to_string(),
+        selectivity: scenario.selectivity,
+        records: cli.records,
+        payload_bytes,
+        iterations: cli.iterations,
+        wall_clock_seconds_median: report::median(&walls),
+        wall_clock_seconds_min: walls.iter().copied().fold(f64::INFINITY, f64::min),
+        input_rows: cli.records,
+        throughput_input_records_per_sec_median: input_tps_median,
+        throughput_output_records_per_sec_median: report::median(&output_tps),
+        throughput_mb_per_sec_median: input_tps_median * payload_bytes as f64 / 1e6,
+        compute_us_per_input_record_median: report::median(&compute_us),
+        source_output_rows_observed: source_rows_observed,
+        runner_label: runner_label.to_string(),
+        version: version.to_string(),
+        timestamp_unix_secs: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+    })
+}
+
+fn load_baseline(path: &PathBuf) -> Result<Option<BenchResult>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read baseline {}", path.display()))?;
+    let result = serde_json::from_str(&contents)
+        .with_context(|| format!("failed to parse baseline {}", path.display()))?;
+    Ok(Some(result))
+}
+
+fn write_json(path: &PathBuf, result: &BenchResult) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(result)?;
+    std::fs::write(path, json).with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}

--- a/crates/streamling-bench/src/main.rs
+++ b/crates/streamling-bench/src/main.rs
@@ -19,7 +19,7 @@
 mod report;
 mod scenario;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
@@ -159,8 +159,9 @@ pub struct BenchResult {
     pub throughput_output_records_per_sec_median: f64,
     pub throughput_mb_per_sec_median: f64,
     pub compute_us_per_input_record_median: f64,
-    /// Rows the source emitted, from Prometheus — a sanity check, not the
-    /// throughput basis (filter pushdown can make this the post-filter count).
+    /// Rows the source emitted, from Prometheus — a sanity check that the source
+    /// read the whole topic. Filtering happens in the downstream transform, so
+    /// this should be ~records for every scenario, not the post-filter count.
     pub source_output_rows_observed: u64,
     pub runner_label: String,
     pub version: String,
@@ -381,7 +382,7 @@ sinks:
     })
 }
 
-fn load_baseline(path: &PathBuf) -> Result<Option<BenchResult>> {
+fn load_baseline(path: &Path) -> Result<Option<BenchResult>> {
     if !path.exists() {
         return Ok(None);
     }
@@ -392,7 +393,7 @@ fn load_baseline(path: &PathBuf) -> Result<Option<BenchResult>> {
     Ok(Some(result))
 }
 
-fn write_json(path: &PathBuf, result: &BenchResult) -> Result<()> {
+fn write_json(path: &Path, result: &BenchResult) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;

--- a/crates/streamling-bench/src/report.rs
+++ b/crates/streamling-bench/src/report.rs
@@ -107,8 +107,7 @@ pub fn print_report(result: &BenchResult, comparison: &[MetricDelta]) {
     );
     println!(
         "  source rows seen : {} (expected ~{})",
-        result.source_output_rows_observed,
-        (result.selectivity * result.records as f64) as u64,
+        result.source_output_rows_observed, result.records,
     );
 
     if comparison.is_empty() {

--- a/crates/streamling-bench/src/report.rs
+++ b/crates/streamling-bench/src/report.rs
@@ -1,0 +1,180 @@
+//! Aggregation and report-only baseline comparison.
+
+use std::cmp::Ordering;
+
+use crate::BenchResult;
+
+/// Median of a sample. Returns 0.0 for an empty slice.
+pub fn median(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+    let mid = sorted.len() / 2;
+    if sorted.len() % 2 == 1 {
+        sorted[mid]
+    } else {
+        (sorted[mid - 1] + sorted[mid]) / 2.0
+    }
+}
+
+/// One metric compared against its baseline value.
+#[derive(Debug, Clone)]
+pub struct MetricDelta {
+    pub name: &'static str,
+    pub current: f64,
+    pub baseline: f64,
+    pub delta_pct: f64,
+    pub regressed: bool,
+}
+
+fn compare_metric(
+    name: &'static str,
+    current: f64,
+    baseline: f64,
+    threshold: f64,
+    higher_is_better: bool,
+) -> MetricDelta {
+    let delta_pct = if baseline != 0.0 {
+        (current - baseline) / baseline * 100.0
+    } else {
+        0.0
+    };
+    let regressed = if higher_is_better {
+        current < baseline * (1.0 - threshold)
+    } else {
+        current > baseline * (1.0 + threshold)
+    };
+    MetricDelta {
+        name,
+        current,
+        baseline,
+        delta_pct,
+        regressed,
+    }
+}
+
+/// Compare the headline metrics against a baseline. Input throughput is
+/// higher-is-better; per-record compute time is lower-is-better.
+pub fn compare(current: &BenchResult, baseline: &BenchResult, threshold: f64) -> Vec<MetricDelta> {
+    vec![
+        compare_metric(
+            "input_records_per_sec",
+            current.throughput_input_records_per_sec_median,
+            baseline.throughput_input_records_per_sec_median,
+            threshold,
+            true,
+        ),
+        compare_metric(
+            "compute_us_per_input_record",
+            current.compute_us_per_input_record_median,
+            baseline.compute_us_per_input_record_median,
+            threshold,
+            false,
+        ),
+    ]
+}
+
+/// Print a human/markdown-friendly summary for one scenario. `comparison` is
+/// empty when there is no baseline (or when seeding one).
+pub fn print_report(result: &BenchResult, comparison: &[MetricDelta]) {
+    println!("\n### {} ({})", result.scenario, result.format);
+    println!(
+        "records={} payload={}B selectivity={} iterations={} runner={} version={}",
+        result.records,
+        result.payload_bytes,
+        result.selectivity,
+        result.iterations,
+        result.runner_label,
+        result.version,
+    );
+    println!(
+        "  input throughput : {:.0} rec/s ({:.1} MB/s)",
+        result.throughput_input_records_per_sec_median, result.throughput_mb_per_sec_median,
+    );
+    println!(
+        "  output throughput: {:.0} rec/s",
+        result.throughput_output_records_per_sec_median,
+    );
+    println!(
+        "  compute          : {:.3} µs/record",
+        result.compute_us_per_input_record_median,
+    );
+    println!(
+        "  wall clock       : {:.2}s median, {:.2}s min",
+        result.wall_clock_seconds_median, result.wall_clock_seconds_min,
+    );
+    println!(
+        "  source rows seen : {} (expected ~{})",
+        result.source_output_rows_observed,
+        (result.selectivity * result.records as f64) as u64,
+    );
+
+    if comparison.is_empty() {
+        return;
+    }
+    println!("  vs baseline:");
+    for delta in comparison {
+        let flag = if delta.regressed {
+            "⚠️ REGRESSED"
+        } else {
+            "ok"
+        };
+        println!(
+            "    {:<28} {:>14.2} vs {:>14.2}  ({:+.1}%) {}",
+            delta.name, delta.current, delta.baseline, delta.delta_pct, flag,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn median_odd_and_even() {
+        assert_eq!(median(&[3.0, 1.0, 2.0]), 2.0);
+        assert_eq!(median(&[4.0, 1.0, 3.0, 2.0]), 2.5);
+    }
+
+    #[test]
+    fn median_empty_is_zero() {
+        assert_eq!(median(&[]), 0.0);
+    }
+
+    #[test]
+    fn throughput_drop_beyond_threshold_regresses() {
+        // 20% drop, threshold 15% → regression.
+        let delta = compare_metric("tps", 80.0, 100.0, 0.15, true);
+        assert!(delta.regressed);
+        assert!((delta.delta_pct - (-20.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn throughput_drop_within_threshold_is_ok() {
+        // 10% drop, threshold 15% → not a regression.
+        let delta = compare_metric("tps", 90.0, 100.0, 0.15, true);
+        assert!(!delta.regressed);
+    }
+
+    #[test]
+    fn throughput_improvement_is_never_regression() {
+        let delta = compare_metric("tps", 130.0, 100.0, 0.15, true);
+        assert!(!delta.regressed);
+        assert!(delta.delta_pct > 0.0);
+    }
+
+    #[test]
+    fn compute_time_rise_beyond_threshold_regresses() {
+        // Lower-is-better: 20% rise, threshold 15% → regression.
+        let delta = compare_metric("compute", 120.0, 100.0, 0.15, false);
+        assert!(delta.regressed);
+    }
+
+    #[test]
+    fn compute_time_drop_is_never_regression() {
+        let delta = compare_metric("compute", 70.0, 100.0, 0.15, false);
+        assert!(!delta.regressed);
+    }
+}

--- a/crates/streamling-bench/src/scenario.rs
+++ b/crates/streamling-bench/src/scenario.rs
@@ -1,0 +1,29 @@
+//! Benchmark scenarios. Each drives `Kafka (Avro) → SQL transform → blackhole`
+//! on a single-partition topic; only the SQL and its selectivity differ.
+
+pub struct Scenario {
+    pub name: &'static str,
+    /// SQL for the transform. Must read `FROM kafka_source`.
+    pub sql: &'static str,
+    /// Fraction of source rows the transform emits. Sets the sink stop-count
+    /// (`ceil(selectivity * records)`); the source still reads every row.
+    pub selectivity: f64,
+}
+
+// The SELECT lists every payload column so projection pushdown does not prune
+// them — the point is to exercise decode of the full record, not a thin slice.
+pub const SCENARIOS: &[Scenario] = &[
+    // Project + compute, drop no rows: input rows == output rows.
+    Scenario {
+        name: "avro_cdc_projection",
+        sql: "SELECT id, user_id, email, lower(country), device, amount, amount * 1.1 AS amount_with_fee, price, ts FROM kafka_source",
+        selectivity: 1.0,
+    },
+    // Same projection with a predicate that passes exactly 10% (see `sel_key`),
+    // exercising predicate evaluation and a 10:1 source:sink work ratio.
+    Scenario {
+        name: "avro_cdc_filter",
+        sql: "SELECT id, user_id, email, country, ts FROM kafka_source WHERE sel_key = 0",
+        selectivity: 0.1,
+    },
+];

--- a/crates/streamling-e2e/src/resources/kafka.rs
+++ b/crates/streamling-e2e/src/resources/kafka.rs
@@ -182,6 +182,8 @@ impl KafkaResource {
     /// The schema must already be registered (see [`Self::register_schema`]).
     /// Returns the average encoded payload size in bytes, for byte-throughput
     /// reporting.
+    ///
+    /// Panics if `distinct` is zero (there would be no payloads to cycle).
     pub async fn produce_avro_bulk<T, F>(
         &self,
         count: u64,
@@ -192,9 +194,12 @@ impl KafkaResource {
         T: Serialize,
         F: Fn(u64) -> T,
     {
+        assert!(distinct > 0, "produce_avro_bulk requires distinct > 0");
+
         let encoder = AvroEncoder::new(self.sr_settings.clone());
         let subject_strategy = SubjectNameStrategy::TopicNameStrategy(self.topic.clone(), false);
 
+        // Non-empty by the assert above, so indexing and division are safe.
         let mut pool: Vec<Vec<u8>> = Vec::with_capacity(distinct as usize);
         for i in 0..distinct as u64 {
             let payload = encoder
@@ -203,8 +208,7 @@ impl KafkaResource {
                 .map_err(|e| E2eError::Kafka(e.to_string()))?;
             pool.push(payload);
         }
-        let avg_payload_bytes =
-            (pool.iter().map(|p| p.len()).sum::<usize>() / pool.len().max(1)) as u64;
+        let avg_payload_bytes = (pool.iter().map(|p| p.len()).sum::<usize>() / pool.len()) as u64;
 
         for i in 0..count {
             let payload = &pool[(i as usize) % pool.len()];

--- a/crates/streamling-e2e/src/resources/kafka.rs
+++ b/crates/streamling-e2e/src/resources/kafka.rs
@@ -5,8 +5,9 @@ use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
 use rdkafka::client::DefaultClientContext;
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::error::{KafkaError, RDKafkaErrorCode};
 use rdkafka::message::{Header, Message, OwnedHeaders};
-use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
 use rdkafka::util::Timeout;
 use schema_registry_converter::async_impl::avro::{AvroDecoder, AvroEncoder};
 use schema_registry_converter::async_impl::schema_registry::{post_schema, SrSettings};
@@ -167,6 +168,77 @@ impl KafkaResource {
             op
         );
         Ok(())
+    }
+
+    /// Bulk-produce `count` Avro records for benchmark preloading.
+    ///
+    /// Pre-encodes a pool of `distinct` payloads once via `generate`, then
+    /// fire-and-forget produces `count` records by cycling the pool with a
+    /// `dbz.op="c"` header (so the source synthesizes `_gs_op='i'`). Unlike
+    /// [`Self::produce_avro_records`], deliveries are not awaited per record — a
+    /// single `flush` at the end waits for all in-flight messages. That is the
+    /// difference between seconds and hours when loading millions of rows.
+    ///
+    /// The schema must already be registered (see [`Self::register_schema`]).
+    /// Returns the average encoded payload size in bytes, for byte-throughput
+    /// reporting.
+    pub async fn produce_avro_bulk<T, F>(
+        &self,
+        count: u64,
+        distinct: u32,
+        generate: F,
+    ) -> Result<u64>
+    where
+        T: Serialize,
+        F: Fn(u64) -> T,
+    {
+        let encoder = AvroEncoder::new(self.sr_settings.clone());
+        let subject_strategy = SubjectNameStrategy::TopicNameStrategy(self.topic.clone(), false);
+
+        let mut pool: Vec<Vec<u8>> = Vec::with_capacity(distinct as usize);
+        for i in 0..distinct as u64 {
+            let payload = encoder
+                .encode_struct(generate(i), &subject_strategy)
+                .await
+                .map_err(|e| E2eError::Kafka(e.to_string()))?;
+            pool.push(payload);
+        }
+        let avg_payload_bytes =
+            (pool.iter().map(|p| p.len()).sum::<usize>() / pool.len().max(1)) as u64;
+
+        for i in 0..count {
+            let payload = &pool[(i as usize) % pool.len()];
+            let mut record = FutureRecord::to(&self.topic)
+                .payload(payload.as_slice())
+                .key("")
+                .headers(OwnedHeaders::new().insert(Header {
+                    key: "dbz.op",
+                    value: Some("c"),
+                }));
+
+            // Fire-and-forget: enqueue without awaiting delivery, backing off
+            // only when the local producer queue fills up.
+            loop {
+                match self.producer.send_result(record) {
+                    Ok(_delivery) => break,
+                    Err((KafkaError::MessageProduction(RDKafkaErrorCode::QueueFull), rejected)) => {
+                        record = rejected;
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                    Err((e, _)) => return Err(E2eError::Kafka(e.to_string())),
+                }
+            }
+        }
+
+        self.producer
+            .flush(Timeout::After(Duration::from_secs(120)))
+            .map_err(|e| E2eError::Kafka(e.to_string()))?;
+
+        info!(
+            "Bulk-produced {} Avro records to topic {} (avg {} bytes/payload)",
+            count, self.topic, avg_payload_bytes
+        );
+        Ok(avg_payload_bytes)
     }
 
     /// Produce raw bytes to the topic

--- a/justfile
+++ b/justfile
@@ -158,3 +158,32 @@ e2e-test-inspect *TEST_UUID:
     set -euo pipefail
     eval "$(./scripts/k3s-setup.sh --env-only)"
     cargo run --bin streamling-e2e-inspect -- {{TEST_UUID}}
+
+# ============================================================================
+# Benchmarks (requires env-setup first)
+# ============================================================================
+
+# Run the end-to-end throughput benchmark (report-only): builds the release
+# binary, preloads Kafka, runs kafka -> sql -> blackhole, and compares each
+# scenario to its committed baseline. Pass extra flags, e.g.
+#   just bench --records 500000 --iterations 3
+[group('bench')]
+bench *ARGS: e2e-build
+    #!/usr/bin/env bash
+    set -euo pipefail
+    eval "$(./scripts/k3s-setup.sh --env-only)"
+    export E2E_STREAMLING_BIN="$(pwd)/target/release/streamling"
+    export E2E_SHOW_STREAMLING_OUTPUT="${E2E_SHOW_STREAMLING_OUTPUT:-0}"
+    export BENCH_RUNNER_LABEL="${BENCH_RUNNER_LABEL:-local}"
+    cargo run --release -p streamling-bench -- {{ARGS}}
+
+# Re-seed benchmark baselines from a fresh run (writes bench/baselines/<runner>/).
+[group('bench')]
+bench-update-baseline *ARGS: e2e-build
+    #!/usr/bin/env bash
+    set -euo pipefail
+    eval "$(./scripts/k3s-setup.sh --env-only)"
+    export E2E_STREAMLING_BIN="$(pwd)/target/release/streamling"
+    export E2E_SHOW_STREAMLING_OUTPUT="${E2E_SHOW_STREAMLING_OUTPUT:-0}"
+    export BENCH_RUNNER_LABEL="${BENCH_RUNNER_LABEL:-local}"
+    cargo run --release -p streamling-bench -- --update-baseline {{ARGS}}


### PR DESCRIPTION
Benchmark harness for running in CI. Check [the README section](https://github.com/goldsky-io/streamling/blob/sap1ens/bench-ci/README.md#benchmarking) for the high-level details.

Reports look like this:

```
### avro_cdc_projection (avro)
records=500000 payload=76B selectivity=1 iterations=3 runner=local version=dev
  input throughput : 133607 rec/s (10.2 MB/s)
  output throughput: 133607 rec/s
  compute          : 20.218 µs/record
  wall clock       : 3.74s median, 3.71s min
  source rows seen : 500000 (expected ~500000)
  (no baseline at bench/baselines/local/avro_cdc_projection.json — run `just bench-update-baseline` to seed it)

### avro_cdc_filter (avro)
records=500000 payload=76B selectivity=0.1 iterations=3 runner=local version=dev
  input throughput : 102963 rec/s (7.8 MB/s)
  output throughput: 10296 rec/s
  compute          : 28.888 µs/record
  wall clock       : 4.86s median, 4.82s min
  source rows seen : 500000 (expected ~500000)
  (no baseline at bench/baselines/local/avro_cdc_filter.json — run `just bench-update-baseline` to seed it)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New internal benchmark tooling and e2e Kafka helper only; no changes to production pipeline logic, and benchmark runs are report-only.
> 
> **Overview**
> Adds an **end-to-end throughput benchmark** (`streamling-bench`) that drives the release `streamling` binary through **Kafka (Avro/CDC) → SQL → blackhole** on the existing k3s e2e stack, with two scenarios (`avro_cdc_projection`, `avro_cdc_filter`). The harness preloads millions of rows once, runs warmup plus measured iterations with fresh consumer groups and per-run OTel instance IDs, reports median throughput and `compute_us_per_input_record` from Prometheus, and **compares to runner-keyed JSON baselines** (report-only; regressions do not fail the process).
> 
> **Supporting changes:** `streamling-e2e` gains **`produce_avro_bulk`** for fast Kafka preload; **`just bench`** / **`just bench-update-baseline`** mirror local runs; a manual **`streamling-bench.yml`** workflow on a fixed Blacksmith runner uploads results and prints the report to the job summary; README documents usage and baseline seeding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05abd0bf3f134a97ff937e5f64aedf8c56b9b614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->