### PR TITLE
fix: disable df54 leaf-expression extraction; harden WrappingExec against optimizer elision

### DIFF
--- a/crates/streamling-core/src/operators/wrapping.rs
+++ b/crates/streamling-core/src/operators/wrapping.rs
@@ -17,7 +17,6 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::Session;
 use datafusion::common::not_impl_err;
 use datafusion::common::{DFSchemaRef, DataFusionError, Result};
-use datafusion::config::ConfigOptions;
 use datafusion::datasource::sink::DataSink;
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::execution::{SendableRecordBatchStream, SessionState, TaskContext};
@@ -28,7 +27,6 @@ use datafusion::logical_expr::{
 use datafusion::physical_expr::{Distribution, OrderingRequirements};
 use datafusion::physical_plan::execution_plan::{CardinalityEffect, InvariantLevel};
 use datafusion::physical_plan::metrics::MetricsSet;
-use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, Statistics, execute_input_stream,
@@ -479,22 +477,21 @@ impl ExecutionPlan for WrappingExec {
             fn maintains_input_order(&self) -> Vec<bool>;
             fn benefits_from_input_partitioning(&self) -> Vec<bool>;
             fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>>;
-            fn repartitioned(
-                &self,
-                target_partitions: usize,
-                config: &ConfigOptions,
-            ) -> Result<Option<Arc<dyn ExecutionPlan>>>;
             fn metrics(&self) -> Option<MetricsSet>;
             fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>>;
-            fn supports_limit_pushdown(&self) -> bool;
-            fn with_fetch(&self, limit: Option<usize>) -> Option<Arc<dyn ExecutionPlan>>;
             fn cardinality_effect(&self) -> CardinalityEffect;
-            fn try_swapping_with_projection(
-                &self,
-                projection: &ProjectionExec,
-            ) -> Result<Option<Arc<dyn ExecutionPlan>>>;
         }
     }
