### PR TITLE
fix: forward checkpoint markers through unnest without waiting for data

### DIFF
--- a/crates/streamling-core/src/operators/unnest.rs
+++ b/crates/streamling-core/src/operators/unnest.rs
@@ -202,7 +202,6 @@ impl ExecutionPlan for StreamingUnnestExec {
             options: self.options.clone(),
             metrics,
             resolved_schema: None,
-            pending_checkpoints: Vec::new(),
         }))
     }
 
@@ -259,10 +258,6 @@ struct UnnestStream {
     /// type promotion occurred (e.g., Utf8 -> LargeUtf8 via safe_take fallback).
     /// Used to ensure empty batches use consistent types with non-empty batches.
     resolved_schema: Option<SchemaRef>,
-    /// Pending checkpoint messages from early empty batches.
-    /// These are queued until we have a resolved schema to ensure schema consistency.
-    /// They will be emitted with the first non-empty batch or when the stream ends.
-    pending_checkpoints: Vec<CheckpointMessage>,
 }
 
 impl RecordBatchStream for UnnestStream {
@@ -338,49 +333,25 @@ impl UnnestStream {
                     timer.done();
 
                     let result_batch = match result {
-                        Some(mut batch) => {
+                        Some(batch) => {
                             // Track the resolved schema from actual batch processing.
                             // This may have different types than self.schema if type promotion
                             // occurred (e.g., Utf8 -> LargeUtf8 via safe_take fallback).
                             self.resolved_schema = Some(batch.schema());
-
-                            // Merge any pending checkpoints from early empty batches
-                            // into this non-empty batch to ensure they're propagated
-                            if !self.pending_checkpoints.is_empty() {
-                                use std::collections::HashMap as StdHashMap;
-                                let mut all_checkpoints =
-                                    std::mem::take(&mut self.pending_checkpoints);
-                                all_checkpoints.extend(checkpoint_messages.clone());
-                                let mut metadata = StdHashMap::new();
-                                crate::checkpoints::checkpoint_management::enrich_batch_metadata_with_checkpoints(
-                                    &mut metadata,
-                                    &all_checkpoints,
-                                );
-                                // Rebuild batch with merged checkpoint metadata
-                                let enriched_schema = Arc::new(Schema::new_with_metadata(
-                                    batch.schema().fields().clone(),
-                                    metadata,
-                                ));
-                                batch = RecordBatch::try_new(
-                                    enriched_schema,
-                                    batch.columns().to_vec(),
-                                )?;
-                            }
                             batch
                         }
                         None => {
-                            // Empty result - queue checkpoints if schema not yet resolved
+                            // Empty result - forward any checkpoint markers immediately.
+                            // Holding them until a non-empty batch arrives would stall
+                            // checkpointing whenever this operator yields no rows for long
+                            // stretches (e.g. a highly selective upstream filter): the
+                            // checkpoint producer does not start a new epoch until the
+                            // in-flight one resolves, so no later batch would ever arrive
+                            // to flush a held marker. `create_empty_checkpoint_batch`
+                            // falls back to the static plan schema when no batch has
+                            // resolved yet - the same fallback the end-of-stream path uses.
                             if !checkpoint_messages.is_empty() {
-                                if self.resolved_schema.is_none() {
-                                    // Schema not yet resolved - queue checkpoints to avoid
-                                    // emitting empty batch with potentially wrong schema types.
-                                    // These will be emitted with the first non-empty batch or at stream end.
-                                    self.pending_checkpoints.extend(checkpoint_messages);
-                                    continue;
-                                } else {
-                                    // Schema resolved - safe to emit empty batch with correct types
-                                    self.create_empty_checkpoint_batch(&checkpoint_messages)?
-                                }
+                                self.create_empty_checkpoint_batch(&checkpoint_messages)?
                             } else {
                                 // No checkpoint metadata, safe to skip
                                 continue;
@@ -409,15 +380,7 @@ impl UnnestStream {
                         self.metrics.baseline_metrics.output_rows(),
                         self.metrics.baseline_metrics.elapsed_compute(),
                     );
-                    // Stream ended - emit any pending checkpoints as an empty batch
-                    if !self.pending_checkpoints.is_empty() {
-                        let checkpoints = std::mem::take(&mut self.pending_checkpoints);
-                        // Use resolved_schema if available, otherwise fall back to self.schema
-                        // (if no non-empty batch was ever processed, no type promotion occurred)
-                        Some(self.create_empty_checkpoint_batch(&checkpoints))
-                    } else {
-                        None
-                    }
+                    None
                 }
                 Some(Err(e)) => Some(Err(e)),
             });
@@ -1253,7 +1216,6 @@ mod tests {
             options: UnnestOptions::default(),
             metrics,
             resolved_schema: None,
-            pending_checkpoints: Vec::new(),
         };
 
         // Process the stream
@@ -1284,6 +1246,87 @@ mod tests {
             ),
             "Checkpoint message should match"
         );
+
+        Ok(())
+    }
+
+    /// A marker arriving before any non-empty batch must be forwarded
+    /// immediately, not held until a non-empty batch or end of stream: the
+    /// checkpoint producer does not start a new epoch until the in-flight one
+    /// resolves, so on a long-running pipeline whose unnest yields no rows
+    /// (highly selective upstream filter) a held marker would never be
+    /// flushed and checkpointing would stall permanently.
+    #[tokio::test]
+    async fn test_unnest_forwards_marker_immediately_on_open_stream() -> Result<()> {
+        let checkpoint_messages = vec![CheckpointMessage::Marker {
+            epoch: CheckpointEpoch(7),
+            created_at_ms: 1000,
+        }];
+        let mut metadata = HashMap::new();
+        enrich_batch_metadata_with_checkpoints(&mut metadata, &checkpoint_messages);
+
+        let input_fields = Fields::from(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "items",
+                DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
+                false,
+            ),
+        ]);
+        let input_schema = Arc::new(Schema::new_with_metadata(input_fields, metadata));
+
+        // Batch with only empty lists: build_batch returns None, so the only
+        // thing to forward is the checkpoint marker.
+        let mut list_builder = ListBuilder::new(Int32Array::builder(0));
+        list_builder.append_value([]);
+        let empty_list = list_builder.finish();
+        let marker_batch = RecordBatch::try_new(
+            Arc::clone(&input_schema),
+            vec![Arc::new(Int32Array::from(vec![1])), Arc::new(empty_list)],
+        )?;
+
+        let output_fields = Fields::from(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("item", DataType::Int32, true),
+        ]);
+        let output_schema = Arc::new(Schema::new(output_fields));
+
+        // The stream stays open after the marker batch - like a live pipeline.
+        let input_stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&input_schema),
+            stream::iter(vec![Ok(marker_batch)]).chain(stream::pending()),
+        ));
+
+        let metrics = UnnestMetrics::new(0, &ExecutionPlanMetricsSet::new());
+        let mut unnest_stream = UnnestStream {
+            input: input_stream,
+            schema: Arc::clone(&output_schema),
+            list_type_columns: vec![ListUnnest {
+                index_in_input_schema: 1,
+                depth: 1,
+            }],
+            struct_column_indices: HashSet::new(),
+            options: UnnestOptions::default(),
+            metrics,
+            resolved_schema: None,
+        };
+
+        let output_batch =
+            tokio::time::timeout(std::time::Duration::from_secs(5), unnest_stream.next())
+                .await
+                .expect("marker should be forwarded without waiting for more input")
+                .expect("stream should yield a batch")?;
+
+        assert_eq!(output_batch.num_rows(), 0, "Marker batch should be empty");
+        let extracted = extract_checkpoint_messages(output_batch.schema().metadata());
+        assert_eq!(extracted.len(), 1, "Should carry the checkpoint marker");
+        assert!(matches!(
+            &extracted[0],
+            CheckpointMessage::Marker {
+                epoch: CheckpointEpoch(7),
+                ..
+            }
+        ));
 
         Ok(())
     }
