### PR TITLE
ci: publish rolling nightly prerelease from green main commits

### DIFF
--- a/.github/workflows/streamling.yml
+++ b/.github/workflows/streamling.yml
@@ -455,3 +455,47 @@ jobs:
           echo "Created multi-arch manifests:"
           echo "  - $TAG_SHA"
           echo "  - $TAG_LATEST"
+
+  # ==========================================================================
+  # Rolling 'nightly' prerelease from every green main commit.
+  # Linux binaries only; versioned releases remain the 'latest' release.
+  # ==========================================================================
+  publish-prerelease:
+    needs: [validate-and-test, e2e-tests, build-release-main]
+    if: github.ref_name == 'main'
+    # Serialize delete/recreate of the rolling tag across overlapping main runs.
+    concurrency:
+      group: publish-prerelease
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download release binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-binary-*-*
+          path: release-artifacts/
+      - name: Package release assets
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets
+          found=0
+          for dir in release-artifacts/release-binary-*; do
+            [ -d "$dir" ] || continue
+            found=1
+            base=$(basename "$dir")
+            os_arch=${base#release-binary-}
+            chmod +x "$dir/streamling"
+            tar -czf "release-assets/streamling-${os_arch}.tar.gz" -C "$dir" streamling
+          done
+          if [ "$found" -eq 0 ]; then
+            echo "No release artifact directories found" >&2
+            exit 1
+          fi
+      - name: Publish rolling prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release delete nightly --cleanup-tag --yes || true
+          gh release create nightly --prerelease --target "$GITHUB_SHA" --title "nightly (${GITHUB_SHA:0:7})" --notes "Rolling prerelease from main @ $GITHUB_SHA. Linux binaries only; use the versioned releases for macOS/Windows." release-assets/*


### PR DESCRIPTION
## What

Adds a `publish-prerelease` job to the CI workflow (`streamling.yml`) that publishes the per-commit linux binaries as a rolling `nightly` GitHub prerelease.

## How it works

- Runs only on `main`, and only when lint, unit tests, e2e tests, and both linux builds all pass (default `needs` semantics, no `always()`).
- Reuses the `release-binary-linux-{x86_64,aarch64}` artifacts already built by `build-release-main` — no extra compilation.
- Packages them as `streamling-linux-x86_64.tar.gz` / `streamling-linux-aarch64.tar.gz`, matching the versioned release asset naming.
- Recreates the `nightly` tag + prerelease via `gh release delete --cleanup-tag` + `gh release create --prerelease` (release tags can't be moved in place). A job-level `concurrency` group serializes overlapping main runs.

## What it doesn't do

- No crates.io publishing.
- Never marked `latest` — the manual versioned releases (`streamling-release.yml`) keep that.
- Linux only, since that's all this workflow builds; macOS/Windows binaries still come from the versioned release.

First `nightly` will appear on the first push to `main` after this merges (the workflow's path filter includes its own file).