+
+    // `try_swapping_with_projection`, `with_fetch`, `repartitioned`, and
+    // `supports_limit_pushdown` are deliberately NOT delegated to `self.inner`
+    // (they fall back to the trait's no-op defaults). Each of those hooks
+    // returns a rewritten subtree that does NOT contain this wrapper, so
+    // DataFusion 54's hook-driven physical optimizer rules (e.g.
+    // ProjectionPushdown) would replace the wrapper with the returned plan —
+    // silently deleting the telemetry/billing instrumentation (output_rows),
+    // side-output processing, and live inspection this node provides. Same
+    // hazard class as the RebatchExec elision (see tests/rebatch_elision.rs).
 
     fn schema(&self) -> SchemaRef {
         self.adjusted_schema.clone()

--- a/crates/streamling-core/src/session.rs
+++ b/crates/streamling-core/src/session.rs
@@ -86,6 +86,29 @@ impl SessionManager {
             .set_bool("datafusion.catalog.create_default_catalog_and_schema", true)
             // this increases e2e latency and can keep intermediate results in memory indefinitely, so we disable it
             .set_bool("datafusion.execution.coalesce_batches", false)
+            // DataFusion 54's ExtractLeafExpressions rule rewrites plans by
+            // pulling leaf expressions (struct/map field access) into
+            // extraction projections aliased `__datafusion_extracted_N`, with
+            // recovery projections meant to hide the extra columns again. Our
+            // user-defined extension nodes (Wrapper/Rebatch/MultiSink/...)
+            // capture their schema when built, and the rule's alias counter is
+            // not stable across re-optimization, so with the rule enabled
+            // plans that contain such extension nodes fail in three ways:
+            //   - "Extension planner for Wrapper ... created an ExecutionPlan
+            //     with mismatched schema" (the logical schema carries one set
+            //     of `__datafusion_extracted_N` names, physical planning
+            //     regenerates different ones) — a hard planning error,
+            //   - extraction columns leaking past the recovery projection
+            //     into sinks ("number of columns(N+1) must match number of
+            //     fields(N)" when building the sink batch),
+            //   - `arrow-schema` index-out-of-bounds panic in `Schema::field`
+            //     (the leaked phantom column reaching an unchecked index).
+            // Disable the rule to keep pre-54 planning semantics for
+            // streaming plans built around extension nodes.
+            .set_bool(
+                "datafusion.optimizer.enable_leaf_expression_pushdown",
+                false,
+            )
             .set_u64("datafusion.execution.batch_size", batch_size)
             .set_str(
                 "datafusion.catalog.default_catalog",

--- a/crates/streamling-core/tests/df54_regressions.rs
+++ b/crates/streamling-core/tests/df54_regressions.rs
@@ -1,0 +1,98 @@
+//! Regression tests for two DataFusion 54 upgrade hazards.
+//!
+//! 1. `WrappingExec` (telemetry wrapper) must not be deleted by DataFusion
+//!    54's hook-driven optimizer rules — same elision hazard as `RebatchExec`
+//!    (see tests/rebatch_elision.rs): delegated
+//!    `try_swapping_with_projection`/`with_fetch`/`repartitioned` returned
+//!    inner subtrees that do not contain the wrapper.
+//! 2. `ExtractLeafExpressions` (`__datafusion_extracted_N` aliasing) must be
+//!    disabled: its aliases drift between logical and physical planning of
+//!    user-defined extension nodes ("Extension planner for Wrapper ... created
+//!    an ExecutionPlan with mismatched schema"), and its extraction columns
+//!    leak into sinks (Arrow column-count mismatch, `Schema::field`
+//!    out-of-bounds panic).
+
+use std::sync::Arc;
+
+use arrow_schema::{DataType, Field, Schema};
+use datafusion::common::config::ConfigOptions;
+use datafusion::physical_expr::expressions::col;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_optimizer::projection_pushdown::ProjectionPushdown;
+use datafusion::physical_plan::empty::EmptyExec;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::{ExecutionPlan, displayable};
+
+use streamling_core::dynamic_table::DynamicTableRegistry;
+use streamling_core::operators::wrapping::WrappingExec;
+use streamling_core::session::SessionManager;
+
+#[test]
+fn projection_pushdown_must_not_elide_wrapping_exec() {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int64, false),
+        Field::new("b", DataType::Utf8, false),
+    ]));
+    let source = Arc::new(EmptyExec::new(schema.clone()));
+    let inner_proj = Arc::new(
+        ProjectionExec::try_new(
+            vec![
+                (col("a", &schema).unwrap(), "a".to_string()),
+                (col("b", &schema).unwrap(), "b".to_string()),
+            ],
+            source,
+        )
+        .unwrap(),
+    );
+    let wrapped: Arc<dyn ExecutionPlan> = Arc::new(WrappingExec::new(
+        inner_proj,
+        "source_1".to_string(),
+        vec![],
+        vec![],
+        None,
+    ));
+    let plan: Arc<dyn ExecutionPlan> = Arc::new(
+        ProjectionExec::try_new(
+            vec![(col("a", &wrapped.schema()).unwrap(), "a".to_string())],
+            wrapped,
+        )
+        .unwrap(),
+    );
+
+    let before = displayable(plan.as_ref()).indent(true).to_string();
+    let optimized = ProjectionPushdown::new()
+        .optimize(plan, &ConfigOptions::default())
+        .expect("ProjectionPushdown failed");
+    let after = displayable(optimized.as_ref()).indent(true).to_string();
+
+    // WrappingExec displays as its inner node (delegated DisplayAs), so probe
+    // the tree structurally instead of by name: the projection's child must
+    // still be the wrapper (schema adjusted by WrappingExec), and the plan
+    // must not have collapsed to projection-over-source.
+    fn contains_wrapping(plan: &Arc<dyn ExecutionPlan>) -> bool {
+        plan.downcast_ref::<WrappingExec>().is_some()
+            || plan.children().iter().any(|c| contains_wrapping(c))
+    }
+    assert!(
+        contains_wrapping(&optimized),
+        "WrappingExec was ELIDED by ProjectionPushdown under df54!\n\
+         === BEFORE ===\n{before}\n=== AFTER ===\n{after}"
+    );
+}
+
+#[test]
+fn leaf_expression_extraction_is_disabled() {
+    let sm = SessionManager::new(8192, 10, DynamicTableRegistry::new()).unwrap();
+    let state = sm.session_state();
+    assert!(
+        !state
+            .config_options()
+            .optimizer
+            .enable_leaf_expression_pushdown,
+        "ExtractLeafExpressions must stay disabled: its __datafusion_extracted_N \
+         aliases are not stable across re-optimization of plans containing \
+         user-defined extension nodes (Wrapper/Rebatch/MultiSink), which makes \
+         physical planning fail with a schema mismatch and leaks extraction \
+         columns into sinks"
+    );
+}