@@ -1352,7 +1395,6 @@ mod tests {
             options: UnnestOptions::default(),
             metrics,
             resolved_schema: None,
-            pending_checkpoints: Vec::new(),
         };
 
         // Process the stream
@@ -1468,7 +1510,6 @@ mod tests {
             options: UnnestOptions::default(),
             metrics,
             resolved_schema: None,
-            pending_checkpoints: Vec::new(),
         };
 
         // Process the stream

--- a/crates/streamling-e2e/tests/checkpoint.rs
+++ b/crates/streamling-e2e/tests/checkpoint.rs
@@ -11,6 +11,132 @@ use streamling_e2e::{init_tracing, PipelineOpts, TestContext, TestContextOptions
 // Checkpoint Tests
 // ============================================================================
 
+/// Checkpoints must progress even when an unnest never produces any rows.
+///
+/// This pipeline filters out every source row before an unnest, so the unnest
+/// only ever sees empty marker-carrying batches. Checkpoint markers must flow
+/// through to the sink regardless: the checkpoint producer does not start a
+/// new epoch until the in-flight one resolves, so an operator that holds a
+/// marker while waiting for data deadlocks checkpointing permanently on any
+/// pipeline whose filter matches nothing for a while after startup.
+///
+/// The pipeline never terminates on its own (no record limit is reachable),
+/// so the run is stopped by the harness timeout; the assertion is that
+/// checkpoint state was persisted while it ran.
+#[tokio::test]
+async fn test_checkpoint_progresses_when_unnest_yields_no_rows() {
+    init_tracing();
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+
+    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE unnest_marker_test (
+                id UInt32,
+                name String
+            ) ENGINE = MergeTree()
+            ORDER BY id",
+        )
+        .await
+        .expect("Failed to create ClickHouse table");
+
+    let values: Vec<String> = (0..100).map(|i| format!("({}, 'name_{}')", i, i)).collect();
+    clickhouse
+        .execute(&format!(
+            "INSERT INTO unnest_marker_test (id, name) VALUES {}",
+            values.join(", ")
+        ))
+        .await
+        .expect("Failed to insert ClickHouse data");
+
+    let state_table = format!("unnest_marker_state_{}", ctx.test_id.replace("-", "_"));
+    let application_id = format!("unnest_marker_test_{}", ctx.test_id);
+
+    // The filter matches no rows, so the unnest downstream of it only ever
+    // receives empty batches carrying checkpoint markers.
+    let pipeline = r#"
+sources:
+  checkpoint_source:
+    type: clickhouse
+    table_name: unnest_marker_test
+    primary_key: id
+
+transforms:
+  filtered:
+    type: sql
+    primary_key: id
+    sql: SELECT id, make_array(id, id + 1) AS items FROM checkpoint_source WHERE id > 1000000
+  expanded:
+    type: sql
+    primary_key: id
+    sql: SELECT id, unnest(items) AS item FROM filtered
+
+sinks:
+  pg_sink:
+    type: postgres
+    from: expanded
+    table: unnest_marker_out
+    schema: public
+    primary_key: id
+    on_conflict: update
+    batch_size: 10
+    batch_flush_interval: 100ms
+"#;
+
+    // No record limit: the sink never receives data rows, so the pipeline
+    // only stops when the harness timeout kills it.
+    let run_result = ctx
+        .run_pipeline_with_opts(
+            pipeline,
+            PipelineOpts::new()
+                .timeout(std::time::Duration::from_secs(25))
+                .env("STREAMLING__APPLICATION_ID", &application_id)
+                .env("STREAMLING__STATE_BACKEND__BACKEND_TYPE", "Postgres")
+                .env(
+                    "STREAMLING__STATE_BACKEND__POSTGRES__HOST",
+                    &ctx.postgres.host,
+                )
+                .env(
+                    "STREAMLING__STATE_BACKEND__POSTGRES__PORT",
+                    ctx.postgres.port.to_string(),
+                )
+                .env("STREAMLING__STATE_BACKEND__POSTGRES__USER", "postgres")
+                .env("STREAMLING__STATE_BACKEND__POSTGRES__PASSWORD", "postgres")
+                .env("STREAMLING__STATE_BACKEND__POSTGRES__DB", &ctx.pg_database)
+                .env("STREAMLING__STATE_BACKEND__POSTGRES__SSLMODE", "disable")
+                .env(
+                    "STREAMLING__STATE_BACKEND__POSTGRES__STATE_TABLE_NAME",
+                    &state_table,
+                )
+                .env("STREAMLING__CHECKPOINT_INTERVAL_SEC", "1")
+                .env("STREAMLING__RECORD_BATCH_SIZE", "10"),
+        )
+        .await;
+
+    // The run is expected to end via the harness timeout; a clean exit is
+    // also acceptable. Either way, checkpoints must have been persisted.
+    tracing::info!("Pipeline run ended: {:?}", run_result.is_ok());
+
+    let checkpoint_count = ctx
+        .postgres
+        .count(&format!(
+            "SELECT COUNT(*) FROM streamling.\"{}\"",
+            state_table
+        ))
+        .await
+        .expect("Failed to query checkpoint state table");
+
+    assert!(
+        checkpoint_count > 0,
+        "At least one checkpoint should complete while the unnest yields no rows, got {}",
+        checkpoint_count
+    );
+}
+
 /// Test that ClickHouse source correctly checkpoints and resumes from saved state.
 ///
 /// This test:

