### PR TITLE
fix: plan source filters against the full payload schema, not the projected scan schema

### DIFF
--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -30,6 +30,7 @@ use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::Result;
 use datafusion::execution::TaskContext;
 use datafusion::logical_expr::Expr;
+use datafusion::physical_expr::expressions::col as physical_col;
 use datafusion::physical_expr::{EquivalenceProperties, PhysicalExpr};
 use datafusion::physical_plan::stream::RecordBatchReceiverStreamBuilder;
 use datafusion::physical_plan::{
@@ -38,6 +39,7 @@ use datafusion::physical_plan::{
     execution_plan::{Boundedness, EmissionType},
     filter::FilterExec,
     project_schema,
+    projection::ProjectionExec,
 };
 use streamling_core::formats::avro::{
     AvroToArrowConverter, FromArrowToAvroConverter, convert_avro_schema_to_arrow,
@@ -46,6 +48,7 @@ use streamling_core::formats::avro::{
 use streamling_core::formats::json::{FromArrowToJsonConverter, JsonToArrowConverter};
 use streamling_core::formats::{FromArrowConverter, ToArrowConverter};
 use streamling_core::operators::filter::StreamingFilterExec;
+use streamling_core::operators::projection::StreamingProjectionExec;
 use streamling_core::schema::arrow_schema_from_type_map;
 use streamling_core::session::SessionManager;
 use streamling_core::topology::SchemaIdOverride;
@@ -1887,9 +1890,15 @@ impl KafkaSourceTableProvider {
         include_metadata: bool,
         state_backend: Arc<dyn StateOperatorBackend<TopicPartitionOffset>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        // The topology-level source `filter:` is defined against the source's
+        // full payload schema. A scan projection pushed down by the engine may
+        // prune columns the filter references, so when a filter is present the
+        // source is built UNPROJECTED, the filter planned against the full
+        // schema, and the projection re-applied on top of the filter.
+        let exec_projections = if filter.is_some() { None } else { projections };
         let kafka_source_exec = Arc::new(KafkaSourceExec::new(
             reference_name.clone(),
-            projections,
+            exec_projections,
             full_schema,
             payload_schema,
             config,
@@ -1909,17 +1918,39 @@ impl KafkaSourceTableProvider {
         ));
 
         if let Some(filter_expr) = &filter {
+            let unprojected_schema = kafka_source_exec.schema();
             let filter_predicate = Self::prepare_filter_expression(
                 filter_expr,
-                &kafka_source_exec.schema(),
+                &unprojected_schema,
                 &self.session_manager,
             )
             .streamling_with_context(|| format!("invalid filter for source '{reference_name}'"))?;
             // Use StreamingFilterExec to preserve batch metadata (including checkpoint markers)
             let original_filter = FilterExec::try_new(filter_predicate, kafka_source_exec)?;
-            Ok(Arc::new(StreamingFilterExec::from_original(
-                original_filter,
-            )?))
+            let filtered: Arc<dyn ExecutionPlan> =
+                Arc::new(StreamingFilterExec::from_original(original_filter)?);
+            match projections {
+                Some(indices) => {
+                    // Re-apply the pushed-down projection above the filter so the
+                    // scan still returns the projected schema. StreamingProjectionExec
+                    // preserves batch metadata (checkpoint markers), like the filter.
+                    let exprs = indices
+                        .iter()
+                        .map(|&i| {
+                            let field = unprojected_schema.field(i);
+                            Ok((
+                                physical_col(field.name(), &unprojected_schema)?,
+                                field.name().clone(),
+                            ))
+                        })
+                        .collect::<Result<Vec<_>>>()?;
+                    let projection = ProjectionExec::try_new(exprs, filtered)?;
+                    Ok(Arc::new(StreamingProjectionExec::from_original(
+                        projection,
+                    )?))
+                }
+                None => Ok(filtered),
+            }
         } else {
             Ok(kafka_source_exec)
         }
@@ -2842,6 +2873,69 @@ impl TableProvider for KafkaSinkTableProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A topology-level source `filter:` is defined against the source's full
+    /// payload schema. When the engine pushes a scan projection that prunes a
+    /// column the filter references, the filter must still plan against the
+    /// full schema (and the projection applied afterwards) — otherwise a
+    /// perfectly valid filter becomes a fatal "invalid filter for source"
+    /// error at startup.
+    #[tokio::test]
+    async fn source_filter_survives_scan_projection_pushdown() {
+        use datafusion::catalog::TableProvider;
+        use streamling_core::dynamic_table::DynamicTableRegistry;
+        use streamling_state::StateOperatorBackendFactory;
+        use streamling_state::in_memory::InMemoryStateOperatorBackendFactory;
+
+        let session_manager = SessionManager::new(8192, 10, DynamicTableRegistry::new()).unwrap();
+        let state_backend = InMemoryStateOperatorBackendFactory::new()
+            .unwrap()
+            .create::<TopicPartitionOffset>("test-kafka-filter");
+
+        let mut json_schema = BTreeMap::new();
+        json_schema.insert("a".to_string(), "string".to_string());
+        json_schema.insert("b".to_string(), "int64".to_string());
+        json_schema.insert("c".to_string(), "string".to_string());
+
+        let provider = KafkaSourceTableProvider::new(
+            "src".to_string(),
+            "src-metrics".to_string(),
+            test_kafka_config(),
+            "test-topic".to_string(),
+            None,
+            Some("c = 'x'".to_string()),
+            1000,
+            10,
+            10,
+            false,
+            state_backend,
+            session_manager.clone(),
+            None,
+            false,
+            vec![],
+            true,
+            vec![],
+            KafkaFormat::Json,
+            Some(json_schema),
+        )
+        .unwrap();
+
+        // The engine pushes a projection that keeps only column `a` (index 0)
+        // — pruning `c`, which the source filter references.
+        let state = session_manager.session_state();
+        let plan = provider
+            .scan(&state, Some(&vec![0]), &[], None)
+            .await
+            .expect(
+                "source filter must plan against the full payload schema, \
+                 not the projected scan schema",
+            );
+
+        // The scan contract still holds: output schema is the projected one.
+        let schema = plan.schema();
+        let fields: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(fields, vec!["a"], "scan must project to the pushed columns");
+    }
 
     #[test]
     fn json_payload_to_string_rejects_empty_payload() {

--- a/crates/streamling-core/src/operators/wrapping.rs
+++ b/crates/streamling-core/src/operators/wrapping.rs
@@ -3,6 +3,7 @@ use crate::checkpoints::checkpoint_management::{
 };
 use crate::operators::filter::StreamingFilterExec;
 use crate::operators::inspect::LiveDataInspect;
+use crate::operators::projection::StreamingProjectionExec;
 use crate::operators::scan_sharing::{BroadcastingExec, SharedSourceHandle, SharedSourceRegistry};
 use crate::session::{get_streamling_config, get_streamling_config_from_session};
 use crate::side_output::{SourceSideOutput, SupportsSideOutputs};
@@ -236,6 +237,43 @@ impl WrappingSourceTableProvider {
         side_outputs: Vec<Arc<dyn SourceSideOutput>>,
         event_time_instrumentation: Option<EventTimeInstrumentation>,
     ) -> Arc<dyn ExecutionPlan> {
+        // A pushed-down scan projection may sit above the source filter (the
+        // filter plans against the full payload schema and the projection is
+        // re-applied above it — see the Kafka source). See through the
+        // projection so the wrapper still lands below the filter, then
+        // rebuild the filter and projection on top (R7: side outputs and
+        // event-time freshness must observe the pre-filter row stream).
+        if let Some(projection_exec) = inner_exec.downcast_ref::<StreamingProjectionExec>()
+            && let Some(filter_exec) = projection_exec
+                .input()
+                .downcast_ref::<StreamingFilterExec>()
+        {
+            let source_exec = filter_exec.input().clone();
+            let wrapped_source: Arc<dyn ExecutionPlan> = Arc::new(WrappingExec::new(
+                source_exec,
+                reference_name.to_string(),
+                side_outputs.clone(),
+                Vec::new(),
+                event_time_instrumentation.clone(),
+            ));
+            let rebuilt = Arc::new(filter_exec.clone())
+                .with_new_children(vec![wrapped_source])
+                .and_then(|new_filter| {
+                    Arc::new(projection_exec.clone()).with_new_children(vec![new_filter])
+                });
+            match rebuilt {
+                Ok(plan) => return plan,
+                Err(e) => {
+                    warn!(
+                        "Failed to rebuild projection+filter around WrappingExec for '{}': {}. \
+                         Falling back to wrapping the projected plan.",
+                        reference_name, e
+                    );
+                    // fall through to the default wrap below
+                }
+            }
+        }
+
         if let Some(filter_exec) = inner_exec.downcast_ref::<StreamingFilterExec>() {
             let source_exec = filter_exec.input().clone();
             let wrapped_source: Arc<dyn ExecutionPlan> = Arc::new(WrappingExec::new(
@@ -1054,6 +1092,73 @@ mod tests {
             ],
         )
         .unwrap()
+    }
+
+    #[test]
+    fn test_wrap_with_side_outputs_sees_through_scan_projection() {
+        use crate::operators::projection::StreamingProjectionExec;
+        use datafusion::physical_plan::projection::ProjectionExec;
+
+        let schema = test_schema();
+        let mem_table = MemTable::try_new(schema.clone(), vec![vec![test_batch()]]).unwrap();
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+
+        let source_exec =
+            futures::executor::block_on(mem_table.scan(&state, None, &[], None)).unwrap();
+
+        let predicate: Arc<dyn datafusion::physical_expr::PhysicalExpr> =
+            Arc::new(Column::new("active", 2));
+        let filter = FilterExec::try_new(predicate, source_exec.clone()).unwrap();
+        let streaming_filter =
+            Arc::new(StreamingFilterExec::from_original(filter).unwrap()) as Arc<dyn ExecutionPlan>;
+
+        // Scan projection re-applied above the source filter (as the Kafka
+        // source does when the engine pushes a projection down).
+        let first_col = schema.field(0).name().clone();
+        let col_expr: Arc<dyn datafusion::physical_expr::PhysicalExpr> =
+            Arc::new(Column::new(&first_col, 0));
+        let projection =
+            ProjectionExec::try_new(vec![(col_expr, first_col)], streaming_filter).unwrap();
+        let streaming_projection =
+            Arc::new(StreamingProjectionExec::from_original(projection).unwrap())
+                as Arc<dyn ExecutionPlan>;
+
+        let rows_seen = Arc::new(AtomicUsize::new(0));
+        let side_output = Arc::new(CountingSideOutput {
+            rows_seen: rows_seen.clone(),
+        });
+
+        let result = WrappingSourceTableProvider::wrap_with_side_outputs_before_filter(
+            streaming_projection,
+            "test_source",
+            vec![side_output],
+            None,
+        );
+
+        // Order must be projection -> filter -> wrapper -> source, so side
+        // outputs / event-time observe every pre-filter row (R7).
+        assert!(
+            result.downcast_ref::<StreamingProjectionExec>().is_some(),
+            "Expected top-level plan to be StreamingProjectionExec, got: {}",
+            result.name()
+        );
+        let proj_children = result.children();
+        assert_eq!(proj_children.len(), 1);
+        assert!(
+            proj_children[0]
+                .downcast_ref::<StreamingFilterExec>()
+                .is_some(),
+            "Expected projection's child to be StreamingFilterExec, got: {}",
+            proj_children[0].name()
+        );
+        let filter_children = proj_children[0].children();
+        assert_eq!(filter_children.len(), 1);
+        assert!(
+            filter_children[0].downcast_ref::<WrappingExec>().is_some(),
+            "Expected filter's child to be WrappingExec, got: {}",
+            filter_children[0].name()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Third fix for the DataFusion 49 → 54 upgrade regressions (companions: #50, #51).

## Problem

A topology-level source `filter:` is defined against the source's **full payload schema**. Under DataFusion 54, scan projections get pushed through the surrounding extension nodes down to the Kafka source (they didn't under 49) — and a filter column is *typically not selected downstream*, since filtering is the only reason it's read. The source then prepared the filter against the already-projected exec schema and died at startup:

```
invalid filter for source '…'
Caused by: Schema error: No field named <col>. Valid fields are <projected columns…>
```

A perfectly valid filter becomes a fatal, crash-looping planning error, and the "Valid fields" list is misleading — it shows the projected schema, not the topic's schema, which makes the error look like a schema-evolution problem when it isn't.

## Fix

When a filter is present, build the source **unprojected**, plan the filter against the full schema, then re-apply the pushed projection above the filter. `StreamingProjectionExec` is used for the re-projection so batch metadata (checkpoint markers) survives, matching the existing `StreamingFilterExec`. The scan contract is preserved — output schema is still the projected one — and the no-filter fast path is unchanged.

Row cost is the same as pre-54 behavior: the filter needs those columns decoded anyway, and the projection still prunes immediately above it.

## Testing

- New unit test `source_filter_survives_scan_projection_pushdown`: reproduces the exact failure (filter referencing a projection-pruned column → "No field named c. Valid fields are a."), passes with the fix, and asserts the scan still returns the projected schema.
- `cargo test -p streamling-connectors`: 284 passed. fmt/clippy clean; `streamling` compiles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Kafka source physical planning and wrapper plan reordering on the hot path; behavior change is intentional for DF54 projection pushdown but could affect lag/event-time ordering if rebuild fails and falls back.
> 
> **Overview**
> Fixes a **DataFusion 54** regression where pushed scan projections could prune columns referenced by topology `filter:` on Kafka sources, causing fatal startup planning errors (`No field named …`).
> 
> **Kafka source planning** now builds the exec **without** the pushed projection when a source filter exists, compiles the filter against the **full** schema, then re-applies the engine’s column projection above the filter via **`StreamingProjectionExec`** (checkpoint metadata preserved, same pattern as **`StreamingFilterExec`**). Scan output schema stays projected; the no-filter path is unchanged.
> 
> **`WrappingSourceTableProvider`** peels **`StreamingProjectionExec` → `StreamingFilterExec`** so **`WrappingExec`** (side outputs, event-time) still sits **below** the filter, then rebuilds filter + projection on top.
> 
> Adds unit tests for projection+filter planning and wrapper reordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d93433b17a9cf5288e2175e5cd193243a7954b84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->