### PR TITLE
fix: apply scan projection to plugin source batches (df54)

### DIFF
--- a/crates/streamling-common/src/functions/array_enumerate.rs
+++ b/crates/streamling-common/src/functions/array_enumerate.rs
@@ -124,7 +124,13 @@ impl ScalarUDFImpl for ArrayEnumerateFunc {
         let list_array = input_array
             .as_any()
             .downcast_ref::<ListArray>()
-            .ok_or_else(|| streamling_user_err!("Input must be a list array"))?;
+            .ok_or_else(|| {
+                streamling_user_err!(
+                    "Input must be a list array, got array of type {:?} (declared field: {:?})",
+                    input_array.data_type(),
+                    args.arg_fields.first().map(|f| f.data_type())
+                )
+            })?;
 
         // Zero-copy optimization: reuse the flattened values buffer from the input list
         let values_array = list_array.values();

--- a/crates/streamling-core/src/plugin/table_provider.rs
+++ b/crates/streamling-core/src/plugin/table_provider.rs
@@ -7,7 +7,7 @@ use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use datafusion::catalog::Session;
 use datafusion::common::Result;
-use datafusion::common::{not_impl_err, project_schema};
+use datafusion::common::{DataFusionError, not_impl_err, project_schema};
 use datafusion::datasource::sink::{DataSink, DataSinkExec};
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -38,6 +38,11 @@ use tracing::{debug, error, warn};
 #[derive(Debug)]
 struct PluginSourceExec {
     schema: SchemaRef,
+    /// Column indices into the plugin's full schema, pushed down from the scan.
+    /// The plugin always emits full rows; the projection is applied here so the
+    /// emitted batches match `schema` (DataFusion 54 resolves downstream column
+    /// indices against the projected scan schema).
+    projection: Option<Vec<usize>>,
     plugin_channels: Arc<PluginChannels>,
     cached_properties: Arc<PlanProperties>,
     internal_buffer_size: u32,
@@ -47,6 +52,7 @@ struct PluginSourceExec {
 impl PluginSourceExec {
     pub fn new(
         schema: SchemaRef,
+        projection: Option<Vec<usize>>,
         plugin_channels: Arc<PluginChannels>,
         internal_buffer_size: u32,
         metric_metadata_id: String,
@@ -54,6 +60,7 @@ impl PluginSourceExec {
         let cached_properties = Self::compute_properties(schema.clone());
         Self {
             schema,
+            projection,
             plugin_channels,
             cached_properties: Arc::new(cached_properties),
             internal_buffer_size,
@@ -125,6 +132,7 @@ impl ExecutionPlan for PluginSourceExec {
         let metrics_receiver = self.plugin_channels.metrics.receiver.clone();
         let metrics_recorder = get_metrics_recorder();
         let metric_metadata_id = self.metric_metadata_id.clone();
+        let projection = self.projection.clone();
 
         builder.spawn(async move {
             tokio::spawn(process_plugin_metrics(
@@ -148,6 +156,22 @@ impl ExecutionPlan for PluginSourceExec {
                             match message.into_enum() {
                                 Ok(PluginMsg::NextBatch { data }) => {
                                     let mut record_batch: RecordBatch = data.into();
+                                    // The plugin emits full rows; apply the scan's column
+                                    // projection so batches match the declared (projected)
+                                    // schema. `RecordBatch::project` preserves schema
+                                    // metadata, so checkpoint signals survive.
+                                    if let Some(indices) = &projection {
+                                        record_batch = match record_batch.project(indices) {
+                                            Ok(projected) => projected,
+                                            Err(e) => {
+                                                let _ = tx
+                                                    .send(Err(DataFusionError::from(e)
+                                                        .context("projecting plugin source batch")))
+                                                    .await;
+                                                return Ok(());
+                                            }
+                                        };
+                                    }
                                     batch_count += 1;
 
                                     if !checkpoint_buffer.is_empty() {
@@ -300,8 +324,13 @@ impl PluginSourceProvider {
         internal_buffer_size: u32,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let schema_projected = project_schema(&schema_ref, projections)?;
+        // An identity projection (all columns in order) needs no per-batch work.
+        let projection = projections
+            .filter(|indices| !indices.iter().copied().eq(0..schema_ref.fields().len()))
+            .cloned();
         Ok(Arc::new(PluginSourceExec::new(
             schema_projected,
+            projection,
             plugin_channels,
             internal_buffer_size,
             self.metric_metadata_id.clone(),


### PR DESCRIPTION
## Summary

Fixes the `plugin-e2e` failures blocking plugins (df54 lockstep merge): 3 `ethereum_source` tests failed with `array_enumerate: Input must be a list array`.

## Root cause

`PluginSourceProvider::scan` declares the **projected** schema, but `PluginSourceExec` forwards raw full-width plugin batches without applying the projection (plugins always emit full rows). DataFusion 49 resolved downstream column indices against the child's actual schema, so the mismatch was harmless. DataFusion 54 resolves them against the projected scan schema, so every by-index reference downstream reads a shifted column — `array_enumerate(receipts)` received `block_number` (UInt64).

The df54 upgrade (#22) already fixed this class of bug on the scan-sharing path by making `BroadcastingExec` projection-aware; the direct-scan path was missed because streamling's own e2e only exercises built-in sources (which apply projections), while plugin sources are only exercised by the plugins repo's e2e.

## Changes

- `PluginSourceExec` stores the pushed-down column indices and applies `RecordBatch::project` to every emitted batch. `project` preserves schema metadata, so checkpoint signals survive (same guarantee the `BroadcastingExec` fix relies on). Identity projections are dropped at plan time.
- `array_enumerate`: the bare "Input must be a list array" error now includes the runtime array type and declared field type — this is what made the misrouting diagnosable.

## Verification

Reproduced the failure with a standalone pipeline (plugin ethereum_source → the failing unnest/array_enumerate SQL → print sink) before the fix; after the fix, the three failing plugins-repo e2e tests pass locally against the k3s env.

Full plugins e2e suite + a plugins-repo CI dispatch against this branch are running for regression coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MM9a2rXvhLnp6MwfqQuCk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core plugin source execution and batch schema alignment on every projected scan; incorrect projection logic would break plugin pipelines and checkpoints, but the change mirrors an existing `BroadcastingExec` pattern with metadata-preserving `project`.
> 
> **Overview**
> Fixes **DataFusion 54** column-index mismatches on the direct plugin-source scan path: the scan advertises a **projected** schema, but plugins still emit **full-width** batches, so downstream operators could read the wrong column (e.g. `array_enumerate(receipts)` seeing `block_number`).
> 
> **`PluginSourceExec`** now keeps the pushed-down column indices and runs **`RecordBatch::project`** on each batch before checkpoint enrichment and send, matching the pattern already used on **`BroadcastingExec`**. Identity projections (all columns in order) are skipped at plan time to avoid extra work. Projection failures surface as **`DataFusionError`** on the stream.
> 
> **`array_enumerate`** runtime type errors now include the actual array type and declared field type to make this class of misrouting easier to debug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e08711ea5c32d6b73819da77d806a77fbcc8489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->