### PR DESCRIPTION
Two fixes for regressions introduced by the DataFusion 49 → 54 upgrade (#22). Companion to #50, which fixed the same optimizer-elision hazard on `RebatchExec`.

## 1. Disable `datafusion.optimizer.enable_leaf_expression_pushdown`

DataFusion 54 introduced `ExtractLeafExpressions`, which pulls struct/map field accesses into extraction projections aliased `__datafusion_extracted_N`, with recovery projections meant to hide the extra columns again. Our user-defined extension nodes (Wrapper/Rebatch/MultiSink) capture their schema at construction, and the rule's alias counter is not stable across re-optimization. With the rule enabled, plans containing such nodes fail in three ways:

- **Physical planning error**: `Extension planner for Wrapper id: … created an ExecutionPlan with mismatched schema` — the logical schema carries one set of extracted names (`__datafusion_extracted_1..3`), physical planning regenerates different ones (`_6/_17/_18`). Hits any plan that wraps a decode transform or dataset-source node with field extraction.
- **Sink schema mismatch**: extraction columns leak past the recovery projection into sinks — `Arrow error: number of columns(N+1) must match number of fields(N)` when building the sink batch. Intermittent (fires when a leaking batch reaches the sink), so it can survive readiness checks.
- **Panic**: `arrow-schema` `Schema::field` index out of bounds — the same leaked phantom column reaching an unchecked index path.

Disabling the rule (it is config-gated upstream) restores pre-54 planning semantics for streaming plans built around extension nodes. If the extraction optimization is ever wanted here, extension-node schema capture needs to become alias-stable first.

## 2. Stop delegating optimizer-negotiation hooks on `WrappingExec`

`try_swapping_with_projection`, `with_fetch`, `repartitioned`, and `supports_limit_pushdown` were `delegate!`d to `self.inner`. Each returns a rewritten subtree that does not contain the wrapper, so DataFusion 54's hook-driven optimizer rules could replace the wrapper with the returned plan — silently deleting the telemetry instrumentation (`output_rows`), side-output processing, and live inspection this node provides. Same hazard class as #50, demonstrated by the new test (fails on the old code). `children()`/`metrics()` delegation is deliberately untouched: it preserves the existing transparent-fusion design and `execute()`-side telemetry, and carries no plan-rewriting risk.

## Testing

- `tests/df54_regressions.rs`: both tests fail without the fixes, pass with them (verified by stash/restore).
- `cargo test -p streamling-core`: 381 + 2 passed; fmt/clippy clean; `streamling`/`streamling-connectors` compile.

## Known df54 issue deliberately NOT in this PR

A source-level `filter:` referencing a column absent from the scan schema is now a fatal startup error (`invalid filter for source … Schema error: No field named …`) where DataFusion 49 tolerated it. Needs a dedicated repro to decide tolerate-vs-reject — the filter may be genuinely wrong and worth surfacing, just not as a crash loop.