### PR TITLE
chore: add CI bench baselines

### DIFF
--- a/bench/baselines/blacksmith-8vcpu/avro_cdc_filter.json
+++ b/bench/baselines/blacksmith-8vcpu/avro_cdc_filter.json
@@ -1,0 +1,19 @@
+{
+  "scenario": "avro_cdc_filter",
+  "format": "avro",
+  "selectivity": 0.1,
+  "records": 5000000,
+  "payload_bytes": 76,
+  "iterations": 5,
+  "wall_clock_seconds_median": 46.404246092,
+  "wall_clock_seconds_min": 46.24034357,
+  "input_rows": 5000000,
+  "throughput_input_records_per_sec_median": 107748.76053555775,
+  "throughput_output_records_per_sec_median": 10774.876053555776,
+  "throughput_mb_per_sec_median": 8.18890580070239,
+  "compute_us_per_input_record_median": 29.0062,
+  "source_output_rows_observed": 5000000,
+  "runner_label": "blacksmith-8vcpu",
+  "version": "9abfd93f38e3d5a9268d1ac2dca784e07dd515d4",
+  "timestamp_unix_secs": 1783555549
+}

--- a/bench/baselines/blacksmith-8vcpu/avro_cdc_projection.json
+++ b/bench/baselines/blacksmith-8vcpu/avro_cdc_projection.json
@@ -1,0 +1,19 @@
+{
+  "scenario": "avro_cdc_projection",
+  "format": "avro",
+  "selectivity": 1.0,
+  "records": 5000000,
+  "payload_bytes": 76,
+  "iterations": 5,
+  "wall_clock_seconds_median": 46.333442308,
+  "wall_clock_seconds_min": 46.240698559,
+  "input_rows": 5000000,
+  "throughput_input_records_per_sec_median": 107913.41525550094,
+  "throughput_output_records_per_sec_median": 107913.41525550094,
+  "throughput_mb_per_sec_median": 8.20141955941807,
+  "compute_us_per_input_record_median": 29.0184,
+  "source_output_rows_observed": 5000000,
+  "runner_label": "blacksmith-8vcpu",
+  "version": "9abfd93f38e3d5a9268d1ac2dca784e07dd515d4",
+  "timestamp_unix_secs": 1783555266
+}


### PR DESCRIPTION
Follow-up to https://github.com/goldsky-io/streamling/pull/47: adding baseline files. 

CI run: https://github.com/goldsky-io/streamling/actions/runs/28983609686

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds reference benchmark artifacts only; no runtime, build, or application logic changes.
> 
> **Overview**
> Seeds **committed baseline JSON** for the `streamling-bench` workflow on the **`blacksmith-8vcpu`** runner so future manual bench runs can compare against fixed reference numbers.
> 
> Adds two scenario snapshots from CI run at **`9abfd93`**: **`avro_cdc_filter`** (0.1 selectivity, ~108k input / ~11k output records/sec median) and **`avro_cdc_projection`** (full selectivity, ~108k records/sec). Each file records 5M records, 5 iterations, wall-clock medians, and throughput metrics keyed by `runner_label`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e152587ce73aadeb268888c969f45edc90e009e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->