### PR TITLE
fix: make the live table schema authoritative for ClickHouse sink writes

### DIFF
--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -2242,8 +2242,7 @@ impl ClickHouseClient {
                 "ClickHouse returned an error body while listing columns of '{}': {}",
                 table_name,
                 body.lines().next().unwrap_or_default()
-            )
-            .into());
+            ));
         }
         Ok(body
             .lines()

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -969,6 +969,18 @@ impl DataSink for ClickHouseSinkExec {
         // ClickHouse and every INSERT naming them fails. `_gs_op` is kept —
         // the CDC split below needs it, and it is stripped before INSERT.
         let normalized_schema = match client.fetch_table_column_names(&self.table_name).await {
+            // An empty listing right after CREATE TABLE IF NOT EXISTS succeeded
+            // means the lookup is unreliable (database/name resolution mismatch,
+            // system.columns lag) — treat it like a failed fetch rather than
+            // dropping every column and issuing empty INSERTs.
+            Ok(live_columns) if live_columns.is_empty() => {
+                warn!(
+                    "[{}] ClickHouse column listing for table '{}' came back empty; \
+                     writing with the sink's declared schema",
+                    node_label, self.table_name
+                );
+                self.schema.clone()
+            }
             Ok(live_columns) => {
                 let live: std::collections::HashSet<&str> =
                     live_columns.iter().map(|s| s.as_str()).collect();
@@ -2221,7 +2233,19 @@ impl ClickHouseClient {
         let bytes = self
             .process_http_response(response_result, &query, "table columns")
             .await?;
-        Ok(String::from_utf8_lossy(&bytes)
+        let body = String::from_utf8_lossy(&bytes);
+        // ClickHouse can return HTTP 200 with an exception in the body (the
+        // same quirk check_ddl_response guards against); parsing those lines
+        // as column names would drop every real column downstream.
+        if CLICKHOUSE_ERROR_RE.is_match(&body) {
+            return Err(streamling_core::streamling_err!(
+                "ClickHouse returned an error body while listing columns of '{}': {}",
+                table_name,
+                body.lines().next().unwrap_or_default()
+            )
+            .into());
+        }
+        Ok(body
             .lines()
             .map(|l| l.trim().to_string())
             .filter(|l| !l.is_empty())
@@ -2433,17 +2457,29 @@ impl ClickHouseClient {
 
         let original_schema = batch.schema();
 
-        let extra_columns: Vec<&str> = original_schema
+        // Single O(n) pass to index the incoming columns by name; per-field
+        // `index_of` would make this O(n^2) on every batch.
+        let index_by_name: std::collections::HashMap<&str, usize> = original_schema
             .fields()
             .iter()
-            .map(|f| f.name().as_str())
-            .filter(|name| normalized_schema.field_with_name(name).is_err())
+            .enumerate()
+            .map(|(i, f)| (f.name().as_str(), i))
             .collect();
-        if !extra_columns.is_empty() {
+
+        if index_by_name.len() < original_schema.fields().len() {
             tracing::debug!(
-                "dropping {} column(s) not present in the ClickHouse sink schema: {:?}",
-                extra_columns.len(),
-                extra_columns
+                "incoming batch has duplicate column names; later occurrences win \
+                 ({} unique of {} columns)",
+                index_by_name.len(),
+                original_schema.fields().len()
+            );
+        }
+        if original_schema.fields().len() > normalized_schema.fields().len() {
+            tracing::debug!(
+                "batch is wider than the ClickHouse sink schema ({} vs {} columns); \
+                 extra columns are dropped",
+                original_schema.fields().len(),
+                normalized_schema.fields().len()
             );
         }
 
@@ -2451,9 +2487,9 @@ impl ClickHouseClient {
             .fields()
             .iter()
             .map(|normalized_field| {
-                let idx = original_schema
-                    .index_of(normalized_field.name())
-                    .map_err(|_| {
+                let idx = *index_by_name
+                    .get(normalized_field.name().as_str())
+                    .ok_or_else(|| {
                         DataFusionError::from(streamling_core::streamling_err!(
                             "ClickHouse sink schema column '{}' missing from the incoming batch",
                             normalized_field.name()

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -963,7 +963,45 @@ impl DataSink for ClickHouseSinkExec {
         let client = self.client.clone();
         let table_name = self.table_name.clone();
         let num_records_before_stop = self.num_records_before_stop;
-        let normalized_schema = self.schema.clone();
+        // Adopt the LIVE table's column set for writes. The input schema can
+        // be wider than a pre-existing table (e.g. an upstream `SELECT *`
+        // widened after the table was created); those columns don't exist in
+        // ClickHouse and every INSERT naming them fails. `_gs_op` is kept —
+        // the CDC split below needs it, and it is stripped before INSERT.
+        let normalized_schema = match client.fetch_table_column_names(&self.table_name).await {
+            Ok(live_columns) => {
+                let live: std::collections::HashSet<&str> =
+                    live_columns.iter().map(|s| s.as_str()).collect();
+                let (kept, dropped): (Vec<_>, Vec<_>) =
+                    self.schema.fields().iter().cloned().partition(|f| {
+                        live.contains(f.name().as_str()) || f.name() == COLUMN_NAME_OP
+                    });
+                if !dropped.is_empty() {
+                    warn!(
+                        "[{}] dropping {} column(s) not present in ClickHouse table '{}': {:?}",
+                        node_label,
+                        dropped.len(),
+                        self.table_name,
+                        dropped
+                            .iter()
+                            .map(|f| f.name().as_str())
+                            .collect::<Vec<_>>()
+                    );
+                }
+                Arc::new(arrow::datatypes::Schema::new_with_metadata(
+                    kept,
+                    self.schema.metadata().clone(),
+                ))
+            }
+            Err(e) => {
+                warn!(
+                    "[{}] could not list columns of ClickHouse table '{}' ({}); \
+                     writing with the sink's declared schema",
+                    node_label, self.table_name, e
+                );
+                self.schema.clone()
+            }
+        };
         let primary_keys = self.primary_keys.clone();
         let parallelism = self.parallelism.max(1);
         let write_batch_size = self.write_batch_size;
@@ -2162,6 +2200,34 @@ impl ClickHouseClient {
         })
     }
 
+    /// List the column names of a live table from `system.columns`.
+    /// Async (unlike `fetch_schema`, which uses `block_on` internally and
+    /// must not be called from async contexts like `write_all`).
+    pub async fn fetch_table_column_names(
+        &self,
+        table_name: &str,
+    ) -> streamling_core::error::Result<Vec<String>> {
+        let (database_expr, bare_table) = match table_name.split_once('.') {
+            Some((db, tbl)) => (format!("'{}'", db.replace('\'', "''")), tbl),
+            None => ("currentDatabase()".to_string(), table_name),
+        };
+        let query = format!(
+            "SELECT name FROM system.columns WHERE database = {} AND table = '{}' \
+             ORDER BY position FORMAT TabSeparated",
+            database_expr,
+            bare_table.replace('\'', "''")
+        );
+        let response_result = self.send_query(reqwest::Method::GET, &query).await;
+        let bytes = self
+            .process_http_response(response_result, &query, "table columns")
+            .await?;
+        Ok(String::from_utf8_lossy(&bytes)
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect())
+    }
+
     pub fn fetch_schema(
         &self,
         table_name: &str,
@@ -2348,6 +2414,16 @@ impl ClickHouseClient {
 
     /// Convert a RecordBatch to use the provided normalized schema
     /// TODO: Move this to a projection expr instead so it can be folded?
+    /// Columns are paired against `normalized_schema` **by name**, mirroring
+    /// `normalize_batch_from_clickhouse`. The incoming batch may carry more
+    /// columns than the sink's table — e.g. an upstream `SELECT *` widened
+    /// after the table was created — and those extras are dropped (the table
+    /// schema is authoritative for writes). A sink column missing from the
+    /// batch is an error. The previous positional triple-zip built the output
+    /// batch with every incoming column, so a wider batch failed
+    /// `RecordBatch::try_new` with "number of columns(N+1) must match number
+    /// of fields(N)", and a same-width-but-reordered batch would silently
+    /// mislabel columns.
     fn normalize_batch_for_clickhouse(
         batch: &RecordBatch,
         normalized_schema: &SchemaRef,
@@ -2357,12 +2433,34 @@ impl ClickHouseClient {
 
         let original_schema = batch.schema();
 
-        let normalized_columns: Result<Vec<_>, DataFusionError> = batch
-            .columns()
+        let extra_columns: Vec<&str> = original_schema
+            .fields()
             .iter()
-            .zip(original_schema.fields().iter())
-            .zip(normalized_schema.fields().iter())
-            .map(|((column, original_field), normalized_field)| {
+            .map(|f| f.name().as_str())
+            .filter(|name| normalized_schema.field_with_name(name).is_err())
+            .collect();
+        if !extra_columns.is_empty() {
+            tracing::debug!(
+                "dropping {} column(s) not present in the ClickHouse sink schema: {:?}",
+                extra_columns.len(),
+                extra_columns
+            );
+        }
+
+        let normalized_columns: Result<Vec<_>, DataFusionError> = normalized_schema
+            .fields()
+            .iter()
+            .map(|normalized_field| {
+                let idx = original_schema
+                    .index_of(normalized_field.name())
+                    .map_err(|_| {
+                        DataFusionError::from(streamling_core::streamling_err!(
+                            "ClickHouse sink schema column '{}' missing from the incoming batch",
+                            normalized_field.name()
+                        ))
+                    })?;
+                let column = &batch.columns()[idx];
+                let original_field = &original_schema.fields()[idx];
                 match (original_field.data_type(), normalized_field.data_type()) {
                     (DataType::Utf8View, DataType::Utf8) => {
                         Ok(cast(column.as_ref(), &DataType::Utf8)

--- a/crates/streamling-e2e/tests/clickhouse_sink.rs
+++ b/crates/streamling-e2e/tests/clickhouse_sink.rs
@@ -1046,4 +1046,27 @@ sinks:
         .await
         .expect("Failed to query count");
     assert_eq!(count, total_records as u64, "all rows written");
+
+    // Value-level check: by-name pairing must not mislabel the surviving
+    // columns when the extra one is dropped.
+    #[derive(Row, Deserialize)]
+    struct OutRow {
+        id: i64,
+        value: String,
+    }
+    let rows: Vec<OutRow> = clickhouse
+        .query("SELECT id, value FROM select_except_readd_test FINAL ORDER BY id")
+        .await
+        .expect("Failed to query rows");
+    let got: Vec<(i64, &str)> = rows.iter().map(|r| (r.id, r.value.as_str())).collect();
+    assert_eq!(
+        got,
+        vec![
+            (1, "value_1"),
+            (2, "value_2"),
+            (3, "value_3"),
+            (4, "value_4")
+        ],
+        "surviving columns must keep their own data"
+    );
 }

--- a/crates/streamling-e2e/tests/clickhouse_sink.rs
+++ b/crates/streamling-e2e/tests/clickhouse_sink.rs
@@ -945,3 +945,105 @@ sinks:
         "id=1 should have the updated value"
     );
 }
+
+// =============================================================================
+// SELECT * EXCEPT with same-name re-add
+// =============================================================================
+
+/// `SELECT * EXCEPT (col, _gs_op), <expr> AS col2, <expr> AS _gs_op` — the
+/// wildcard excludes a source column and the enriched `_gs_op`, then re-adds
+/// computed columns, one under the same name. The sink batch must match the
+/// transform's declared schema (no duplicated/leftover columns).
+#[tokio::test]
+async fn test_select_except_same_name_readd() {
+    init_tracing();
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+
+    let clickhouse = ctx
+        .clickhouse
+        .as_ref()
+        .expect("ClickHouse should be enabled");
+
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+
+    // Pre-create the sink table WITHOUT the `ts` column: the upstream `*`
+    // has widened since the table was created (source schema evolution), so
+    // the transform now emits one more column than the table has. The write
+    // path must tolerate extra batch columns (project to the table schema),
+    // as it did before the DataFusion 54 upgrade.
+    clickhouse
+        .execute(
+            "CREATE TABLE select_except_readd_test (\
+                 id Int64, value String, is_deleted UInt8 DEFAULT 0, \
+                 insert_time DateTime DEFAULT now() \
+             ) ENGINE = ReplacingMergeTree(insert_time) ORDER BY id",
+        )
+        .await
+        .expect("Failed to pre-create sink table");
+
+    let total_records = 4;
+    let records: Vec<TestRecord> = (1..=total_records)
+        .map(|i| TestRecord {
+            id: i,
+            value: format!("value_{}", i),
+            timestamp: 1000 + i,
+        })
+        .collect();
+
+    ctx.kafka
+        .produce_avro_records_with_op(&records, "c")
+        .await
+        .expect("Failed to produce records");
+
+    let pipeline = format!(
+        r#"
+sources:
+  kafka_source:
+    type: kafka
+    topic: {topic}
+    starting_offsets: earliest
+    primary_key: id
+
+transforms:
+  except_transform:
+    type: sql
+    primary_key: id
+    sql: >-
+      SELECT * EXCEPT (timestamp, _gs_op), timestamp AS ts,
+      CASE WHEN _gs_op = 'c' THEN 'i' ELSE _gs_op END AS _gs_op
+      FROM kafka_source
+
+sinks:
+  ch_sink:
+    type: clickhouse
+    from: except_transform
+    table: select_except_readd_test
+    primary_key: id
+"#,
+        topic = ctx.kafka_topic,
+    );
+
+    let mut opts = PipelineOpts::new().record_limit(total_records as u64);
+    for (k, v) in clickhouse_env(&ctx) {
+        opts = opts.env(&k, &v);
+    }
+
+    let status = ctx
+        .run_pipeline_with_opts(&pipeline, opts)
+        .await
+        .expect("Streamling execution failed");
+
+    assert!(status.success(), "Streamling should exit successfully");
+
+    let count = clickhouse
+        .count("SELECT COUNT(*) FROM select_except_readd_test FINAL")
+        .await
+        .expect("Failed to query count");
+    assert_eq!(count, total_records as u64, "all rows written");
+}


### PR DESCRIPTION
Fifth fix in the DataFusion-54 hardening series (#50–#53).

## Problem

The ClickHouse sink's write schema follows the pipeline's **input**, not the **table**. When the upstream schema is wider than a pre-existing table — e.g. a `SELECT *` transform over a source whose resolved schema has more columns than the table had at creation time — every write fails. Depending on the width difference it surfaces as:

- `Arrow error: number of columns(N+1) must match number of fields(N)` — `normalize_batch_for_clickhouse` paired columns **positionally** via a triple-zip and rebuilt the batch with every incoming column; or
- `NO_SUCH_COLUMN_IN_TABLE` from ClickHouse on the INSERT, retried forever — a wedged pipeline that still reports healthy liveness.

The positional zip also silently truncates when widths diverge the other way, which can **mislabel columns** — arguably worse than the crash.

## Fix

1. `write_all` fetches the live table's columns (new async `fetch_table_column_names`; the existing `fetch_schema` uses `block_on` and can't be called from async) and filters the write schema to real table columns, warning with the dropped names — the warning also serves as the diagnostic for *why* a batch was wider. `_gs_op` is kept for the CDC split and stripped before INSERT, as before. On listing failure, previous behavior is preserved.
2. `normalize_batch_for_clickhouse` pairs columns **by name** against the sink schema, mirroring the read-side `normalize_batch_from_clickhouse` (which was already fixed this way).

## Testing

- New e2e test `test_select_except_same_name_readd`: pre-creates the sink table narrower than the pipeline's output; on main it wedges (INSERT retries until the run times out), with the fix it passes (extra column dropped + warned, rows written, dedup semantics intact).
- `cargo test -p streamling-connectors`: 109 passed; core suite green; fmt/clippy clean.
- Full local e2e blocked by an environment issue in an unrelated Postgres/metrics test (fails identically on a pre-change build); relying on CI for the full suite.

## Follow-up

The Postgres sink write path deserves the same live-table-schema audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core ClickHouse sink write and batch normalization on every INSERT; mitigated by fallbacks on column-list failure and an e2e regression for schema-wider-than-table cases.
> 
> **Overview**
> Fixes ClickHouse sink failures when the pipeline schema is **wider** than an existing table (e.g. upstream `SELECT *` after schema evolution): writes now follow the **live table**, not the declared input schema.
> 
> In **`write_all`**, after `CREATE TABLE IF NOT EXISTS`, the sink loads column names via new async **`fetch_table_column_names`** (`system.columns`, with error-body detection like DDL). The write schema is filtered to columns that exist in ClickHouse (keeping **`_gs_op`** for CDC); extras are **warned and dropped**. Empty listings or fetch errors fall back to the previous declared schema so writes do not wedge on empty INSERTs.
> 
> **`normalize_batch_for_clickhouse`** now maps columns **by name** to the sink schema (matching read-side **`normalize_batch_from_clickhouse`**): extra batch columns are dropped, missing sink columns error, and reordered batches no longer mislabel data. The old positional zip caused Arrow column-count mismatches or silent wrong-column INSERTs.
> 
> Adds e2e **`test_select_except_same_name_readd`**: narrower pre-created table, `SELECT * EXCEPT` + re-added `_gs_op`, verifies rows land with correct `id`/`value`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ffbac2dc947f75565547451af04722dc86b3bba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->