--- a/crates/streamling-e2e/tests/checkpoint.rs
+++ b/crates/streamling-e2e/tests/checkpoint.rs
@@ -5,11 +5,28 @@
 //!
 //! Ported from crates/streamling/tests/pipeline_checkpoint_test.rs
 
+use serde::Serialize;
 use streamling_e2e::{init_tracing, PipelineOpts, TestContext, TestContextOptions};
 
 // ============================================================================
 // Checkpoint Tests
 // ============================================================================
+
+/// Test record for the Kafka-sourced checkpoint tests
+#[derive(Debug, Clone, Serialize)]
+struct MarkerTestRecord {
+    id: i64,
+    value: String,
+}
+
+const MARKER_TEST_SCHEMA: &str = r#"{
+    "type": "record",
+    "name": "MarkerTestRecord",
+    "fields": [
+        {"name": "id", "type": "long"},
+        {"name": "value", "type": "string"}
+    ]
+}"#;
 
 /// Checkpoints must progress even when an unnest never produces any rows.
 ///
@@ -27,53 +44,52 @@ use streamling_e2e::{init_tracing, PipelineOpts, TestContext, TestContextOptions
 async fn test_checkpoint_progresses_when_unnest_yields_no_rows() {
     init_tracing();
 
-    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+    let ctx = TestContext::with_options(TestContextOptions::new())
         .await
         .expect("Failed to create test context");
 
-    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
-
-    clickhouse
-        .execute(
-            "CREATE TABLE unnest_marker_test (
-                id UInt32,
-                name String
-            ) ENGINE = MergeTree()
-            ORDER BY id",
-        )
+    ctx.kafka
+        .register_schema(MARKER_TEST_SCHEMA)
         .await
-        .expect("Failed to create ClickHouse table");
+        .expect("Failed to register schema");
 
-    let values: Vec<String> = (0..100).map(|i| format!("({}, 'name_{}')", i, i)).collect();
-    clickhouse
-        .execute(&format!(
-            "INSERT INTO unnest_marker_test (id, name) VALUES {}",
-            values.join(", ")
-        ))
+    let records: Vec<MarkerTestRecord> = (1..=50)
+        .map(|i| MarkerTestRecord {
+            id: i,
+            value: format!("value_{}", i),
+        })
+        .collect();
+    ctx.kafka
+        .produce_avro_records(&records)
         .await
-        .expect("Failed to insert ClickHouse data");
+        .expect("Failed to produce records");
 
     let state_table = format!("unnest_marker_state_{}", ctx.test_id.replace("-", "_"));
     let application_id = format!("unnest_marker_test_{}", ctx.test_id);
 
     // The filter matches no rows, so the unnest downstream of it only ever
     // receives empty batches carrying checkpoint markers.
-    let pipeline = r#"
+    let pipeline = format!(
+        r#"
 sources:
-  checkpoint_source:
-    type: clickhouse
-    table_name: unnest_marker_test
+  kafka_source:
+    type: kafka
+    topic: {topic}
+    starting_offsets: earliest
     primary_key: id
 
 transforms:
   filtered:
     type: sql
     primary_key: id
-    sql: SELECT id, make_array(id, id + 1) AS items FROM checkpoint_source WHERE id > 1000000
+    sql: SELECT id, make_array(id, id + 1) AS items FROM kafka_source WHERE id > 1000000
   expanded:
     type: sql
     primary_key: id
-    sql: SELECT id, unnest(items) AS item FROM filtered
+    sql: |-
+      SELECT id, item FROM (
+        SELECT id, unnest(items) AS item FROM filtered
+      ) t WHERE item IS NOT NULL
 
 sinks:
   pg_sink:
@@ -85,13 +101,15 @@ sinks:
     on_conflict: update
     batch_size: 10
     batch_flush_interval: 100ms
-"#;
+"#,
+        topic = ctx.kafka_topic,
+    );
 
     // No record limit: the sink never receives data rows, so the pipeline
     // only stops when the harness timeout kills it.
     let run_result = ctx
         .run_pipeline_with_opts(
-            pipeline,
+            &pipeline,
             PipelineOpts::new()
                 .timeout(std::time::Duration::from_secs(25))
                 .env("STREAMLING__APPLICATION_ID", &application_id)


### PR DESCRIPTION
## Problem

A pipeline with an unnest downstream of a highly selective filter stops checkpointing entirely whenever the filter matches no rows after startup. Data keeps flowing, but the first checkpoint epoch never finalizes: the sink never receives the marker, the epoch times out after 300s and keeps retrying, and no checkpoint state is ever persisted — so any restart rewinds to the last checkpoint from before the stall.

## Root cause

`UnnestStream` queued checkpoint markers that arrived before any non-empty batch (`pending_checkpoints`), releasing them only with the first non-empty batch or at end of stream. On a live stream neither is guaranteed to happen: the checkpoint producer does not start a new epoch until the in-flight one resolves, so once the first marker is held, nothing else ever arrives to flush it. The producer and the unnest wait on each other forever.

The queue existed to keep empty-batch schemas consistent with resolved (possibly type-promoted) schemas, but holding markers cannot deliver that: `safe_take`'s Utf8 → LargeUtf8 promotion is per-batch, so consumers already observe mixed types across non-empty batches whenever promotion kicks in mid-stream. The end-of-stream path also already emitted marker-only batches with the static plan schema as a fallback.

## Fix

Forward markers immediately as empty batches via the existing `create_empty_checkpoint_batch` helper (resolved schema when known, static plan schema otherwise). Remove the `pending_checkpoints` machinery.

## Tests

- Unit: `test_unnest_forwards_marker_immediately_on_open_stream` — a marker-carrying empty batch followed by a stream that stays open must yield the marker batch promptly; hangs (5s timeout) on the previous code.
- E2E: `test_checkpoint_progresses_when_unnest_yields_no_rows` — full pipeline whose filter matches nothing ahead of an unnest; asserts checkpoint state is persisted while it runs.
- Existing unnest checkpoint-metadata tests unchanged and passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes checkpoint propagation in a core streaming operator; behavior is narrower (immediate forward vs hold) and covered by new unit and e2e tests, but incorrect marker handling could still affect pipeline recovery.
> 
> **Overview**
> Fixes **checkpoint deadlock** when `UnnestStream` sits behind a filter that drops every row: markers were queued in `pending_checkpoints` until the first non-empty batch or EOS, but the checkpoint producer will not advance epochs until the in-flight marker is acknowledged—so on a live stream that never unnests rows, markers never flushed and checkpointing stalled indefinitely.
> 
> **`UnnestStream`** now emits checkpoint-carrying empty batches **immediately** via `create_empty_checkpoint_batch` when `build_batch` returns no rows (resolved schema when known, static plan schema otherwise). The `pending_checkpoints` queue, merge-into-non-empty-batch logic, and end-of-stream flush are removed.
> 
> Adds **`test_unnest_forwards_marker_immediately_on_open_stream`** (marker batch + indefinitely open input must yield within 5s) and e2e **`test_checkpoint_progresses_when_unnest_yields_no_rows`** (Kafka → impossible filter → unnest → Postgres; asserts checkpoint rows in state table while the sink gets no data rows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eb3e9462ec700e2acfbdddaafcb708931a3227e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->