### PR TITLE
feat: terminal checkpoint and graceful shutdown for pipelines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7034,6 +7034,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "sqlx",
  "streamling-common",
  "streamling-config",

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -1577,6 +1577,14 @@ impl ExecutionPlan for ClickHouseSourceExec {
             let mut query_retry_attempts: u32 = 0;
             let mut query_retry_backoff_ms: u64 = 100;
 
+            // Observe the process-wide shutdown signal between pages so a
+            // SIGTERM during a long bounded scan ends the stream at a page
+            // boundary instead of running the table to completion (and
+            // blowing the shutdown budget). Nothing past the last emitted
+            // page is checkpoint-covered, so a restart resumes from the last
+            // finalized cursor.
+            let shutdown = streamling_core::shutdown::subscribe();
+
             // Attach any buffered checkpoint messages to a batch about to be emitted.
             // Clears the buffer after attaching, so messages ride exactly one batch.
             let attach_checkpoints = {
@@ -1597,6 +1605,13 @@ impl ExecutionPlan for ClickHouseSourceExec {
             };
 
             while !controller.is_done() {
+                if *shutdown.borrow() {
+                    info!(
+                        "[{}] shutdown requested; ending bounded scan early after {} page(s)",
+                        reference_name, page_count
+                    );
+                    break;
+                }
                 page_count += 1;
                 // Count-first sizing: probe the exact row count for the range the
                 // cursor covers and shrink the width to fit BEFORE the data read.

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -1583,8 +1583,10 @@ impl ExecutionPlan for ClickHouseSourceExec {
             // boundary instead of running the table to completion (and
             // blowing the shutdown budget). Nothing past the last emitted
             // page is checkpoint-covered, so a restart resumes from the last
-            // finalized cursor.
-            let shutdown = streamling_core::shutdown::subscribe();
+            // finalized cursor. The retry/timeout backoff sleeps below select
+            // on the same signal — an uncancellable 30s backoff would outlive
+            // the shutdown budget all by itself.
+            let mut shutdown = streamling_core::shutdown::subscribe();
 
             // Attach any buffered checkpoint messages to a batch about to be emitted.
             // Clears the buffer after attaching, so messages ride exactly one batch.
@@ -1918,7 +1920,12 @@ impl ExecutionPlan for ClickHouseSourceExec {
                                 reference_name, page_count, old_width, controller.width()
                             );
                             page_count -= 1;
-                            tokio::time::sleep(Duration::from_millis(1_000)).await;
+                            // Shutdown-aware backoff: fall through to the
+                            // loop-top check as soon as the signal flips.
+                            tokio::select! {
+                                _ = tokio::time::sleep(Duration::from_millis(1_000)) => {}
+                                _ = shutdown.changed() => {}
+                            }
                             continue;
                         }
 
@@ -1937,7 +1944,13 @@ impl ExecutionPlan for ClickHouseSourceExec {
                         page_count -= 1;
                         let jitter = (query_retry_attempts as u64 % 100) * 7;
                         let sleep_ms = std::cmp::min(30_000u64, query_retry_backoff_ms + jitter);
-                        tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
+                        // Shutdown-aware backoff: a full 30s uncancellable
+                        // sleep would outlive the shutdown budget on its own;
+                        // fall through to the loop-top check on signal.
+                        tokio::select! {
+                            _ = tokio::time::sleep(Duration::from_millis(sleep_ms)) => {}
+                            _ = shutdown.changed() => {}
+                        }
                         query_retry_backoff_ms = std::cmp::min(query_retry_backoff_ms.saturating_mul(2), 30_000);
                         continue;
                     }

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -143,8 +143,9 @@ const MAX_PAGE_BYTES: u64 = (i32::MAX as u64) / 2;
 ///
 /// Extracted as a free function so the drain logic is unit-testable without a
 /// ClickHouse connection or a multi-minute scan. Returns `None` when the buffer
-/// is empty (nothing to flush).
-fn build_checkpoint_flush_batch(
+/// is empty (nothing to flush). Shared with the Kafka source, whose exit paths
+/// have the same buffered-message shape.
+pub(crate) fn build_checkpoint_flush_batch(
     buffer: &mut Vec<CheckpointMessage>,
     schema: SchemaRef,
 ) -> Option<RecordBatch> {

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -60,7 +60,7 @@ pub use streamling_config::{
 use streamling_core::data::{COLUMN_NAME_OP, RowKind};
 use streamling_core::node_context::get_node_context;
 use streamling_core::operators::wrapping::WrappingDataSink;
-use streamling_core::retry::retry_forever_with_backoff_async;
+use streamling_core::retry::{RetryOutcome, retry_forever_with_backoff_until_cancelled};
 use streamling_core::telemetry::provider::get_reference_name_from_metric_key;
 use streamling_core::telemetry::recorder::get_metrics_recorder;
 use streamling_core::topology::Telemetry;
@@ -1110,7 +1110,8 @@ impl DataSink for ClickHouseSinkExec {
                         async move {
                             let operation_name =
                                 format!("{}: INSERT into '{}'", node_label, table_name);
-                            retry_forever_with_backoff_async(
+                            let mut shutdown = streamling_core::shutdown::subscribe();
+                            match retry_forever_with_backoff_until_cancelled(
                                 || async {
                                     client
                                         .send_arrow_batch(&table_name, &slice, &schema)
@@ -1118,12 +1119,20 @@ impl DataSink for ClickHouseSinkExec {
                                         .streamling_context("failed to send Arrow batch")
                                 },
                                 &operation_name,
+                                &mut shutdown,
                             )
-                            .await;
+                            .await
+                            {
+                                RetryOutcome::Completed => Ok(()),
+                                RetryOutcome::Cancelled => Err(streamling_core::streamling_err!(
+                                    "{} aborted: shutdown requested before the write succeeded",
+                                    operation_name
+                                )),
+                            }
                         }
                     }
                 })
-                .await;
+                .await?;
             } else {
                 // append_only_mode=false: split rows by _gs_op into inserts vs deletes
                 use datafusion::arrow::array::StringArray;
@@ -1198,7 +1207,8 @@ impl DataSink for ClickHouseSinkExec {
                             async move {
                                 let operation_name =
                                     format!("{}: INSERT into '{}'", node_label, table_name);
-                                retry_forever_with_backoff_async(
+                                let mut shutdown = streamling_core::shutdown::subscribe();
+                                match retry_forever_with_backoff_until_cancelled(
                                     || async {
                                         client
                                             .send_arrow_batch(&table_name, &slice, &schema)
@@ -1206,12 +1216,22 @@ impl DataSink for ClickHouseSinkExec {
                                             .streamling_context("failed to send Arrow batch")
                                     },
                                     &operation_name,
+                                    &mut shutdown,
                                 )
-                                .await;
+                                .await
+                                {
+                                    RetryOutcome::Completed => Ok(()),
+                                    RetryOutcome::Cancelled => {
+                                        Err(streamling_core::streamling_err!(
+                                            "{} aborted: shutdown requested before the write succeeded",
+                                            operation_name
+                                        ))
+                                    }
+                                }
                             }
                         }
                     })
-                    .await;
+                    .await?;
                 }
 
                 // Process deletes: extract PK columns and issue ALTER TABLE DELETE
@@ -1235,7 +1255,8 @@ impl DataSink for ClickHouseSinkExec {
                     let client_for_delete = client.clone();
                     let table_for_delete = table_name.clone();
                     let pks = primary_keys.clone();
-                    retry_forever_with_backoff_async(
+                    let mut shutdown = streamling_core::shutdown::subscribe();
+                    match retry_forever_with_backoff_until_cancelled(
                         || {
                             let client = client_for_delete.clone();
                             let table = table_for_delete.clone();
@@ -1244,8 +1265,18 @@ impl DataSink for ClickHouseSinkExec {
                             async move { client.delete_by_primary_keys(&table, &pks, &batch).await }
                         },
                         &operation_name,
+                        &mut shutdown,
                     )
-                    .await;
+                    .await
+                    {
+                        RetryOutcome::Completed => {}
+                        RetryOutcome::Cancelled => {
+                            return Err(DataFusionError::from(streamling_core::streamling_err!(
+                                "{} aborted: shutdown requested before the delete succeeded",
+                                operation_name
+                            )));
+                        }
+                    }
                 }
             }
 

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1499,13 +1499,28 @@ async fn flush_pending_to_synth_batch(
     tx: &tokio::sync::mpsc::Sender<DataFusionResult<RecordBatch>>,
     reference_name: &str,
 ) {
-    let leftover: Vec<CheckpointMessage> = {
+    let drained: Vec<CheckpointMessage> = {
         let mut g = pending.lock().unwrap();
         std::mem::take(&mut *g)
     };
-    if leftover.is_empty() {
+    if drained.is_empty() {
         return;
     }
+    // Dedup by epoch within the flush: the terminal path can buffer the same
+    // Finalizer twice (once forwarded from the checkpoint channel by the
+    // forwarder task, once pushed inline by `emit_terminal_checkpoint`).
+    // Consumers are idempotent for duplicate Finalizers, but there is no
+    // reason to make them exercise that property.
+    let mut seen_marker = HashSet::new();
+    let mut seen_finalizer = HashSet::new();
+    let leftover: Vec<CheckpointMessage> = drained
+        .into_iter()
+        .filter(|msg| match msg {
+            CheckpointMessage::Marker { epoch, .. } => seen_marker.insert(epoch.0),
+            CheckpointMessage::Finalizer(epoch) => seen_finalizer.insert(epoch.0),
+            _ => true,
+        })
+        .collect();
     debug!(
         "Hybrid source '{}': flushing {} unattached marker(s) on a synthetic empty batch",
         reference_name,
@@ -1639,6 +1654,60 @@ mod tests {
             Field::new("id", DataType::Int32, false),
             Field::new("name", DataType::Utf8, false),
         ]))
+    }
+
+    /// The terminal path can buffer the same Finalizer twice: once forwarded
+    /// from the checkpoint channel by the forwarder task, once pushed inline by
+    /// `emit_terminal_checkpoint` after the finalize wait. The synthetic flush
+    /// must collapse duplicates so inline consumers never see the same epoch's
+    /// Marker/Finalizer twice on one batch — making the "duplicate Finalizers
+    /// are idempotent" contract a defence-in-depth property instead of a
+    /// load-bearing one.
+    #[tokio::test]
+    async fn test_flush_pending_dedups_duplicate_markers_and_finalizers() {
+        use streamling_core::checkpoints::checkpoint_management::now_ms;
+
+        let pending: Arc<Mutex<Vec<CheckpointMessage>>> = Arc::new(Mutex::new(vec![
+            CheckpointMessage::Marker {
+                epoch: streamling_core::checkpoints::checkpoint_management::CheckpointEpoch(7),
+                created_at_ms: now_ms(),
+            },
+            CheckpointMessage::Marker {
+                epoch: streamling_core::checkpoints::checkpoint_management::CheckpointEpoch(7),
+                created_at_ms: now_ms(),
+            },
+            CheckpointMessage::Finalizer(
+                streamling_core::checkpoints::checkpoint_management::CheckpointEpoch(7),
+            ),
+            CheckpointMessage::Finalizer(
+                streamling_core::checkpoints::checkpoint_management::CheckpointEpoch(7),
+            ),
+        ]));
+        let schema = create_test_schema();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+
+        flush_pending_to_synth_batch(&pending, &schema, &tx, "dedup_test").await;
+
+        let batch = rx
+            .recv()
+            .await
+            .expect("a synthetic batch should be flushed")
+            .expect("synthetic batch should not be an error");
+        let messages = extract_checkpoint_messages(batch.schema().metadata());
+        let markers = messages
+            .iter()
+            .filter(|m| matches!(m, CheckpointMessage::Marker { .. }))
+            .count();
+        let finalizers = messages
+            .iter()
+            .filter(|m| matches!(m, CheckpointMessage::Finalizer(_)))
+            .count();
+        assert_eq!(markers, 1, "duplicate Markers for one epoch must collapse");
+        assert_eq!(
+            finalizers, 1,
+            "duplicate Finalizers for one epoch must collapse"
+        );
+        assert!(pending.lock().unwrap().is_empty(), "pending fully drained");
     }
 
     async fn create_state_backend(name: &str) -> Arc<dyn StateOperatorBackend<HybridSourceState>> {

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1405,9 +1405,25 @@ fn merge_pending_markers(
 
 /// The bound on how long a completing source waits for the terminal checkpoint
 /// to finalize before giving up and emitting the finalizer best-effort. Keeps a
-/// sink that never acks from hanging the source task; the host-side wait and the
-/// shutdown watchdog provide the outer bounds.
-const TERMINAL_CHECKPOINT_FINALIZE_TIMEOUT: Duration = Duration::from_secs(30);
+/// sink that never acks from hanging the source task.
+///
+/// Derived from the same `STREAMLING__SHUTDOWN_BUDGET_SECS` the run loop's
+/// watchdog uses (see `Streamling::shutdown_budget`), minus a margin so this
+/// wait always expires — and the best-effort finalizer is still emitted —
+/// BEFORE the watchdog hard-exits the process. A fixed value larger than the
+/// budget would let the watchdog kill the process mid-wait, dropping the
+/// finalizer entirely.
+fn terminal_checkpoint_finalize_timeout() -> Duration {
+    const DEFAULT_SHUTDOWN_BUDGET_SECS: u64 = 25;
+    const MARGIN_SECS: u64 = 10;
+    const MIN_TIMEOUT_SECS: u64 = 5;
+    let budget = std::env::var("STREAMLING__SHUTDOWN_BUDGET_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|s| *s > 0)
+        .unwrap_or(DEFAULT_SHUTDOWN_BUDGET_SECS);
+    Duration::from_secs(budget.saturating_sub(MARGIN_SECS).max(MIN_TIMEOUT_SECS))
+}
 
 /// Emit the terminal checkpoint round-trip inline on the data stream, so both
 /// the marker and the finalizer keep a consistent cut and reach inline
@@ -1434,31 +1450,32 @@ async fn emit_terminal_checkpoint(
 ) {
     let terminal = control.begin_terminal_checkpoint();
 
-    pending.lock().unwrap().push(CheckpointMessage::Marker {
-        epoch: terminal.clone(),
-        created_at_ms: now_ms(),
-    });
+    pending
+        .lock()
+        .expect("pending markers mutex poisoned")
+        .push(CheckpointMessage::Marker {
+            epoch: terminal.clone(),
+            created_at_ms: now_ms(),
+        });
     flush_pending_to_synth_batch(pending, schema_for_synth, tx, reference_name).await;
 
     // The send above is buffered and the sinks pull concurrently, so awaiting
     // here does not block their consumption of the marker batch.
-    if tokio::time::timeout(
-        TERMINAL_CHECKPOINT_FINALIZE_TIMEOUT,
-        control.await_terminal_finalized(),
-    )
-    .await
-    .is_err()
+    let finalize_timeout = terminal_checkpoint_finalize_timeout();
+    if tokio::time::timeout(finalize_timeout, control.await_terminal_finalized())
+        .await
+        .is_err()
     {
         warn!(
             "Hybrid source '{}': terminal checkpoint did not finalize within {:?}; \
              emitting finalizer best-effort",
-            reference_name, TERMINAL_CHECKPOINT_FINALIZE_TIMEOUT
+            reference_name, finalize_timeout
         );
     }
 
     pending
         .lock()
-        .unwrap()
+        .expect("pending markers mutex poisoned")
         .push(CheckpointMessage::Finalizer(terminal));
     flush_pending_to_synth_batch(pending, schema_for_synth, tx, reference_name).await;
 }

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1315,6 +1315,9 @@ impl ExecutionPlan for HybridSourceExec {
             // abort it so it doesn't pin the provider Arc until process exit.
             if let Some(handle) = shutdown_watcher_handle {
                 handle.abort();
+                // Await the aborted task so the provider Arc it captured is
+                // deterministically dropped before this task ends.
+                let _ = handle.await;
             }
         });
 
@@ -1466,11 +1469,20 @@ async fn emit_terminal_checkpoint(
         .await
         .is_err()
     {
+        // At least one live sink never confirmed its writes. Do NOT emit the
+        // Finalizer: it tells inline consumers to commit/truncate past the
+        // terminal epoch, and doing that for an epoch that never finalized
+        // would advance durable state past unconfirmed data — the restart
+        // would then skip replaying exactly the tail this mechanism exists to
+        // protect. Skipping only costs the end-of-job finalize work (e.g.
+        // staging cleanup); at-least-once replay covers the data itself.
         warn!(
             "Hybrid source '{}': terminal checkpoint did not finalize within {:?}; \
-             emitting finalizer best-effort",
+             SKIPPING the terminal Finalizer so no consumer commits past \
+             unconfirmed data (it will be replayed on restart)",
             reference_name, finalize_timeout
         );
+        return;
     }
 
     pending
@@ -1513,7 +1525,7 @@ async fn flush_pending_to_synth_batch(
     // reason to make them exercise that property.
     let mut seen_marker = HashSet::new();
     let mut seen_finalizer = HashSet::new();
-    let leftover: Vec<CheckpointMessage> = drained
+    let to_flush: Vec<CheckpointMessage> = drained
         .into_iter()
         .filter(|msg| match msg {
             CheckpointMessage::Marker { epoch, .. } => seen_marker.insert(epoch.0),
@@ -1524,10 +1536,10 @@ async fn flush_pending_to_synth_batch(
     debug!(
         "Hybrid source '{}': flushing {} unattached marker(s) on a synthetic empty batch",
         reference_name,
-        leftover.len()
+        to_flush.len()
     );
     let mut md = HashMap::new();
-    enrich_batch_metadata_with_checkpoints(&mut md, &leftover);
+    enrich_batch_metadata_with_checkpoints(&mut md, &to_flush);
     let synth_schema = Arc::new(Schema::new_with_metadata(
         schema_for_synth.fields().clone(),
         md,

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1562,6 +1562,14 @@ async fn emit_terminal_checkpoint(
             finalize_timeout,
             control.pending_terminal_ack_sinks()
         );
+        // Counter alongside the warn: a skipped terminal Finalizer means the
+        // tail silently replays on the next restart — operators need a metric
+        // to alert on, not just a log line. Grouped under the coordinator's
+        // component id with the other checkpoint_* counters.
+        streamling_core::telemetry::recorder::get_control_plane_metrics_recorder(
+            "checkpoint_coordinator",
+        )
+        .record_count("checkpoint_terminal_finalizer_skipped", 1);
         return;
     }
 

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1185,10 +1185,8 @@ impl ExecutionPlan for HybridSourceExec {
                 )
                 .await;
 
-                let shutdown_requested = shutdown_rx
-                    .as_ref()
-                    .map(|rx| *rx.borrow())
-                    .unwrap_or(false);
+                let shutdown_requested =
+                    shutdown_rx.as_ref().map(|rx| *rx.borrow()).unwrap_or(false);
 
                 // Stream ended — use our local knowledge of what phase we were
                 // executing to decide whether to advance or exit.

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1081,7 +1081,9 @@ impl ExecutionPlan for HybridSourceExec {
         // loop below falls through to the terminal-checkpoint path. Without
         // this the loop would block indefinitely in `stream.next()` on a live
         // topic and never observe the signal. Bounded-phase (ClickHouse)
-        // sources observe the same signal directly in their pagination loop.
+        // streams have no equivalent stop hook — the forwarding loop below
+        // selects on the shutdown watch instead, and the ClickHouse scan also
+        // checks the signal between pages.
         let shutdown_watcher_handle = shutdown_rx.clone().map(|mut sd| {
             let provider_for_shutdown = provider.clone();
             let ref_name = reference_name_for_spawn.clone();
@@ -1139,7 +1141,51 @@ impl ExecutionPlan for HybridSourceExec {
                     }
                 };
 
-                while let Some(batch_result) = stream.next().await {
+                // Forward batches until the inner stream ends — or, during a
+                // BOUNDED phase, until the process-wide shutdown signal flips.
+                // The select on the shutdown watch is what makes bounded
+                // (ClickHouse) phases shutdown-aware: the watcher task above
+                // only stops the Kafka unbounded source, and the post-loop
+                // check below only runs after the stream ends, so without
+                // this arm a SIGTERM during a long bounded scan would sit in
+                // `stream.next()` until the scan finished and the watchdog
+                // force-exited instead of draining. Ending a bounded stream
+                // early is safe: nothing past the last emitted batch is
+                // checkpoint-covered, so a restart resumes from the last
+                // finalized cursor. The unbounded (Kafka) phase is exempt on
+                // purpose — its source observes the signal itself and drains
+                // the in-flight batch before ending its stream, which this
+                // loop must keep consuming.
+                let mut shutdown_for_stream = shutdown_rx.clone();
+                let mut shutdown_watch_dead = false;
+                loop {
+                    let next = match (&mut shutdown_for_stream, shutdown_watch_dead) {
+                        (Some(sd), false) if !is_executing_unbounded => {
+                            if *sd.borrow() {
+                                info!(
+                                    "Hybrid source '{}': shutdown requested; ending bounded stream early",
+                                    reference_name_for_spawn,
+                                );
+                                break;
+                            }
+                            tokio::select! {
+                                biased;
+                                changed = sd.changed() => {
+                                    // On a real change the next iteration sees
+                                    // borrow()==true and breaks; a closed
+                                    // sender means no shutdown signal exists,
+                                    // so stop watching rather than spin.
+                                    shutdown_watch_dead = changed.is_err();
+                                    continue;
+                                }
+                                n = stream.next() => n,
+                            }
+                        }
+                        _ => stream.next().await,
+                    };
+                    let Some(batch_result) = next else {
+                        break;
+                    };
                     match batch_result {
                         Ok(batch) => {
                             // Bounded sources (ClickHouse) emit u256/i256 columns as
@@ -1509,10 +1555,12 @@ async fn emit_terminal_checkpoint(
         // protect. Skipping only costs the end-of-job finalize work (e.g.
         // staging cleanup); at-least-once replay covers the data itself.
         warn!(
-            "Hybrid source '{}': terminal checkpoint did not finalize within {:?} of shutdown; \
-             SKIPPING the terminal Finalizer so no consumer commits past \
-             unconfirmed data (it will be replayed on restart)",
-            reference_name, finalize_timeout
+            "Hybrid source '{}': terminal checkpoint did not finalize within {:?} of shutdown \
+             (sinks that never acked: {:?}); SKIPPING the terminal Finalizer so no consumer \
+             commits past unconfirmed data (it will be replayed on restart)",
+            reference_name,
+            finalize_timeout,
+            control.pending_terminal_ack_sinks()
         );
         return;
     }

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1412,20 +1412,21 @@ fn merge_pending_markers(
 }
 
 /// The bound on how long a completing source waits for the terminal checkpoint
-/// to finalize before giving up and emitting the finalizer best-effort. Keeps a
-/// sink that never acks from hanging the source task.
+/// to finalize. On timeout the terminal Finalizer is SKIPPED (never emitted
+/// for an unconfirmed epoch — see `emit_terminal_checkpoint`); this bound only
+/// keeps a sink that never acks from hanging the source task.
 ///
 /// Derived from the run loop's shared shutdown budget
 /// (`streamling_core::shutdown::shutdown_budget`, the same value the watchdog
-/// is armed with), minus a margin so this wait always expires — and the
-/// best-effort finalizer is still emitted — BEFORE the watchdog hard-exits the
-/// process. A fixed value larger than the budget would let the watchdog kill
-/// the process mid-wait, dropping the finalizer entirely.
+/// is armed with), minus a margin so this wait always expires BEFORE the
+/// watchdog hard-exits the process. The minimum-floor is itself capped at
+/// budget − 2s so a deliberately tiny budget can never invert the invariant.
 fn terminal_checkpoint_finalize_timeout() -> Duration {
     const MARGIN_SECS: u64 = 10;
     const MIN_TIMEOUT_SECS: u64 = 5;
     let budget = streamling_core::shutdown::shutdown_budget().as_secs();
-    Duration::from_secs(budget.saturating_sub(MARGIN_SECS).max(MIN_TIMEOUT_SECS))
+    let capped_floor = MIN_TIMEOUT_SECS.min(budget.saturating_sub(2).max(1));
+    Duration::from_secs(budget.saturating_sub(MARGIN_SECS).max(capped_floor))
 }
 
 /// Emit the terminal checkpoint round-trip inline on the data stream, so both

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1465,11 +1465,35 @@ async fn emit_terminal_checkpoint(
 
     // The send above is buffered and the sinks pull concurrently, so awaiting
     // here does not block their consumption of the marker batch.
+    //
+    // How long to wait depends on WHY we are completing:
+    // - Shutdown requested (SIGTERM): the watchdog is armed, so the wait must
+    //   be bounded under the shutdown budget.
+    // - Natural job-mode completion: no deadline is running, and in a
+    //   multi-source job the shared terminal epoch cannot finalize until the
+    //   SLOWEST branch completes and its sinks ack — sibling skew can
+    //   legitimately exceed any SIGTERM-sized budget. Wait until finalized or
+    //   until a shutdown request arrives (then fall back to the bounded wait).
+    //   A sink wedged forever with no shutdown request keeps the pipeline
+    //   alive-but-stalled, exactly as an unacked epoch does on main; the
+    //   operator-initiated SIGTERM then drains it under the budget.
+    let mut shutdown = streamling_core::shutdown::subscribe();
     let finalize_timeout = terminal_checkpoint_finalize_timeout();
-    if tokio::time::timeout(finalize_timeout, control.await_terminal_finalized())
-        .await
-        .is_err()
-    {
+    let finalized = if *shutdown.borrow() {
+        tokio::time::timeout(finalize_timeout, control.await_terminal_finalized())
+            .await
+            .is_ok()
+    } else {
+        tokio::select! {
+            _ = control.await_terminal_finalized() => true,
+            _ = shutdown.changed() => {
+                tokio::time::timeout(finalize_timeout, control.await_terminal_finalized())
+                    .await
+                    .is_ok()
+            }
+        }
+    };
+    if !finalized {
         // At least one live sink never confirmed its writes. Do NOT emit the
         // Finalizer: it tells inline consumers to commit/truncate past the
         // terminal epoch, and doing that for an epoch that never finalized
@@ -1478,7 +1502,7 @@ async fn emit_terminal_checkpoint(
         // protect. Skipping only costs the end-of-job finalize work (e.g.
         // staging cleanup); at-least-once replay covers the data itself.
         warn!(
-            "Hybrid source '{}': terminal checkpoint did not finalize within {:?}; \
+            "Hybrid source '{}': terminal checkpoint did not finalize within {:?} of shutdown; \
              SKIPPING the terminal Finalizer so no consumer commits past \
              unconfirmed data (it will be replayed on restart)",
             reference_name, finalize_timeout

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -19,8 +19,8 @@ use serde::{Deserialize, Serialize};
 use streamling_config::AppConfig;
 use streamling_core::checkpoints::channels::{subscribe_with_id, unsubscribe};
 use streamling_core::checkpoints::checkpoint_management::{
-    CHECKPOINT_COORDINATOR_CHANNEL, CheckpointMessage, enrich_batch_metadata_with_checkpoints,
-    extract_checkpoint_messages,
+    CHECKPOINT_COORDINATOR_CHANNEL, CheckpointControl, CheckpointMessage,
+    enrich_batch_metadata_with_checkpoints, extract_checkpoint_messages, now_ms,
 };
 use streamling_core::data::COLUMN_NAME_OP;
 use streamling_core::error::ResultExt;
@@ -139,6 +139,15 @@ pub struct HybridTableProvider {
     pub state: Arc<RwLock<HybridSourceState>>,
     reference_name: String,
     session_manager: SessionManager,
+    /// Control handle for the checkpoint coordinator. When set, this source
+    /// begins a terminal checkpoint and emits its marker/finalizer inline after
+    /// the last batch when it completes (job mode) or when shutdown is
+    /// requested (streaming mode). `None` outside a running pipeline (tests).
+    checkpoint_control: Option<CheckpointControl>,
+    /// Process-wide shutdown signal. When it flips true the source drains its
+    /// current phase, emits the terminal checkpoint, and ends its stream
+    /// instead of advancing to the next phase. `None` in tests.
+    shutdown_rx: Option<tokio::sync::watch::Receiver<bool>>,
 }
 impl Debug for HybridTableProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -203,9 +212,26 @@ impl HybridTableProvider {
             state: Arc::new(RwLock::new(initial_state)),
             reference_name,
             session_manager,
+            checkpoint_control: None,
+            shutdown_rx: None,
         };
 
         Ok(provider)
+    }
+
+    /// Attach the checkpoint control handle so this source begins the terminal
+    /// checkpoint when it completes / shuts down. Builder-style so the provider
+    /// can be configured before being wrapped in an `Arc`.
+    pub fn with_checkpoint_control(mut self, control: CheckpointControl) -> Self {
+        self.checkpoint_control = Some(control);
+        self
+    }
+
+    /// Attach the process-wide shutdown signal so this source drains and emits
+    /// the terminal checkpoint on SIGTERM instead of advancing phases.
+    pub fn with_shutdown(mut self, shutdown_rx: tokio::sync::watch::Receiver<bool>) -> Self {
+        self.shutdown_rx = Some(shutdown_rx);
+        self
     }
 
     pub fn new_from_topology(
@@ -1047,6 +1073,31 @@ impl ExecutionPlan for HybridSourceExec {
         let pending_for_main = pending_markers.clone();
 
         let reference_name_for_spawn = self.provider.reference_name.clone();
+        let checkpoint_control = provider.checkpoint_control.clone();
+        let shutdown_rx = provider.shutdown_rx.clone();
+
+        // Shutdown watcher: when the process-wide shutdown signal fires, stop
+        // the inner unbounded source (Kafka) so its stream ends and the main
+        // loop below falls through to the terminal-checkpoint path. Without
+        // this the loop would block indefinitely in `stream.next()` on a live
+        // topic and never observe the signal. Bounded-phase (ClickHouse)
+        // sources observe the same signal directly in their pagination loop.
+        if let Some(mut sd) = shutdown_rx.clone() {
+            let provider_for_shutdown = provider.clone();
+            let ref_name = reference_name_for_spawn.clone();
+            tokio::spawn(async move {
+                while !*sd.borrow() {
+                    if sd.changed().await.is_err() {
+                        return;
+                    }
+                }
+                info!(
+                    "Hybrid source '{}': shutdown requested; stopping inner unbounded source",
+                    ref_name
+                );
+                provider_for_shutdown.shutdown();
+            });
+        }
 
         tokio::spawn(async move {
             // Every exit path from the loop falls through to the
@@ -1134,41 +1185,105 @@ impl ExecutionPlan for HybridSourceExec {
                 )
                 .await;
 
+                let shutdown_requested = shutdown_rx
+                    .as_ref()
+                    .map(|rx| *rx.borrow())
+                    .unwrap_or(false);
+
                 // Stream ended — use our local knowledge of what phase we were
                 // executing to decide whether to advance or exit.
                 if is_executing_unbounded {
-                    warn!("Unbounded source stream ended, exiting hybrid source");
+                    // The unbounded (Kafka) stream ended — in practice only on
+                    // shutdown (the watcher above called `provider.shutdown()`)
+                    // or if the topic itself ended. Emit the terminal checkpoint
+                    // so the tail is covered and the sinks flush + ack a final
+                    // epoch before we stop, then exit.
+                    if shutdown_requested {
+                        info!(
+                            "Hybrid source '{}': unbounded stream ended after shutdown request, finalizing",
+                            reference_name_for_spawn
+                        );
+                    } else {
+                        warn!("Unbounded source stream ended, exiting hybrid source");
+                    }
+                    if let Some(control) = &checkpoint_control {
+                        emit_terminal_checkpoint(
+                            control,
+                            &pending_for_main,
+                            &schema_for_synth,
+                            &tx,
+                            &reference_name_for_spawn,
+                        )
+                        .await;
+                    }
                     break 'outer;
-                } else {
-                    match provider.advance_to_next_phase().await {
-                        Ok(()) => {
-                            let state = provider.state.read().await;
-                            let now_unbounded =
-                                state.current_phase >= provider.config.bounded_sources.len();
-                            drop(state);
+                }
 
-                            if now_unbounded && provider.config.job_mode {
-                                info!(
-                                    "Job mode: all {} bounded phase(s) complete, terminating hybrid source",
-                                    provider.config.bounded_sources.len()
-                                );
-                                provider.shutdown();
-                                break 'outer;
-                            }
+                // Bounded stream ended. If shutdown was requested, do not advance
+                // into another phase: emit the terminal checkpoint for what we
+                // produced and stop.
+                if shutdown_requested {
+                    info!(
+                        "Hybrid source '{}': shutdown requested during bounded phase; \
+                         emitting terminal checkpoint and stopping",
+                        reference_name_for_spawn
+                    );
+                    provider.shutdown();
+                    if let Some(control) = &checkpoint_control {
+                        emit_terminal_checkpoint(
+                            control,
+                            &pending_for_main,
+                            &schema_for_synth,
+                            &tx,
+                            &reference_name_for_spawn,
+                        )
+                        .await;
+                    }
+                    break 'outer;
+                }
 
-                            info!("Advanced to next phase, continuing with new source");
-                            continue;
-                        }
-                        Err(e) => {
-                            error!(
-                                "Hybrid source '{}': advance_to_next_phase failed; \
-                                 hybrid state may not have persisted the phase advance. \
-                                 The next restart will probe per-phase state for recovery: {:?}",
-                                provider.reference_name, e
+                match provider.advance_to_next_phase().await {
+                    Ok(()) => {
+                        let state = provider.state.read().await;
+                        let now_unbounded =
+                            state.current_phase >= provider.config.bounded_sources.len();
+                        drop(state);
+
+                        if now_unbounded && provider.config.job_mode {
+                            info!(
+                                "Job mode: all {} bounded phase(s) complete, terminating hybrid source",
+                                provider.config.bounded_sources.len()
                             );
-                            let _ = tx.send(Err(e)).await;
+                            // Emit the terminal checkpoint while the sinks are
+                            // still consuming this stream, so the last bounded
+                            // rows are covered by a finalized checkpoint and the
+                            // sinks flush + ack before teardown.
+                            if let Some(control) = &checkpoint_control {
+                                emit_terminal_checkpoint(
+                                    control,
+                                    &pending_for_main,
+                                    &schema_for_synth,
+                                    &tx,
+                                    &reference_name_for_spawn,
+                                )
+                                .await;
+                            }
+                            provider.shutdown();
                             break 'outer;
                         }
+
+                        info!("Advanced to next phase, continuing with new source");
+                        continue;
+                    }
+                    Err(e) => {
+                        error!(
+                            "Hybrid source '{}': advance_to_next_phase failed; \
+                             hybrid state may not have persisted the phase advance. \
+                             The next restart will probe per-phase state for recovery: {:?}",
+                            provider.reference_name, e
+                        );
+                        let _ = tx.send(Err(e)).await;
+                        break 'outer;
                     }
                 }
             }
@@ -1288,6 +1403,66 @@ fn merge_pending_markers(
             batch
         }
     }
+}
+
+/// The bound on how long a completing source waits for the terminal checkpoint
+/// to finalize before giving up and emitting the finalizer best-effort. Keeps a
+/// sink that never acks from hanging the source task; the host-side wait and the
+/// shutdown watchdog provide the outer bounds.
+const TERMINAL_CHECKPOINT_FINALIZE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Emit the terminal checkpoint round-trip inline on the data stream, so both
+/// the marker and the finalizer keep a consistent cut and reach inline
+/// consumers (sinks) the same way every other checkpoint does:
+///
+/// 1. `Marker` on a synthetic batch after all real data, so the sinks flush and
+///    ack a final epoch covering everything they received.
+/// 2. Wait (bounded) for the coordinator to finalize that epoch — meaning every
+///    live sink acked it.
+/// 3. `Finalizer` on a second synthetic batch, so inline consumers run their
+///    finalize work (offset/state commit, staging truncation) before the stream
+///    ends.
+///
+/// `begin_terminal_checkpoint` is idempotent across the sources of a
+/// multi-source pipeline: the first caller mints the epoch, the rest reuse it,
+/// and it finalizes once every sink has acked it (or been dropped from the
+/// expected set via `sink_completed`).
+async fn emit_terminal_checkpoint(
+    control: &CheckpointControl,
+    pending: &Arc<Mutex<Vec<CheckpointMessage>>>,
+    schema_for_synth: &SchemaRef,
+    tx: &tokio::sync::mpsc::Sender<DataFusionResult<RecordBatch>>,
+    reference_name: &str,
+) {
+    let terminal = control.begin_terminal_checkpoint();
+
+    pending.lock().unwrap().push(CheckpointMessage::Marker {
+        epoch: terminal.clone(),
+        created_at_ms: now_ms(),
+    });
+    flush_pending_to_synth_batch(pending, schema_for_synth, tx, reference_name).await;
+
+    // The send above is buffered and the sinks pull concurrently, so awaiting
+    // here does not block their consumption of the marker batch.
+    if tokio::time::timeout(
+        TERMINAL_CHECKPOINT_FINALIZE_TIMEOUT,
+        control.await_terminal_finalized(),
+    )
+    .await
+    .is_err()
+    {
+        warn!(
+            "Hybrid source '{}': terminal checkpoint did not finalize within {:?}; \
+             emitting finalizer best-effort",
+            reference_name, TERMINAL_CHECKPOINT_FINALIZE_TIMEOUT
+        );
+    }
+
+    pending
+        .lock()
+        .unwrap()
+        .push(CheckpointMessage::Finalizer(terminal));
+    flush_pending_to_synth_batch(pending, schema_for_synth, tx, reference_name).await;
 }
 
 /// Flush any markers currently buffered in `pending` to the downstream

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1082,7 +1082,7 @@ impl ExecutionPlan for HybridSourceExec {
         // this the loop would block indefinitely in `stream.next()` on a live
         // topic and never observe the signal. Bounded-phase (ClickHouse)
         // sources observe the same signal directly in their pagination loop.
-        if let Some(mut sd) = shutdown_rx.clone() {
+        let shutdown_watcher_handle = shutdown_rx.clone().map(|mut sd| {
             let provider_for_shutdown = provider.clone();
             let ref_name = reference_name_for_spawn.clone();
             tokio::spawn(async move {
@@ -1096,8 +1096,8 @@ impl ExecutionPlan for HybridSourceExec {
                     ref_name
                 );
                 provider_for_shutdown.shutdown();
-            });
-        }
+            })
+        });
 
         tokio::spawn(async move {
             // Every exit path from the loop falls through to the
@@ -1311,6 +1311,11 @@ impl ExecutionPlan for HybridSourceExec {
             let _ = forwarder_shutdown_tx.send(());
             let _ = forwarder_handle.await;
             unsubscribe(CHECKPOINT_COORDINATOR_CHANNEL, hybrid_marker_sub_id);
+            // The shutdown watcher may never fire (clean job-mode completion);
+            // abort it so it doesn't pin the provider Arc until process exit.
+            if let Some(handle) = shutdown_watcher_handle {
+                handle.abort();
+            }
         });
 
         Ok(builder.build())
@@ -1407,21 +1412,16 @@ fn merge_pending_markers(
 /// to finalize before giving up and emitting the finalizer best-effort. Keeps a
 /// sink that never acks from hanging the source task.
 ///
-/// Derived from the same `STREAMLING__SHUTDOWN_BUDGET_SECS` the run loop's
-/// watchdog uses (see `Streamling::shutdown_budget`), minus a margin so this
-/// wait always expires — and the best-effort finalizer is still emitted —
-/// BEFORE the watchdog hard-exits the process. A fixed value larger than the
-/// budget would let the watchdog kill the process mid-wait, dropping the
-/// finalizer entirely.
+/// Derived from the run loop's shared shutdown budget
+/// (`streamling_core::shutdown::shutdown_budget`, the same value the watchdog
+/// is armed with), minus a margin so this wait always expires — and the
+/// best-effort finalizer is still emitted — BEFORE the watchdog hard-exits the
+/// process. A fixed value larger than the budget would let the watchdog kill
+/// the process mid-wait, dropping the finalizer entirely.
 fn terminal_checkpoint_finalize_timeout() -> Duration {
-    const DEFAULT_SHUTDOWN_BUDGET_SECS: u64 = 25;
     const MARGIN_SECS: u64 = 10;
     const MIN_TIMEOUT_SECS: u64 = 5;
-    let budget = std::env::var("STREAMLING__SHUTDOWN_BUDGET_SECS")
-        .ok()
-        .and_then(|s| s.parse::<u64>().ok())
-        .filter(|s| *s > 0)
-        .unwrap_or(DEFAULT_SHUTDOWN_BUDGET_SECS);
+    let budget = streamling_core::shutdown::shutdown_budget().as_secs();
     Duration::from_secs(budget.saturating_sub(MARGIN_SECS).max(MIN_TIMEOUT_SECS))
 }
 

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1447,6 +1447,11 @@ fn terminal_checkpoint_finalize_timeout() -> Duration {
 /// multi-source pipeline: the first caller mints the epoch, the rest reuse it,
 /// and it finalizes once every sink has acked it (or been dropped from the
 /// expected set via `sink_completed`).
+///
+/// Send failures on `tx` are logged, not surfaced: every call site is a
+/// completion path that ends the stream immediately after this returns, and
+/// the only way the receiver is gone is that downstream already tore down —
+/// there is no caller decision an error could change.
 async fn emit_terminal_checkpoint(
     control: &CheckpointControl,
     pending: &Arc<Mutex<Vec<CheckpointMessage>>>,

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1420,12 +1420,14 @@ fn merge_pending_markers(
 /// (`streamling_core::shutdown::shutdown_budget`, the same value the watchdog
 /// is armed with), minus a margin so this wait always expires BEFORE the
 /// watchdog hard-exits the process. The minimum-floor is itself capped at
-/// budget − 2s so a deliberately tiny budget can never invert the invariant.
+/// budget − 2s so a deliberately tiny budget can never invert the invariant:
+/// for budgets ≤ 2s the timeout collapses to zero, which expires immediately
+/// and takes the safe branch (Finalizer skipped).
 fn terminal_checkpoint_finalize_timeout() -> Duration {
     const MARGIN_SECS: u64 = 10;
     const MIN_TIMEOUT_SECS: u64 = 5;
     let budget = streamling_core::shutdown::shutdown_budget().as_secs();
-    let capped_floor = MIN_TIMEOUT_SECS.min(budget.saturating_sub(2).max(1));
+    let capped_floor = MIN_TIMEOUT_SECS.min(budget.saturating_sub(2));
     Duration::from_secs(budget.saturating_sub(MARGIN_SECS).max(capped_floor))
 }
 

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1537,7 +1537,7 @@ async fn flush_pending_to_synth_batch(
     reference_name: &str,
 ) {
     let drained: Vec<CheckpointMessage> = {
-        let mut g = pending.lock().unwrap();
+        let mut g = pending.lock().expect("pending markers mutex poisoned");
         std::mem::take(&mut *g)
     };
     if drained.is_empty() {
@@ -1570,7 +1570,18 @@ async fn flush_pending_to_synth_batch(
         md,
     ));
     let synth = RecordBatch::new_empty(synth_schema);
-    let _ = tx.send(Ok(synth)).await;
+    if tx.send(Ok(synth)).await.is_err() {
+        // Downstream already gone. On teardown paths this is expected; on the
+        // terminal-checkpoint path it means the Marker/Finalizer batch was
+        // dropped and the epoch will not finalize (at-least-once replay covers
+        // the data). Either way, make it visible instead of silent.
+        warn!(
+            "Hybrid source '{}': downstream closed; dropped a synthetic batch \
+             carrying {} checkpoint message(s)",
+            reference_name,
+            to_flush.len()
+        );
+    }
 }
 
 struct ClickHouseSchemaAdapter {

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -996,11 +996,27 @@ async fn calculate_lag_task(
         lag_report_interval_ms.unwrap_or(DEFAULT_LAG_REPORT_INTERVAL_MS),
     ));
 
+    // Also observe the process-wide shutdown signal: outside job mode nothing
+    // flips the provider-level channel, and a lag task that outlives the
+    // pipeline gets cancelled at runtime teardown — where its consumer's
+    // rd_kafka_destroy can no longer be deferred to a blocking thread.
+    let mut global_shutdown_rx = streamling_core::shutdown::subscribe();
+
     loop {
+        if *global_shutdown_rx.borrow() {
+            info!("Lag task observed process shutdown for {}", reference_name);
+            break;
+        }
         tokio::select! {
             _ = shutdown_rx.changed() => {
                 if *shutdown_rx.borrow() {
                     info!("Lag task received shutdown signal for {}", reference_name);
+                    break;
+                }
+            },
+            _ = global_shutdown_rx.changed() => {
+                if *global_shutdown_rx.borrow() {
+                    info!("Lag task observed process shutdown for {}", reference_name);
                     break;
                 }
             },
@@ -1382,30 +1398,57 @@ impl ExecutionPlan for KafkaSourceExec {
             let mut source_complete_interval = num_records_before_stop
                 .map(|_| tokio::time::interval(Duration::from_millis(5)));
 
+            // Process-wide shutdown signal (one top-level SIGTERM/SIGINT
+            // handler flips it). This replaces the per-iteration
+            // `signal(SignalKind::terminate())` listener this loop used to
+            // re-create on every outer iteration — a signal landing in the
+            // drop/recreate window was lost entirely, leaving the source
+            // running until the watchdog force-exited the process.
+            let mut global_shutdown_rx = streamling_core::shutdown::subscribe();
+            // When a shutdown signal arrives we break the INNER loop only, so
+            // the batch already buffered in the converter is still converted
+            // and sent (drain, don't drop), then exit the outer loop.
+            let mut drain_and_stop = false;
+
             'outer: loop {
+                // A shutdown requested before this iteration started (e.g.
+                // before the first poll, or while sending the previous batch)
+                // would not wake `changed()` below — the subscription has
+                // already observed the value. Check it explicitly; nothing is
+                // buffered at the top of an iteration, so exiting here drops
+                // no data.
+                if drain_and_stop || *global_shutdown_rx.borrow() {
+                    info!("Kafka source '{}': shutdown requested; stopping", reference_name);
+                    break 'outer;
+                }
+
                 watchdog.refresh_lag();
                 watchdog.check_and_alert(&topic);
 
                 let outer_loop_start_at = Instant::now();
                 let deadline = Instant::now() + batch_interval;
-                // SIGTERM on Unix; Windows has no SIGTERM, so the shutdown branch
-                // below falls back to Ctrl-C there.
-                #[cfg(unix)]
-                let mut sigterm = {
-                    use tokio::signal::unix::{SignalKind, signal};
-                    signal(SignalKind::terminate())?
-                };
 
                 let mut row_kinds = Vec::new();
                 let mut batch_row_count = 0u64;
 
                 loop {
                     tokio::select! {
-                        // Check for shutdown signal
+                        // Provider-level shutdown (hybrid job-mode termination)
                         _ = shutdown_rx.changed() => {
                             if *shutdown_rx.borrow() {
                                 info!("Kafka consumer received shutdown signal");
-                                break 'outer;
+                                drain_and_stop = true;
+                                break;
+                            }
+                        },
+                        // Process-wide shutdown (SIGTERM/SIGINT via the
+                        // top-level handler): finish the in-flight batch and
+                        // send it before exiting.
+                        _ = global_shutdown_rx.changed() => {
+                            if *global_shutdown_rx.borrow() {
+                                info!("Kafka source '{}': received shutdown signal, draining in-flight batch", reference_name);
+                                drain_and_stop = true;
+                                break;
                             }
                         },
                         // Check for SourceComplete messages (only in test mode with num_records_before_stop).
@@ -1478,17 +1521,6 @@ impl ExecutionPlan for KafkaSourceExec {
                         _ = sleep_until(deadline) => {
                             break;
                         },
-                        // shutdown hook: SIGTERM on Unix, Ctrl-C on Windows
-                        _ = async {
-                            #[cfg(unix)]
-                            { let _ = sigterm.recv().await; }
-                            #[cfg(not(unix))]
-                            { let _ = tokio::signal::ctrl_c().await; }
-                        } => {
-                            // TODO: flush, cleanup, etc.
-                            info!("Received shutdown signal, shutting down");
-                            break 'outer; // exit the outer loop, which terminates the task
-                        }
                     }
                 }
 

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -3,7 +3,7 @@ mod metadata;
 mod schema_registry;
 
 use streamling_config::{KafkaCompression, KafkaConfig};
-use streamling_core::checkpoints::channels::{send, subscribe};
+use streamling_core::checkpoints::channels::{send, subscribe_with_id, unsubscribe};
 use streamling_core::checkpoints::checkpoint_management::{
     CHECKPOINT_COORDINATOR_CHANNEL, CheckpointEpoch, CheckpointMessage,
     enrich_batch_metadata_with_checkpoints, extract_checkpoint_messages, now_ms,
@@ -1224,7 +1224,13 @@ impl ExecutionPlan for KafkaSourceExec {
         let batch_size_limit = self.record_batch_size as u64;
 
         let reference_name = self.reference_name.clone();
-        let receiver = subscribe(CHECKPOINT_COORDINATOR_CHANNEL);
+        // Keep the subscriber id so the consume task can unsubscribe on exit:
+        // dropping the receiver while the sender stays in the global channel
+        // map makes every later broadcast return SendError — which used to
+        // panic sinks/coordinator mid-drain the moment this source exited on
+        // shutdown.
+        let (receiver, checkpoint_subscriber_id) =
+            subscribe_with_id(CHECKPOINT_COORDINATOR_CHANNEL);
 
         let mut metadata = if self.include_metadata {
             Some(KafkaMetadata::default())
@@ -1693,6 +1699,7 @@ impl ExecutionPlan for KafkaSourceExec {
             }
 
             info!("Shutting down Kafka consumer: unsubscribing and unassigning");
+            unsubscribe(CHECKPOINT_COORDINATOR_CHANNEL, checkpoint_subscriber_id);
             consumer.unsubscribe();
             consumer.unassign().expect("Failed to unassign consumer");
             // Always forget after explicit cleanup to avoid redundant drop overhead.
@@ -2803,11 +2810,12 @@ impl DataSink for KafkaSink {
                     }
 
                     let sink_id = get_reference_name_from_metric_key(&self.metric_metadata_id);
-                    send(
+                    // Best-effort: see the postgres sink — a receiver dropped
+                    // during shutdown must not panic the sink mid-drain.
+                    let _ = send(
                         CHECKPOINT_COORDINATOR_CHANNEL,
                         CheckpointMessage::Ack { epoch, sink_id },
-                    )
-                    .unwrap();
+                    );
                     metrics_recorder.record_time(
                         "checkpoint_sink_flush",
                         ack_start.elapsed(),

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -985,7 +985,7 @@ async fn calculate_lag_task(
     reference_name: String,
     metric_metadata_id: String,
     kafka_topic_partition_list: KafkaTopicPartitionList,
-    consumer: StreamConsumer,
+    consumer: SafeKafkaConsumer,
     state_backend: Arc<dyn StateOperatorBackend<TopicPartitionOffset>>,
     metrics_recorder: Arc<MetricsRecorder>,
     lag_report_interval_ms: Option<u64>,
@@ -1233,12 +1233,15 @@ impl ExecutionPlan for KafkaSourceExec {
         let metric_metadata_id = self.metric_metadata_id.clone();
         let kafka_lag_reporter_interval = self.kafka_config.lag_report_interval_ms;
         let metrics_recorder = get_metrics_recorder().clone();
-        let lag_consumer = Self::create_consumer(
+        // Wrap the lag consumer so its rd_kafka_destroy is deferred to a
+        // blocking thread on drop, instead of running inline on a tokio worker
+        // (the documented deadlock the main consumer is already protected from).
+        let lag_consumer = SafeKafkaConsumer::new(Self::create_consumer(
             &self.kafka_config,
             &self.start_at,
             &self.reference_name,
             true,
-        );
+        ));
         let topic = self.topic.clone();
         let stall_watchdog_timeout = Duration::from_secs(Self::stall_watchdog_timeout_sec());
         builder.spawn(async move {

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -1671,7 +1671,15 @@ impl ExecutionPlan for KafkaSourceExec {
 
                                 consumer_offsets.remove(&epoch);
                             } else {
-                                error!("No position found for epoch: {:?}", epoch);
+                                // Expected for epochs whose Marker never reached this
+                                // source — notably the terminal epoch, whose Marker
+                                // travels inline to the sinks only. Commits are
+                                // cumulative, so a missed epoch never loses data; the
+                                // uncommitted tail replays on restart (at-least-once).
+                                debug!(
+                                    "No recorded position for finalized epoch {:?}; skipping commit (cumulative commits make this safe)",
+                                    epoch
+                                );
                             }
                         }
                         CheckpointMessage::SourceComplete(name) => {

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -1420,9 +1420,12 @@ impl ExecutionPlan for KafkaSourceExec {
                 // A shutdown requested before this iteration started (e.g.
                 // before the first poll, or while sending the previous batch)
                 // would not wake `changed()` below — the subscription has
-                // already observed the value. Check it explicitly; nothing is
-                // buffered at the top of an iteration, so exiting here drops
-                // no data.
+                // already observed the value. Check it explicitly. No DATA is
+                // buffered at the top of an iteration, but
+                // `checkpoint_messages_buffer` may hold Markers/Finalizers
+                // that arrived after the last batch was built (they ride the
+                // NEXT batch, which never comes) — the post-loop flush below
+                // delivers them on a synthetic batch.
                 if drain_and_stop || *global_shutdown_rx.borrow() {
                     info!("Kafka source '{}': shutdown requested; stopping", reference_name);
                     break 'outer;
@@ -1704,6 +1707,29 @@ impl ExecutionPlan for KafkaSourceExec {
                     }
                 }
                 metrics_recorder.record_elapsed_compute(outer_loop_start_at.elapsed(), metric_metadata_id.as_str());
+            }
+
+            // Flush any checkpoint messages buffered to ride the next batch —
+            // no exit path from the loop above produces one. Without this, a
+            // Marker/Finalizer that arrived after the last batch was built is
+            // silently dropped: the sinks never see it, the epoch cannot
+            // collect this branch's acks, and its offsets are never committed
+            // before teardown (replayed on restart, but the clean drain is
+            // lost). Mirrors the end-of-stream flush in the ClickHouse and
+            // hybrid sources.
+            {
+                let flush_batch = crate::table_providers::clickhouse::build_checkpoint_flush_batch(
+                    &mut checkpoint_messages_buffer,
+                    full_schema.clone(),
+                );
+                if let Some(batch) = flush_batch
+                    && tx.send(Ok(batch)).await.is_err()
+                {
+                    warn!(
+                        "Kafka source '{}': receiver dropped before final checkpoint flush",
+                        reference_name
+                    );
+                }
             }
 
             info!("Shutting down Kafka consumer: unsubscribing and unassigning");

--- a/crates/streamling-connectors/src/table_providers/postgres/batch_processor.rs
+++ b/crates/streamling-connectors/src/table_providers/postgres/batch_processor.rs
@@ -120,11 +120,13 @@ async fn process_checkpoint_messages_with_truncation(
                 );
 
                 let sink_id = get_reference_name_from_metric_key(&context.metric_metadata_id);
-                send(
+                // Best-effort: during shutdown a source may have dropped its
+                // channel receiver already; a failed ack broadcast must not
+                // panic the sink mid-drain (the epoch simply never finalizes).
+                let _ = send(
                     CHECKPOINT_COORDINATOR_CHANNEL,
                     CheckpointMessage::Ack { epoch, sink_id },
-                )
-                .unwrap();
+                );
 
                 // Record sink flush time (time from batch arrival to ack sent)
                 context.metrics_recorder.record_time(

--- a/crates/streamling-connectors/src/table_providers/postgres/batch_processor.rs
+++ b/crates/streamling-connectors/src/table_providers/postgres/batch_processor.rs
@@ -151,9 +151,9 @@ async fn execute_insert_slice(
     context: &BatchProcessorContext,
     slice: &RecordBatch,
     epoch_for_rows: Option<u64>,
-) {
+) -> streamling_core::error::Result<()> {
     if slice.num_rows() == 0 {
-        return;
+        return Ok(());
     }
 
     let query = PostgresQueryBuilder::build_complete_upsert_query(
@@ -189,13 +189,16 @@ async fn execute_insert_slice(
         epoch_for_rows,
         context.client_statement_timeout,
     )
-    .await;
+    .await
 }
 
 /// Execute a DELETE for a single slice of a RecordBatch
-async fn execute_delete_slice(context: &BatchProcessorContext, slice: &RecordBatch) {
+async fn execute_delete_slice(
+    context: &BatchProcessorContext,
+    slice: &RecordBatch,
+) -> streamling_core::error::Result<()> {
     if slice.num_rows() == 0 {
-        return;
+        return Ok(());
     }
 
     let query = PostgresQueryBuilder::build_delete_query(
@@ -224,7 +227,7 @@ async fn execute_delete_slice(context: &BatchProcessorContext, slice: &RecordBat
         &sink_ctx,
         context.client_statement_timeout,
     )
-    .await;
+    .await
 }
 
 /// Process a single batch and return whether to continue processing.
@@ -283,13 +286,11 @@ pub async fn process_batch(context: &BatchProcessorContext, batch: RecordBatch) 
                 let ctx = context.clone();
                 move |slice| {
                     let ctx = ctx.clone();
-                    async move {
-                        execute_insert_slice(&ctx, &slice, epoch_for_rows).await;
-                    }
+                    async move { execute_insert_slice(&ctx, &slice, epoch_for_rows).await }
                 }
             },
         )
-        .await;
+        .await?;
     } else {
         // Normal mode: Split by _gs_op and process inserts/updates vs deletes separately
         // Get _gs_op column to identify delete operations
@@ -330,13 +331,11 @@ pub async fn process_batch(context: &BatchProcessorContext, batch: RecordBatch) 
                     let ctx = context.clone();
                     move |slice| {
                         let ctx = ctx.clone();
-                        async move {
-                            execute_insert_slice(&ctx, &slice, epoch_for_rows).await;
-                        }
+                        async move { execute_insert_slice(&ctx, &slice, epoch_for_rows).await }
                     }
                 },
             )
-            .await;
+            .await?;
         }
 
         // Process deletes
@@ -351,13 +350,11 @@ pub async fn process_batch(context: &BatchProcessorContext, batch: RecordBatch) 
                     let ctx = context.clone();
                     move |slice| {
                         let ctx = ctx.clone();
-                        async move {
-                            execute_delete_slice(&ctx, &slice).await;
-                        }
+                        async move { execute_delete_slice(&ctx, &slice).await }
                     }
                 },
             )
-            .await;
+            .await?;
         }
     }
 

--- a/crates/streamling-connectors/src/table_providers/postgres/execution.rs
+++ b/crates/streamling-connectors/src/table_providers/postgres/execution.rs
@@ -1,8 +1,9 @@
 use datafusion::arrow::array::Array;
 use std::sync::Arc;
 use std::time::Duration;
-use streamling_core::error::ResultExt;
-use streamling_core::retry::retry_forever_with_backoff_async;
+use streamling_core::error::{Result, ResultExt};
+use streamling_core::retry::{RetryOutcome, retry_forever_with_backoff_until_cancelled};
+use streamling_core::streamling_err;
 use streamling_core::utils::pg::execute_bounded;
 
 use crate::table_providers::postgres::value_binding;
@@ -15,9 +16,11 @@ pub struct SinkContext {
     pub table_name: String,
 }
 
-/// Execute a batch insert query with retry logic
-/// Never returns an error as retries continue indefinitely until success
-/// If checkpoint_epoch is provided, binds the epoch value for each row
+/// Execute a batch insert query with retry logic.
+/// Retries indefinitely until success — unless process shutdown is requested,
+/// in which case it stops between attempts and returns an error so the sink
+/// fails instead of acking a checkpoint for data that was never written.
+/// If checkpoint_epoch is provided, binds the epoch value for each row.
 pub async fn execute_batch_insert(
     pool: &sqlx::PgPool,
     query: &str,
@@ -27,7 +30,7 @@ pub async fn execute_batch_insert(
     ctx: &SinkContext,
     checkpoint_epoch: Option<u64>,
     client_statement_timeout: Option<Duration>,
-) {
+) -> Result<()> {
     let query = query.to_string();
     let pool = pool.clone();
     let batch_columns: Vec<_> = batch_columns.to_vec();
@@ -38,7 +41,8 @@ pub async fn execute_batch_insert(
         ctx.schema_name, ctx.table_name, ctx.sink_name
     );
 
-    retry_forever_with_backoff_async(
+    let mut shutdown = streamling_core::shutdown::subscribe();
+    let outcome = retry_forever_with_backoff_until_cancelled(
         move || {
             let query = query.clone();
             let pool = pool.clone();
@@ -65,12 +69,23 @@ pub async fn execute_batch_insert(
             }
         },
         &operation_name,
+        &mut shutdown,
     )
-    .await
+    .await;
+
+    match outcome {
+        RetryOutcome::Completed => Ok(()),
+        RetryOutcome::Cancelled => Err(streamling_err!(
+            "{} aborted: shutdown requested before the write succeeded",
+            operation_name
+        )),
+    }
 }
 
-/// Execute a batch delete query with retry logic
-/// Never returns an error as retries continue indefinitely until success
+/// Execute a batch delete query with retry logic.
+/// Retries indefinitely until success — unless process shutdown is requested,
+/// in which case it stops between attempts and returns an error so the sink
+/// fails instead of acking a checkpoint for a delete that never applied.
 pub async fn execute_batch_delete(
     pool: &sqlx::PgPool,
     query: &str,
@@ -79,7 +94,7 @@ pub async fn execute_batch_delete(
     num_rows: usize,
     ctx: &SinkContext,
     client_statement_timeout: Option<Duration>,
-) {
+) -> Result<()> {
     let query = query.to_string();
     let pool = pool.clone();
     let batch_columns: Vec<_> = batch_columns.to_vec();
@@ -90,7 +105,8 @@ pub async fn execute_batch_delete(
         ctx.schema_name, ctx.table_name, ctx.sink_name
     );
 
-    retry_forever_with_backoff_async(
+    let mut shutdown = streamling_core::shutdown::subscribe();
+    let outcome = retry_forever_with_backoff_until_cancelled(
         move || {
             let query = query.clone();
             let pool = pool.clone();
@@ -113,8 +129,17 @@ pub async fn execute_batch_delete(
             }
         },
         &operation_name,
+        &mut shutdown,
     )
-    .await
+    .await;
+
+    match outcome {
+        RetryOutcome::Completed => Ok(()),
+        RetryOutcome::Cancelled => Err(streamling_err!(
+            "{} aborted: shutdown requested before the delete succeeded",
+            operation_name
+        )),
+    }
 }
 
 // Note: Comprehensive testing of batch execution is done via integration tests

--- a/crates/streamling-connectors/src/table_providers/util/parallel.rs
+++ b/crates/streamling-connectors/src/table_providers/util/parallel.rs
@@ -10,18 +10,23 @@ use std::sync::Arc;
 /// - `execute_fn`: Async function called once per slice
 ///
 /// Slices are formed as equally as possible using ceil(max_total_rows / parallelism).
+///
+/// All slices run to completion; if any slice fails, the first error is
+/// returned so the caller can propagate it (e.g. a write cancelled by
+/// shutdown must fail the sink instead of silently acking a checkpoint).
 pub async fn parallel_execute<F, Fut>(
     batch: &RecordBatch,
     parallelism: usize,
     min_batch_e: usize,
     execute_fn: F,
-) where
+) -> streamling_core::error::Result<()>
+where
     F: Fn(RecordBatch) -> Fut + Send + Sync + 'static,
-    Fut: std::future::Future<Output = ()> + Send + 'static,
+    Fut: std::future::Future<Output = streamling_core::error::Result<()>> + Send + 'static,
 {
     let total_rows = batch.num_rows();
     if total_rows == 0 {
-        return;
+        return Ok(());
     }
 
     let max_workers = parallelism.max(1);
@@ -45,10 +50,14 @@ pub async fn parallel_execute<F, Fut>(
         (func)(slice)
     });
 
-    let _ = tasks
+    let results = tasks
         .buffer_unordered(effective_workers)
         .collect::<Vec<_>>()
         .await;
+    for result in results {
+        result?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -77,13 +86,22 @@ mod tests {
         .unwrap()
     }
 
-    async fn inc_seen_assert(seen: Arc<AtomicUsize>, slice: RecordBatch, shard_cap: usize) {
+    async fn inc_seen_assert(
+        seen: Arc<AtomicUsize>,
+        slice: RecordBatch,
+        shard_cap: usize,
+    ) -> streamling_core::error::Result<()> {
         assert!(slice.num_rows() <= shard_cap);
         seen.fetch_add(slice.num_rows(), std::sync::atomic::Ordering::SeqCst);
+        Ok(())
     }
 
-    async fn inc_seen(seen: Arc<AtomicUsize>, slice: RecordBatch) {
+    async fn inc_seen(
+        seen: Arc<AtomicUsize>,
+        slice: RecordBatch,
+    ) -> streamling_core::error::Result<()> {
         seen.fetch_add(slice.num_rows(), std::sync::atomic::Ordering::SeqCst);
+        Ok(())
     }
 
     #[tokio::test]
@@ -97,7 +115,8 @@ mod tests {
             let seen = seen.clone();
             move |slice| inc_seen_assert(seen.clone(), slice, shard_cap)
         })
-        .await;
+        .await
+        .unwrap();
 
         assert_eq!(seen.load(Ordering::SeqCst), 1000);
     }
@@ -113,7 +132,8 @@ mod tests {
             let seen = seen.clone();
             move |slice| inc_seen_assert(seen.clone(), slice, shard_cap)
         })
-        .await;
+        .await
+        .unwrap();
 
         assert_eq!(seen.load(Ordering::SeqCst), 1025);
     }
@@ -128,7 +148,8 @@ mod tests {
             let seen = seen.clone();
             move |slice| inc_seen(seen.clone(), slice)
         })
-        .await;
+        .await
+        .unwrap();
 
         assert_eq!(seen.load(Ordering::SeqCst), 10);
     }
@@ -149,10 +170,12 @@ mod tests {
                 async move {
                     seen.fetch_add(slice.num_rows(), Ordering::SeqCst);
                     count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
                 }
             }
         })
-        .await;
+        .await
+        .unwrap();
 
         assert_eq!(seen.load(Ordering::SeqCst), 10);
         assert_eq!(count.load(Ordering::SeqCst), 1);

--- a/crates/streamling-connectors/src/table_providers/util/parallel.rs
+++ b/crates/streamling-connectors/src/table_providers/util/parallel.rs
@@ -54,10 +54,21 @@ where
         .buffer_unordered(effective_workers)
         .collect::<Vec<_>>()
         .await;
+    let mut first_error = None;
     for result in results {
-        result?;
+        if let Err(e) = result {
+            // Log every slice failure (not just the one we return) so a
+            // backend rejecting several slices in one batch stays diagnosable.
+            tracing::warn!("parallel_execute: slice failed: {}", e);
+            if first_error.is_none() {
+                first_error = Some(e);
+            }
+        }
     }
-    Ok(())
+    match first_error {
+        None => Ok(()),
+        Some(e) => Err(e),
+    }
 }
 
 #[cfg(test)]

--- a/crates/streamling-core/Cargo.toml
+++ b/crates/streamling-core/Cargo.toml
@@ -89,3 +89,4 @@ paste.workspace = true
 [dev-dependencies]
 rand.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
+serial_test.workspace = true

--- a/crates/streamling-core/src/checkpoints/channels.rs
+++ b/crates/streamling-core/src/checkpoints/channels.rs
@@ -73,7 +73,16 @@ pub fn unsubscribe(id: &str, subscriber_id: SubscriberId) {
 }
 
 /// Send a checkpoint message to all subscribers of the checkpoint channel using the reference name of the operator.
-/// Returns the number of successful sends. Receivers are only removed if a SourceComplete message is received.
+/// Returns the number of successful sends.
+///
+/// The broadcast always attempts EVERY subscriber: a dead one (receiver
+/// dropped without `unsubscribe`) is pruned and the remaining live subscribers
+/// still receive the message. This used to early-return on the first dead
+/// subscriber for non-completed sources, which silently starved every
+/// subscriber later in the (arbitrary) iteration order of Markers/Acks/
+/// Finalizers the moment any component exited uncleanly during shutdown.
+/// Dead subscribers on a source not marked complete are logged, since they
+/// indicate a component that dropped its receiver without unsubscribing.
 pub fn send(
     id: &str,
     message: CheckpointMessage,
@@ -94,19 +103,21 @@ pub fn send(
         for (subscriber_id, sender) in senders.iter() {
             match sender.send(message.clone()) {
                 Ok(()) => successful_sends += 1,
-                Err(e) => {
-                    // Only remove receivers if this source has been marked as completed
-                    if is_completed {
-                        disconnected_ids.push(*subscriber_id);
-                    } else {
-                        // For sources not yet completed, raise the error
-                        return Err(e);
-                    }
-                }
+                Err(_) => disconnected_ids.push(*subscriber_id),
             }
         }
 
-        // Remove disconnected senders
+        // Prune disconnected senders: a dropped crossbeam receiver never comes
+        // back, so keeping the sender only makes every future broadcast fail
+        // against it.
+        if !disconnected_ids.is_empty() && !is_completed {
+            tracing::warn!(
+                "checkpoint channel '{}': pruned {} disconnected subscriber(s) mid-broadcast \
+                 (a component dropped its receiver without unsubscribing)",
+                id,
+                disconnected_ids.len()
+            );
+        }
         for subscriber_id in disconnected_ids {
             senders.remove(&subscriber_id);
         }
@@ -119,4 +130,47 @@ pub fn send(
     }
 
     Ok(successful_sends)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checkpoints::checkpoint_management::{CheckpointEpoch, CheckpointMessage};
+
+    #[test]
+    fn send_delivers_to_all_live_subscribers_despite_a_dead_one() {
+        // Three subscribers; the middle one drops its receiver WITHOUT
+        // unsubscribing (an unclean component exit). The broadcast must still
+        // deliver to both live subscribers — the old behaviour early-returned
+        // on the first dead sender it happened to iterate, silently starving
+        // whoever came after it.
+        let channel_id = "channels_test_partial_delivery";
+        let (rx_a, _id_a) = subscribe_with_id(channel_id);
+        let (rx_dead, _id_dead) = subscribe_with_id(channel_id);
+        let (rx_b, _id_b) = subscribe_with_id(channel_id);
+        drop(rx_dead);
+
+        let sent = send(
+            channel_id,
+            CheckpointMessage::Finalizer(CheckpointEpoch(99)),
+        )
+        .expect("broadcast must not fail because one subscriber died");
+        assert_eq!(sent, 2, "both live subscribers must receive the message");
+        assert!(matches!(
+            rx_a.try_recv(),
+            Ok(CheckpointMessage::Finalizer(CheckpointEpoch(99)))
+        ));
+        assert!(matches!(
+            rx_b.try_recv(),
+            Ok(CheckpointMessage::Finalizer(CheckpointEpoch(99)))
+        ));
+
+        // The dead subscriber was pruned: a second send reaches the same two.
+        let sent = send(
+            channel_id,
+            CheckpointMessage::Finalizer(CheckpointEpoch(100)),
+        )
+        .expect("broadcast must not fail after pruning");
+        assert_eq!(sent, 2);
+    }
 }

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -221,6 +221,14 @@ impl CheckpointControl {
         // Drop any in-flight timer epochs. The source is done producing data,
         // so their markers can no longer reach the sinks and they would never
         // finalize. The terminal epoch is the only one that matters now.
+        //
+        // Dropping a non-finalized epoch without broadcasting its Finalizer is
+        // safe: no consumer blocks waiting for a Finalizer — sinks ack Markers
+        // and treat Finalizers as best-effort commit/truncate signals, and the
+        // work those dropped epochs would have committed is re-covered by the
+        // terminal epoch's Finalizer. This also mirrors the timer producer,
+        // which has always cleared the previous epoch before inserting a new
+        // one.
         epochs.clear();
         let epoch_num = self.next_epoch.fetch_add(1, Ordering::SeqCst);
         let terminal = CheckpointEpoch(epoch_num);
@@ -1026,6 +1034,10 @@ mod tests {
 
         // No sink has acked the terminal marker yet, so the await must block.
         assert!(
+            !control.is_terminal_finalized(),
+            "terminal epoch must not be finalized before any sink acks"
+        );
+        assert!(
             tokio::time::timeout(
                 Duration::from_millis(150),
                 control.await_terminal_finalized()
@@ -1049,6 +1061,10 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), control.await_terminal_finalized())
             .await
             .expect("await_terminal_finalized must return once the terminal epoch finalizes");
+        assert!(
+            control.is_terminal_finalized(),
+            "is_terminal_finalized must report true once the terminal epoch finalizes"
+        );
 
         {
             let epochs = coordinator.epochs.lock();

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -242,6 +242,19 @@ impl CheckpointControl {
         // terminal epoch's Finalizer. This also mirrors the timer producer,
         // which has always cleared the previous epoch before inserting a new
         // one.
+        //
+        // Audited consumers (all fire-and-forget; none matches an exact epoch
+        // in a way that can stall):
+        // - Kafka source: exact-match offset lookup with a silent no-op on
+        //   miss; commits are cumulative, so the next finalized epoch covers
+        //   any skipped one (bounded replay, never a wait).
+        // - ClickHouse source: persists its CURRENT split state on any
+        //   Finalizer; a skipped epoch delays persistence to the next one.
+        // - Postgres sink: range truncation (`DELETE <= N-1`).
+        // - Plugin operators/sinks: Finalizers are forwarded to the plugin,
+        //   whose contract requires idempotent, non-blocking handling.
+        // Any FUTURE consumer must follow the same rule: never gate progress
+        // on receiving the Finalizer for one specific epoch.
         epochs.clear();
         let epoch_num = self.next_epoch.fetch_add(1, Ordering::SeqCst);
         let terminal = CheckpointEpoch(epoch_num);
@@ -401,13 +414,15 @@ impl CheckpointCoordinator {
                         );
 
                         // Warn if this sink_id is not in the expected list
-                        if !expected_sinks_sub.lock().contains(&sink_id) {
+                        {
                             let expected = expected_sinks_sub.lock();
-                            warn!(
-                                "Received ack from unexpected sink '{}' for epoch {} (expected: {:?})",
-                                sink_id, epoch.0, *expected
-                            );
-                            continue;
+                            if !expected.contains(&sink_id) {
+                                warn!(
+                                    "Received ack from unexpected sink '{}' for epoch {} (expected: {:?})",
+                                    sink_id, epoch.0, *expected
+                                );
+                                continue;
+                            }
                         }
 
                         // Record ack received metric
@@ -1136,6 +1151,53 @@ mod tests {
             matches!(epochs.get(&epoch), Some(EpochState::Finalized)),
             "epoch should finalize synchronously once the only outstanding sink completes"
         );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_failed_sink_keeps_epochs_stalled() {
+        // The inverse of sink completion: a sink that FAILED is deliberately
+        // NOT deregistered (the run loop only calls sink_completed on Ok), so
+        // an epoch it never acked must stay un-finalized — its missing acks
+        // are the coordinator's only signal that the data is not durable.
+        // Offsets must not commit; the watchdog bounds the resulting stall.
+        let mut coordinator = CheckpointCoordinator::with_timeout(300);
+        coordinator.start(
+            3600,
+            vec!["sink_ok_stall".to_string(), "sink_failed_stall".to_string()],
+        );
+        let control = coordinator.control();
+
+        let terminal = control.begin_terminal_checkpoint();
+
+        // The healthy sink acks; the failed sink never does and is never
+        // deregistered.
+        send(
+            CHECKPOINT_COORDINATOR_CHANNEL,
+            CheckpointMessage::Ack {
+                epoch: terminal.clone(),
+                sink_id: "sink_ok_stall".to_string(),
+            },
+        )
+        .unwrap();
+        control.sink_completed("sink_ok_stall");
+
+        // The terminal epoch must NOT finalize.
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(300),
+                control.await_terminal_finalized()
+            )
+            .await
+            .is_err(),
+            "an epoch missing a failed sink's ack must stay un-finalized"
+        );
+        assert!(
+            !control.is_terminal_finalized(),
+            "failed sink's epoch must not report finalized"
+        );
+
+        coordinator.stop().await;
     }
 
     #[test]

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -425,6 +425,33 @@ fn finalize_ready_epochs(
     newly_finalized
 }
 
+/// Collect the epochs a timeout sweep should remove: `Started`/`InProgress`
+/// epochs older than `timeout`, excluding the terminal epoch (its lifecycle
+/// is owned by the shutdown path's bounded wait, which must be able to
+/// observe it until that wait expires).
+///
+/// Extracted as a free function so the removal decision is unit-testable
+/// without driving the timeout task's sleep loop. The caller removes the
+/// returned epochs from the map under the same lock it used to build the
+/// snapshot.
+fn timed_out_epochs_to_remove(
+    epochs: &BTreeMap<CheckpointEpoch, EpochState>,
+    timeout: Duration,
+    terminal: Option<&CheckpointEpoch>,
+) -> Vec<CheckpointEpoch> {
+    epochs
+        .iter()
+        .filter_map(|(epoch, state)| match state {
+            EpochState::Started { created_at } | EpochState::InProgress { created_at, .. }
+                if created_at.elapsed() > timeout && Some(epoch) != terminal =>
+            {
+                Some(epoch.clone())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
 /// Record the current number of non-finalized epochs as a gauge metric.
 /// Acquires the epochs lock internally, so callers must NOT hold it.
 fn record_in_flight_gauge(
@@ -835,14 +862,34 @@ impl CheckpointCoordinator {
         });
         self.handles.push(producer_handle);
 
-        // Timeout checker task - periodically checks for stalled epochs
+        // Timeout checker task — periodically REMOVES stalled epochs so the
+        // timer producer (which waits for the newest epoch to finalize before
+        // minting the next one) can never wedge permanently on an epoch whose
+        // Marker was lost. A Marker is lost when the broadcast reaches no
+        // source subscriber — e.g. the producer's first interval fires while a
+        // large plan (many sources, plugin UDF compilation) is still being
+        // built, so no source `execute()` has subscribed yet. No batch ever
+        // carries that epoch's Marker, no sink can ack it, and without removal
+        // the producer waits on it forever while data continues to flow
+        // uncheckpointed. Removing the epoch restores liveness: the next
+        // minted epoch's Marker reaches the (by then live) subscribers and
+        // finalizes normally. Removal is safe under the Finalizer consumer
+        // contract at the top of this file: Finalizers can be skipped, and
+        // commit/cleanup semantics are cumulative, so the offsets a removed
+        // epoch covered stay uncommitted until the next finalized epoch covers
+        // them (at-least-once preserved). The terminal epoch is exempt — its
+        // lifecycle is owned by the shutdown path's bounded wait.
         let epochs = Arc::clone(&self.epochs);
         let running = Arc::clone(&self.running);
+        let terminal_epoch_for_timeout = Arc::clone(&self.terminal_epoch);
         let timeout_duration = Duration::from_secs(self.timeout_sec);
+        // Sweep at half the timeout, clamped to [1s, 30s] — 30s for the
+        // production default, sub-second-free short cadences for tests that
+        // construct the coordinator with a small timeout.
+        let check_interval = Duration::from_secs((self.timeout_sec / 2).clamp(1, 30));
 
         let timeout_handle = tokio::spawn(async move {
             let metrics_recorder = get_checkpoint_metrics_recorder();
-            let check_interval = Duration::from_secs(30); // Check every 30 seconds
             let poll_interval = Duration::from_millis(500); // Poll for shutdown frequently
 
             while running.load(Ordering::SeqCst) {
@@ -857,47 +904,45 @@ impl CheckpointCoordinator {
                     break;
                 }
 
-                // Collect and count in-flight under a single lock to avoid a race
-                // where the ack handler finalizes an epoch between these phases.
-                let timed_out_count = {
-                    let epochs_guard = epochs.lock();
-                    let timed_out: Vec<CheckpointEpoch> = epochs_guard
-                        .iter()
-                        .filter_map(|(epoch, state)| match state {
-                            EpochState::Started { created_at }
-                            | EpochState::InProgress { created_at, .. } => {
-                                if created_at.elapsed() > timeout_duration {
-                                    Some(epoch.clone())
-                                } else {
-                                    None
-                                }
-                            }
-                            EpochState::Finalized => None,
-                        })
-                        .collect();
+                // Lock discipline: take `terminal_epoch` alone and drop it
+                // before touching `epochs` (see the CheckpointControl lock
+                // notes — only `begin_terminal_checkpoint` may hold both).
+                let terminal: Option<CheckpointEpoch> =
+                    { terminal_epoch_for_timeout.lock().clone() };
 
+                // Collect, remove, and count in-flight under a single lock to
+                // avoid a race where the ack handler finalizes an epoch
+                // between these phases.
+                let (removed, in_flight) = {
+                    let mut epochs_guard = epochs.lock();
+                    let timed_out = timed_out_epochs_to_remove(
+                        &epochs_guard,
+                        timeout_duration,
+                        terminal.as_ref(),
+                    );
                     for epoch in &timed_out {
-                        warn!(
-                            "Checkpoint epoch {} timed out after {:?}",
-                            epoch.0, timeout_duration
-                        );
+                        epochs_guard.remove(epoch);
                     }
-
-                    let count = timed_out.len();
-
-                    // Compute in-flight while we still hold the lock
                     let in_flight = epochs_guard
                         .values()
                         .filter(|s| !matches!(s, EpochState::Finalized))
                         .count();
-                    metrics_recorder.record_gauge("checkpoint_epochs_in_flight", in_flight as u64);
-
-                    count
+                    (timed_out, in_flight)
                 };
+                metrics_recorder.record_gauge("checkpoint_epochs_in_flight", in_flight as u64);
 
-                if timed_out_count > 0 {
-                    metrics_recorder
-                        .record_count("checkpoint_epochs_failed", timed_out_count as u64);
+                for epoch in &removed {
+                    warn!(
+                        "Checkpoint epoch {} timed out after {:?}; removed so a fresh epoch can be \
+                         minted (its Marker may never have reached a live source — late acks for it \
+                         will be ignored, and its offsets stay uncommitted until the next finalized \
+                         epoch covers them)",
+                        epoch.0, timeout_duration
+                    );
+                }
+
+                if !removed.is_empty() {
+                    metrics_recorder.record_count("checkpoint_epochs_failed", removed.len() as u64);
                 }
             }
         });
@@ -1319,5 +1364,154 @@ mod tests {
             1,
             "only the single terminal epoch should exist"
         );
+    }
+
+    #[test]
+    fn test_timed_out_epochs_to_remove_selects_only_stale_non_terminal() {
+        let timeout = Duration::from_secs(60);
+        let stale = Instant::now() - Duration::from_secs(120);
+        let fresh = Instant::now();
+
+        let mut epochs: BTreeMap<CheckpointEpoch, EpochState> = BTreeMap::new();
+        epochs.insert(
+            CheckpointEpoch(1),
+            EpochState::Started { created_at: stale },
+        );
+        epochs.insert(
+            CheckpointEpoch(2),
+            EpochState::InProgress {
+                acked_sinks: HashSet::from(["a".to_string()]),
+                created_at: stale,
+            },
+        );
+        epochs.insert(
+            CheckpointEpoch(3),
+            EpochState::Started { created_at: fresh },
+        );
+        epochs.insert(CheckpointEpoch(4), EpochState::Finalized);
+        // Epoch 5 is stale but terminal — exempt: the shutdown path owns its
+        // (bounded) wait and must be able to observe it until that expires.
+        epochs.insert(
+            CheckpointEpoch(5),
+            EpochState::Started { created_at: stale },
+        );
+
+        let terminal = CheckpointEpoch(5);
+        let removed = timed_out_epochs_to_remove(&epochs, timeout, Some(&terminal));
+        assert_eq!(
+            removed,
+            vec![CheckpointEpoch(1), CheckpointEpoch(2)],
+            "stale Started and InProgress epochs are removed; fresh, finalized, \
+             and terminal epochs are kept"
+        );
+
+        let removed_no_terminal = timed_out_epochs_to_remove(&epochs, timeout, None);
+        assert_eq!(
+            removed_no_terminal,
+            vec![CheckpointEpoch(1), CheckpointEpoch(2), CheckpointEpoch(5)],
+            "without a terminal epoch, every stale epoch is removed"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_timeout_sweep_removes_stale_epoch_and_unwedges() {
+        // An epoch whose Marker never reached any source (broadcast before the
+        // sources subscribed) can never be acked. The timeout sweep must remove
+        // it so the producer's finalization wait unblocks, and a later epoch
+        // must still finalize normally through the regular ack path.
+        let mut coordinator = CheckpointCoordinator::with_timeout(1);
+        let stale_epoch = CheckpointEpoch(7);
+        {
+            let mut epochs = coordinator.epochs.lock();
+            epochs.insert(
+                stale_epoch.clone(),
+                EpochState::Started {
+                    created_at: Instant::now() - Duration::from_secs(5),
+                },
+            );
+        }
+
+        // Long producer interval: only the timeout sweep and the subscriber run.
+        coordinator.start(3600, vec!["expected_sink".to_string()]);
+
+        // Sweep cadence for timeout_sec=1 is 1s; give it two cycles.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            {
+                let epochs = coordinator.epochs.lock();
+                if !epochs.contains_key(&stale_epoch) {
+                    break;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "stale epoch was not removed by the timeout sweep"
+            );
+            sleep(Duration::from_millis(100)).await;
+        }
+
+        // The pipeline is un-wedged: a later epoch finalizes via a normal ack.
+        let next_epoch = CheckpointEpoch(8);
+        {
+            let mut epochs = coordinator.epochs.lock();
+            epochs.insert(
+                next_epoch.clone(),
+                EpochState::Started {
+                    created_at: Instant::now(),
+                },
+            );
+        }
+        send(
+            CHECKPOINT_COORDINATOR_CHANNEL,
+            CheckpointMessage::Ack {
+                epoch: next_epoch.clone(),
+                sink_id: "expected_sink".to_string(),
+            },
+        )
+        .unwrap();
+        sleep(Duration::from_millis(200)).await;
+        {
+            let epochs = coordinator.epochs.lock();
+            assert!(
+                matches!(epochs.get(&next_epoch), Some(EpochState::Finalized)),
+                "the epoch after a removed one must finalize normally"
+            );
+        }
+
+        coordinator.stop().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_timeout_sweep_never_removes_terminal_epoch() {
+        // The terminal epoch is exempt from timeout removal — the shutdown
+        // path's bounded wait owns its lifecycle.
+        let mut coordinator = CheckpointCoordinator::with_timeout(1);
+        let control = coordinator.control();
+        let terminal = control.begin_terminal_checkpoint();
+        {
+            // Age the terminal epoch far past the timeout.
+            let mut epochs = coordinator.epochs.lock();
+            epochs.insert(
+                terminal.clone(),
+                EpochState::Started {
+                    created_at: Instant::now() - Duration::from_secs(60),
+                },
+            );
+        }
+
+        coordinator.start(3600, vec!["expected_sink".to_string()]);
+        sleep(Duration::from_millis(2600)).await;
+
+        {
+            let epochs = coordinator.epochs.lock();
+            assert!(
+                epochs.contains_key(&terminal),
+                "terminal epoch must survive timeout sweeps"
+            );
+        }
+
+        coordinator.stop().await;
     }
 }

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -313,7 +313,10 @@ impl CheckpointControl {
             // Wake immediately on a finalization (every transition to
             // `Finalized` calls `notify_waiters`), with a coarse fallback poll
             // so an edge lost between the state check above and waiter
-            // registration can never wedge the wait.
+            // registration can never wedge the wait. 200ms is deliberate:
+            // rare enough to be free, and worst-case latency only applies to
+            // the lost-edge race — the notify path is the fast path. Don't
+            // tighten it into a busy-poll or widen it into drain latency.
             tokio::select! {
                 _ = self.finalized_notify.notified() => {}
                 _ = tokio::time::sleep(Duration::from_millis(200)) => {}

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -197,6 +197,12 @@ impl CheckpointControl {
             }
             expected.clone()
         };
+        // Deliberate relaxation: two sinks completing concurrently may each
+        // snapshot before the other's removal lands, so a snapshot can be
+        // stale-LARGER than the live set — `finalize_ready_epochs` then
+        // conservatively declines to finalize, and the other call (whose
+        // snapshot does reflect both removals) finishes the job. Snapshots are
+        // never stale-smaller, so nothing finalizes early.
         info!(
             "Sink completed: {} (removed from expected ack set, {} live sink(s) remain)",
             sink_id,
@@ -1170,10 +1176,15 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_sink_completion_unblocks_finalization_synchronous() {
         // Direct-state variant of the multi-source case with no coordinator
         // tasks running: an InProgress epoch acked by sink_b, waiting on sink_a,
         // must finalize synchronously the moment sink_a is marked completed.
+        // `#[serial]` because `sink_completed` broadcasts the Finalizer on the
+        // global coordinator channel — running in parallel with a
+        // channel-driving serial test would inject a spurious message into its
+        // subscription.
         let coordinator = CheckpointCoordinator::with_timeout(300);
         let epoch = CheckpointEpoch(1042);
 

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -1,4 +1,4 @@
-use crate::checkpoints::channels::{send, subscribe};
+use crate::checkpoints::channels::{SubscriberId, send, subscribe_with_id, unsubscribe};
 use crate::telemetry::recorder::{
     ControlPlaneMetricsRecorder, MetricsRecorder, get_control_plane_metrics_recorder,
 };
@@ -118,9 +118,174 @@ pub struct CheckpointCoordinator {
     /// Monotonically increasing epoch counter. Never reuses epoch numbers,
     /// even if previous epochs are removed due to timeout.
     next_epoch: Arc<AtomicU64>,
+    /// The sinks the coordinator waits on to ack an epoch before finalizing it.
+    /// Mutable so a sink whose upstream source has completed can be dropped
+    /// (via [`CheckpointControl::sink_completed`]) and stop blocking
+    /// finalization. Populated in [`CheckpointCoordinator::start`]; shared with
+    /// the subscriber/producer tasks and any [`CheckpointControl`] handle.
+    expected_sinks: Arc<Mutex<HashSet<String>>>,
+    /// Set once a terminal checkpoint has begun (a bounded source is completing
+    /// or a shutdown was requested). Gates the timer producer so it stops
+    /// issuing new epochs and never clears the terminal epoch out of the map.
+    terminal_started: Arc<AtomicBool>,
+    /// The terminal epoch, once begun. [`CheckpointControl::await_terminal_finalized`]
+    /// resolves when this epoch reaches `Finalized`.
+    terminal_epoch: Arc<Mutex<Option<CheckpointEpoch>>>,
     running: Arc<AtomicBool>,
     handles: Vec<tokio::task::JoinHandle<()>>,
+    /// Subscriber id for the coordinator's own channel subscription, so
+    /// [`CheckpointCoordinator::stop`] can unsubscribe and not leave a dead
+    /// sender in the global channel map.
+    subscriber_id: Option<SubscriberId>,
     timeout_sec: u64,
+}
+
+/// A cloneable handle for signalling checkpoint lifecycle events to the
+/// coordinator from outside its subscriber task — e.g. the pipeline run loop
+/// observing a sink future drain, or a bounded source completing. These are
+/// control-plane signals, so they are handle methods rather than
+/// `CheckpointMessage` variants: the on-the-wire protocol stays limited to
+/// data-plane markers, acks, and finalizers.
+#[derive(Clone)]
+pub struct CheckpointControl {
+    epochs: Arc<Mutex<BTreeMap<CheckpointEpoch, EpochState>>>,
+    expected_sinks: Arc<Mutex<HashSet<String>>>,
+    next_epoch: Arc<AtomicU64>,
+    terminal_started: Arc<AtomicBool>,
+    terminal_epoch: Arc<Mutex<Option<CheckpointEpoch>>>,
+}
+
+impl CheckpointControl {
+    /// Mark a sink as drained: it will never ack again, so drop it from the
+    /// expected-ack set and finalize any in-flight epoch the remaining live
+    /// sinks have already acked. Without this, an epoch waiting on a completed
+    /// sink — and any shutdown gated on finalization — blocks forever (the
+    /// multi-source completion case: one branch finishes while others run on).
+    pub fn sink_completed(&self, sink_id: &str) {
+        // Snapshot the remaining set and release its lock before touching
+        // `epochs`, so we never hold both locks at once. The subscriber/producer
+        // paths lock epochs-then-expected; taking only one lock at a time here
+        // keeps the lock order acyclic.
+        let expected_snapshot: HashSet<String> = {
+            let mut expected = self.expected_sinks.lock();
+            if !expected.remove(sink_id) {
+                // Unknown sink or already removed — nothing to do.
+                return;
+            }
+            expected.clone()
+        };
+        info!(
+            "Sink completed: {} (removed from expected ack set, {} live sink(s) remain)",
+            sink_id,
+            expected_snapshot.len()
+        );
+
+        let newly_finalized = finalize_ready_epochs(&self.epochs, &expected_snapshot);
+        if newly_finalized.is_empty() {
+            return;
+        }
+
+        let metrics_recorder = get_checkpoint_metrics_recorder();
+        for epoch in newly_finalized {
+            metrics_recorder.record_count("checkpoint_epochs_succeeded", 1);
+            metrics_recorder.record_count("checkpoint_finalizers_sent", 1);
+            info!("Epoch {} finalized after sink completion", epoch.0);
+            let _ = send(
+                CHECKPOINT_COORDINATOR_CHANNEL,
+                CheckpointMessage::Finalizer(epoch),
+            );
+        }
+        record_in_flight_gauge(&self.epochs, &metrics_recorder);
+    }
+
+    /// Begin the terminal checkpoint: the single final epoch a completing
+    /// bounded source (or the shutdown path) emits inline after the last data,
+    /// so the sinks flush and ack a checkpoint covering all of it before the
+    /// pipeline tears down. The caller must emit the returned epoch as a
+    /// `Marker` on a final (synthetic) batch so it flows to the sinks after the
+    /// last data.
+    ///
+    /// Setting `terminal_started` first, then minting and inserting under the
+    /// epochs lock, prevents the timer producer from clearing this epoch: the
+    /// producer re-checks `terminal_started` under the same lock before it
+    /// clears/inserts, so it can never race a fresh timer epoch over the
+    /// terminal one. Idempotent: a second call returns the existing terminal
+    /// epoch.
+    pub fn begin_terminal_checkpoint(&self) -> CheckpointEpoch {
+        self.terminal_started.store(true, Ordering::SeqCst);
+
+        let mut epochs = self.epochs.lock();
+        if let Some(existing) = self.terminal_epoch.lock().clone() {
+            return existing;
+        }
+        // Drop any in-flight timer epochs. The source is done producing data,
+        // so their markers can no longer reach the sinks and they would never
+        // finalize. The terminal epoch is the only one that matters now.
+        epochs.clear();
+        let epoch_num = self.next_epoch.fetch_add(1, Ordering::SeqCst);
+        let terminal = CheckpointEpoch(epoch_num);
+        epochs.insert(
+            terminal.clone(),
+            EpochState::Started {
+                created_at: Instant::now(),
+            },
+        );
+        *self.terminal_epoch.lock() = Some(terminal.clone());
+        info!("Begin terminal checkpoint: epoch {}", terminal.0);
+        terminal
+    }
+
+    /// Resolve once the terminal checkpoint has finalized (all live sinks
+    /// acked it). Returns immediately if no terminal checkpoint was begun.
+    pub async fn await_terminal_finalized(&self) {
+        loop {
+            let terminal = self.terminal_epoch.lock().clone();
+            match terminal {
+                None => return,
+                Some(epoch) => {
+                    if matches!(self.epochs.lock().get(&epoch), Some(EpochState::Finalized)) {
+                        return;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    /// Returns true if a terminal checkpoint was begun and has finalized.
+    pub fn is_terminal_finalized(&self) -> bool {
+        match self.terminal_epoch.lock().clone() {
+            None => false,
+            Some(epoch) => matches!(self.epochs.lock().get(&epoch), Some(EpochState::Finalized)),
+        }
+    }
+}
+
+/// Transition every non-finalized epoch that the given (already shrunk)
+/// expected-sink set has fully acked into `Finalized`, returning the epochs
+/// that newly finalized so the caller can broadcast their `Finalizer`.
+fn finalize_ready_epochs(
+    epochs: &Arc<Mutex<BTreeMap<CheckpointEpoch, EpochState>>>,
+    expected: &HashSet<String>,
+) -> Vec<CheckpointEpoch> {
+    let mut newly_finalized = Vec::new();
+    let mut epochs_guard = epochs.lock();
+    for (epoch, state) in epochs_guard.iter_mut() {
+        let is_complete = match state {
+            // A Started epoch has no acks yet; it can only be considered
+            // complete if no sinks remain to ack it at all.
+            EpochState::Started { .. } => expected.is_empty(),
+            EpochState::InProgress { acked_sinks, .. } => {
+                expected.iter().all(|s| acked_sinks.contains(s))
+            }
+            EpochState::Finalized => false,
+        };
+        if is_complete {
+            *state = EpochState::Finalized;
+            newly_finalized.push(epoch.clone());
+        }
+    }
+    newly_finalized
 }
 
 /// Record the current number of non-finalized epochs as a gauge metric.
@@ -149,9 +314,27 @@ impl CheckpointCoordinator {
         Self {
             epochs: Arc::new(Mutex::new(BTreeMap::new())),
             next_epoch: Arc::new(AtomicU64::new(1)),
+            expected_sinks: Arc::new(Mutex::new(HashSet::new())),
+            terminal_started: Arc::new(AtomicBool::new(false)),
+            terminal_epoch: Arc::new(Mutex::new(None)),
             running: Arc::new(AtomicBool::new(false)),
             handles: Vec::new(),
+            subscriber_id: None,
             timeout_sec,
+        }
+    }
+
+    /// Returns a cloneable control handle for signalling lifecycle events
+    /// (sink completion, beginning the terminal checkpoint) from outside the
+    /// coordinator's tasks. The handle shares the coordinator's state, so it is
+    /// valid before or after [`CheckpointCoordinator::start`].
+    pub fn control(&self) -> CheckpointControl {
+        CheckpointControl {
+            epochs: Arc::clone(&self.epochs),
+            expected_sinks: Arc::clone(&self.expected_sinks),
+            next_epoch: Arc::clone(&self.next_epoch),
+            terminal_started: Arc::clone(&self.terminal_started),
+            terminal_epoch: Arc::clone(&self.terminal_epoch),
         }
     }
 
@@ -164,9 +347,13 @@ impl CheckpointCoordinator {
 
         self.running.store(true, Ordering::SeqCst);
 
-        let expected_sinks = Arc::new(expected_sinks);
+        // Populate the shared expected-ack set in place (rather than replacing
+        // the Arc) so any control handle taken before `start` observes it.
+        *self.expected_sinks.lock() = expected_sinks.into_iter().collect();
+        let expected_sinks = Arc::clone(&self.expected_sinks);
 
-        let receiver = subscribe(CHECKPOINT_COORDINATOR_CHANNEL);
+        let (receiver, subscriber_id) = subscribe_with_id(CHECKPOINT_COORDINATOR_CHANNEL);
+        self.subscriber_id = Some(subscriber_id);
         let epochs = Arc::clone(&self.epochs);
         let running = Arc::clone(&self.running);
         let expected_sinks_sub = Arc::clone(&expected_sinks);
@@ -183,10 +370,11 @@ impl CheckpointCoordinator {
                         );
 
                         // Warn if this sink_id is not in the expected list
-                        if !expected_sinks_sub.contains(&sink_id) {
+                        if !expected_sinks_sub.lock().contains(&sink_id) {
+                            let expected = expected_sinks_sub.lock();
                             warn!(
                                 "Received ack from unexpected sink '{}' for epoch {} (expected: {:?})",
-                                sink_id, epoch.0, *expected_sinks_sub
+                                sink_id, epoch.0, *expected
                             );
                             continue;
                         }
@@ -221,6 +409,7 @@ impl CheckpointCoordinator {
                                         );
 
                                         let is_complete = expected_sinks_sub
+                                            .lock()
                                             .iter()
                                             .all(|s| acked_sinks.contains(s));
                                         if is_complete {
@@ -256,6 +445,7 @@ impl CheckpointCoordinator {
                                         );
 
                                         let is_complete = expected_sinks_sub
+                                            .lock()
                                             .iter()
                                             .all(|s| acked_sinks.contains(s));
                                         if is_complete {
@@ -317,6 +507,7 @@ impl CheckpointCoordinator {
         let running = Arc::clone(&self.running);
         let next_epoch_counter = Arc::clone(&self.next_epoch);
         let expected_sinks_prod = Arc::clone(&expected_sinks);
+        let terminal_started_prod = Arc::clone(&self.terminal_started);
 
         let producer_handle = tokio::spawn(async move {
             let metrics_recorder = get_checkpoint_metrics_recorder();
@@ -355,6 +546,15 @@ impl CheckpointCoordinator {
                     break;
                 }
 
+                // A terminal checkpoint has begun (a bounded source completed or
+                // shutdown was requested). Stop the timer producer: the terminal
+                // epoch is the only one that should exist now, and the source
+                // will not produce more data for a fresh timer marker to ride.
+                if terminal_started_prod.load(Ordering::SeqCst) {
+                    debug!("Terminal checkpoint started; stopping timer producer");
+                    break;
+                }
+
                 // Wait for previous epoch to be finalized before creating a new one
                 let finalization_start = Instant::now();
                 let mut last_log = Instant::now();
@@ -384,12 +584,15 @@ impl CheckpointCoordinator {
                                 match state {
                                     EpochState::InProgress { acked_sinks, .. } => {
                                         expected_sinks_prod
+                                            .lock()
                                             .iter()
                                             .filter(|s| !acked_sinks.contains(*s))
                                             .cloned()
                                             .collect()
                                     }
-                                    EpochState::Started { .. } => expected_sinks_prod.to_vec(),
+                                    EpochState::Started { .. } => {
+                                        expected_sinks_prod.lock().iter().cloned().collect()
+                                    }
                                     _ => vec![],
                                 }
                             } else {
@@ -428,14 +631,24 @@ impl CheckpointCoordinator {
 
                 let created_at = Instant::now();
                 let created_at_ms = now_ms();
-                let epoch_num = next_epoch_counter.fetch_add(1, Ordering::SeqCst);
-                let new_epoch = CheckpointEpoch(epoch_num);
-                {
+                // Mint and insert under the epochs lock, re-checking the terminal
+                // flag inside that same critical section. `begin_terminal_checkpoint`
+                // clears the map and inserts its own epoch under this lock, so this
+                // re-check guarantees we never clear the terminal epoch by racing a
+                // fresh timer epoch over it.
+                let new_epoch = {
                     let mut epochs_guard = epochs.lock();
+                    if terminal_started_prod.load(Ordering::SeqCst) {
+                        debug!("Terminal checkpoint started; stopping timer producer");
+                        break;
+                    }
+                    let epoch_num = next_epoch_counter.fetch_add(1, Ordering::SeqCst);
+                    let new_epoch = CheckpointEpoch(epoch_num);
                     // Previous epoch is finalized; clear it before inserting the new one
                     epochs_guard.clear();
                     epochs_guard.insert(new_epoch.clone(), EpochState::Started { created_at });
-                }
+                    new_epoch
+                };
 
                 record_in_flight_gauge(&epochs, &metrics_recorder);
 
@@ -555,6 +768,13 @@ impl CheckpointCoordinator {
             let _ = handle.await;
         }
 
+        // The subscriber task has exited and dropped its receiver; remove the
+        // now-dead sender from the global channel map so later sends don't fail
+        // against it.
+        if let Some(subscriber_id) = self.subscriber_id.take() {
+            unsubscribe(CHECKPOINT_COORDINATOR_CHANNEL, subscriber_id);
+        }
+
         info!("Checkpoint coordinator stopped");
     }
 }
@@ -606,6 +826,7 @@ mod tests {
     use super::*;
     use arrow::array::Int32Array;
     use arrow::datatypes::{DataType, Field, Fields};
+    use serial_test::serial;
     use tokio::time::sleep;
 
     fn create_test_batch_with_metadata(
@@ -672,6 +893,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_unexpected_ack_does_not_finalize_epoch() {
         let mut coordinator = CheckpointCoordinator::with_timeout(300);
         let epoch = CheckpointEpoch(42);
@@ -724,5 +946,170 @@ mod tests {
         }
 
         coordinator.stop().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_sink_completion_unblocks_finalization() {
+        // Two sinks are expected. The epoch is acked by sink_b only, so it
+        // stays in progress waiting on sink_a. When sink_a's branch finishes (a
+        // bounded source completed), sink_a will never ack again. Marking it
+        // complete must remove it from the expected set and let the epoch
+        // finalize on the remaining live sink — otherwise the coordinator (and
+        // any shutdown gated on finalization) blocks forever.
+        let mut coordinator = CheckpointCoordinator::with_timeout(300);
+        let epoch = CheckpointEpoch(1042);
+
+        {
+            let mut epochs = coordinator.epochs.lock();
+            epochs.insert(
+                epoch.clone(),
+                EpochState::Started {
+                    created_at: Instant::now(),
+                },
+            );
+        }
+
+        coordinator.start(
+            3600,
+            vec!["sink_a_dereg".to_string(), "sink_b_dereg".to_string()],
+        );
+
+        // Only sink_b acks; epoch is now InProgress waiting on sink_a.
+        send(
+            CHECKPOINT_COORDINATOR_CHANNEL,
+            CheckpointMessage::Ack {
+                epoch: epoch.clone(),
+                sink_id: "sink_b_dereg".to_string(),
+            },
+        )
+        .unwrap();
+
+        sleep(Duration::from_millis(100)).await;
+
+        {
+            let epochs = coordinator.epochs.lock();
+            assert!(
+                matches!(epochs.get(&epoch), Some(EpochState::InProgress { .. })),
+                "epoch should still be in progress, waiting on sink_a"
+            );
+        }
+
+        // sink_a's branch finished and will never ack. Deregister it via the
+        // control handle (no checkpoint message involved).
+        coordinator.control().sink_completed("sink_a_dereg");
+
+        sleep(Duration::from_millis(100)).await;
+
+        {
+            let epochs = coordinator.epochs.lock();
+            assert!(
+                matches!(epochs.get(&epoch), Some(EpochState::Finalized)),
+                "epoch should finalize once the only outstanding sink completes"
+            );
+        }
+
+        coordinator.stop().await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_terminal_checkpoint_blocks_until_acked() {
+        // A bounded source, on completion, begins a terminal checkpoint and the
+        // pipeline must not tear down until that epoch finalizes. The await must
+        // block until the sink acks the terminal marker, then return.
+        let mut coordinator = CheckpointCoordinator::with_timeout(300);
+        coordinator.start(3600, vec!["sink_terminal".to_string()]);
+        let control = coordinator.control();
+
+        let terminal = control.begin_terminal_checkpoint();
+
+        // No sink has acked the terminal marker yet, so the await must block.
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(150),
+                control.await_terminal_finalized()
+            )
+            .await
+            .is_err(),
+            "await_terminal_finalized must block until the terminal epoch is acked"
+        );
+
+        // The sink processes the terminal marker, flushes, and acks.
+        send(
+            CHECKPOINT_COORDINATOR_CHANNEL,
+            CheckpointMessage::Ack {
+                epoch: terminal.clone(),
+                sink_id: "sink_terminal".to_string(),
+            },
+        )
+        .unwrap();
+
+        // Now the terminal checkpoint finalizes and the await returns.
+        tokio::time::timeout(Duration::from_secs(2), control.await_terminal_finalized())
+            .await
+            .expect("await_terminal_finalized must return once the terminal epoch finalizes");
+
+        {
+            let epochs = coordinator.epochs.lock();
+            assert!(
+                matches!(epochs.get(&terminal), Some(EpochState::Finalized)),
+                "terminal epoch should be finalized after the sink acks"
+            );
+        }
+
+        coordinator.stop().await;
+    }
+
+    #[test]
+    fn test_sink_completion_unblocks_finalization_synchronous() {
+        // Direct-state variant of the multi-source case with no coordinator
+        // tasks running: an InProgress epoch acked by sink_b, waiting on sink_a,
+        // must finalize synchronously the moment sink_a is marked completed.
+        let coordinator = CheckpointCoordinator::with_timeout(300);
+        let epoch = CheckpointEpoch(1042);
+
+        {
+            let mut expected = coordinator.expected_sinks.lock();
+            expected.insert("sink_a_dereg".to_string());
+            expected.insert("sink_b_dereg".to_string());
+        }
+
+        {
+            let mut epochs = coordinator.epochs.lock();
+            let mut acked_sinks = HashSet::new();
+            acked_sinks.insert("sink_b_dereg".to_string());
+            epochs.insert(
+                epoch.clone(),
+                EpochState::InProgress {
+                    acked_sinks,
+                    created_at: Instant::now(),
+                },
+            );
+        }
+
+        let control = coordinator.control();
+        control.sink_completed("sink_a_dereg");
+
+        let epochs = coordinator.epochs.lock();
+        assert!(
+            matches!(epochs.get(&epoch), Some(EpochState::Finalized)),
+            "epoch should finalize synchronously once the only outstanding sink completes"
+        );
+    }
+
+    #[test]
+    fn test_begin_terminal_checkpoint_is_idempotent() {
+        // A second begin returns the same terminal epoch and does not mint a new
+        // one (e.g. if both a bounded-completion path and the shutdown path fire).
+        let coordinator = CheckpointCoordinator::with_timeout(300);
+        let control = coordinator.control();
+
+        let first = control.begin_terminal_checkpoint();
+        let second = control.begin_terminal_checkpoint();
+        assert_eq!(first, second, "terminal epoch must be stable across calls");
+
+        let epochs = coordinator.epochs.lock();
+        assert_eq!(epochs.len(), 1, "only the single terminal epoch should exist");
     }
 }

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -73,14 +73,16 @@ pub fn process_checkpoint_acks(
                 Duration::from_millis(arrival_latency_ms),
                 metric_metadata_id,
             );
-            send(
+            // Best-effort: during shutdown a source may have dropped its
+            // channel receiver already; a failed broadcast must not panic the
+            // sink mid-drain.
+            let _ = send(
                 CHECKPOINT_COORDINATOR_CHANNEL,
                 CheckpointMessage::Ack {
                     epoch,
                     sink_id: sink_id.to_string(),
                 },
-            )
-            .unwrap();
+            );
             metrics_recorder.record_time(
                 "checkpoint_sink_flush",
                 ack_start.elapsed(),
@@ -528,11 +530,12 @@ impl CheckpointCoordinator {
                             metrics_recorder.record_count("checkpoint_finalizers_sent", 1);
 
                             info!("Epoch finalized: {}", epoch.0);
-                            send(
+                            // Best-effort: a receiver dropped during shutdown
+                            // must not panic the coordinator.
+                            let _ = send(
                                 CHECKPOINT_COORDINATOR_CHANNEL,
                                 CheckpointMessage::Finalizer(epoch),
-                            )
-                            .unwrap();
+                            );
                             finalized_notify_sub.notify_waiters();
 
                             record_in_flight_gauge(&epochs, &metrics_recorder);

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -26,6 +26,21 @@ pub struct CheckpointEpoch(pub u64);
 ///   Contains epoch and creation timestamp (ms since UNIX epoch) for propagation timing.
 /// - Ack: An acknowledgment for a checkpoint epoch. Sinks MUST flush/commit their state before sending this.
 /// - Finalizer: A message to finalize a checkpoint epoch. Should be used by sources/operators to flush/commit their state.
+///
+/// # Finalizer consumer contract (load-bearing — read before adding a connector)
+///
+/// Every Finalizer consumer MUST be idempotent and non-blocking, and MUST
+/// NEVER gate progress on receiving the Finalizer for one specific epoch:
+/// - Finalizers can be delivered more than once for the same epoch.
+/// - Finalizers can be SKIPPED entirely: the coordinator drops non-finalized
+///   timer epochs when a terminal checkpoint begins
+///   (`CheckpointControl::begin_terminal_checkpoint`), and a terminal epoch
+///   that never finalizes has its Finalizer withheld deliberately.
+/// - Commit/cleanup semantics must therefore be cumulative (offsets, current
+///   state snapshots) or range-based (`<= N-1` truncation), so a later
+///   Finalizer covers any skipped one.
+/// A consumer that waits for an exact epoch's Finalizer will wedge terminal
+/// checkpoints and hang shutdown.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum CheckpointMessage {
     Marker {

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -1110,6 +1110,10 @@ mod tests {
         assert_eq!(first, second, "terminal epoch must be stable across calls");
 
         let epochs = coordinator.epochs.lock();
-        assert_eq!(epochs.len(), 1, "only the single terminal epoch should exist");
+        assert_eq!(
+            epochs.len(),
+            1,
+            "only the single terminal epoch should exist"
+        );
     }
 }

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -226,6 +226,16 @@ impl CheckpointControl {
     /// clears/inserts, so it can never race a fresh timer epoch over the
     /// terminal one. Idempotent: a second call returns the existing terminal
     /// epoch.
+    ///
+    /// Known trade-off (multi-source completion): the FIRST completing source
+    /// stops the timer producer for the whole pipeline, so branches that are
+    /// still producing get no further periodic checkpoints — their tail's
+    /// durability rides entirely on the shared terminal epoch. A crash in that
+    /// window replays those branches from their last finalized epoch
+    /// (at-least-once preserved; the window is bounded by job length). Keeping
+    /// per-branch timer checkpoints alive would require per-branch epoch
+    /// tracking in the coordinator — a larger redesign deliberately out of
+    /// scope here (see shutdown-investigation.md §5.4).
     pub fn begin_terminal_checkpoint(&self) -> CheckpointEpoch {
         self.terminal_started.store(true, Ordering::SeqCst);
 

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -39,6 +39,7 @@ pub struct CheckpointEpoch(pub u64);
 /// - Commit/cleanup semantics must therefore be cumulative (offsets, current
 ///   state snapshots) or range-based (`<= N-1` truncation), so a later
 ///   Finalizer covers any skipped one.
+///
 /// A consumer that waits for an exact epoch's Finalizer will wedge terminal
 /// checkpoints and hang shutdown.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -299,6 +299,16 @@ impl CheckpointControl {
 
     /// Resolve once the terminal checkpoint has finalized (all live sinks
     /// acked it). Returns immediately if no terminal checkpoint was begun.
+    ///
+    /// Ordering requirement: this is "wait for the terminal checkpoint that
+    /// EXISTS", not "wait for one to appear" — a caller that races ahead of
+    /// [`Self::begin_terminal_checkpoint`] falls through the `None` arm and
+    /// skips the wait entirely. Callers must therefore hold the same
+    /// `CheckpointControl` that minted the terminal epoch and only await
+    /// AFTER `begin_terminal_checkpoint` returned (as the completion paths in
+    /// the hybrid provider do), or gate on a signal that implies it (as the
+    /// run loop does: it awaits only after every sink future drained, which a
+    /// bounded source's stream-end — and thus its `begin` call — precedes).
     pub async fn await_terminal_finalized(&self) {
         loop {
             let terminal = self.terminal_epoch.lock().clone();

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -131,6 +131,10 @@ pub struct CheckpointCoordinator {
     /// The terminal epoch, once begun. [`CheckpointControl::await_terminal_finalized`]
     /// resolves when this epoch reaches `Finalized`.
     terminal_epoch: Arc<Mutex<Option<CheckpointEpoch>>>,
+    /// Woken whenever any epoch transitions to `Finalized`, so
+    /// [`CheckpointControl::await_terminal_finalized`] wakes immediately
+    /// instead of polling.
+    finalized_notify: Arc<tokio::sync::Notify>,
     running: Arc<AtomicBool>,
     handles: Vec<tokio::task::JoinHandle<()>>,
     /// Subscriber id for the coordinator's own channel subscription, so
@@ -153,6 +157,7 @@ pub struct CheckpointControl {
     next_epoch: Arc<AtomicU64>,
     terminal_started: Arc<AtomicBool>,
     terminal_epoch: Arc<Mutex<Option<CheckpointEpoch>>>,
+    finalized_notify: Arc<tokio::sync::Notify>,
 }
 
 impl CheckpointControl {
@@ -185,6 +190,13 @@ impl CheckpointControl {
             return;
         }
 
+        // Single-sender guarantee: the transition to `Finalized` happens under
+        // the epochs lock (here in `finalize_ready_epochs`, or in the
+        // subscriber's ack arm), and only the path that performed the
+        // transition broadcasts the Finalizer — the ack arm no-ops on an
+        // already-`Finalized` epoch. Even if a duplicate ever slipped through,
+        // every Finalizer consumer is idempotent (offset commits, state saves,
+        // `DELETE <= N-1` truncation).
         let metrics_recorder = get_checkpoint_metrics_recorder();
         for epoch in newly_finalized {
             metrics_recorder.record_count("checkpoint_epochs_succeeded", 1);
@@ -195,6 +207,7 @@ impl CheckpointControl {
                 CheckpointMessage::Finalizer(epoch),
             );
         }
+        self.finalized_notify.notify_waiters();
         record_in_flight_gauge(&self.epochs, &metrics_recorder);
     }
 
@@ -256,7 +269,14 @@ impl CheckpointControl {
                     }
                 }
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            // Wake immediately on a finalization (every transition to
+            // `Finalized` calls `notify_waiters`), with a coarse fallback poll
+            // so an edge lost between the state check above and waiter
+            // registration can never wedge the wait.
+            tokio::select! {
+                _ = self.finalized_notify.notified() => {}
+                _ = tokio::time::sleep(Duration::from_millis(200)) => {}
+            }
         }
     }
 
@@ -325,6 +345,7 @@ impl CheckpointCoordinator {
             expected_sinks: Arc::new(Mutex::new(HashSet::new())),
             terminal_started: Arc::new(AtomicBool::new(false)),
             terminal_epoch: Arc::new(Mutex::new(None)),
+            finalized_notify: Arc::new(tokio::sync::Notify::new()),
             running: Arc::new(AtomicBool::new(false)),
             handles: Vec::new(),
             subscriber_id: None,
@@ -343,6 +364,7 @@ impl CheckpointCoordinator {
             next_epoch: Arc::clone(&self.next_epoch),
             terminal_started: Arc::clone(&self.terminal_started),
             terminal_epoch: Arc::clone(&self.terminal_epoch),
+            finalized_notify: Arc::clone(&self.finalized_notify),
         }
     }
 
@@ -365,6 +387,7 @@ impl CheckpointCoordinator {
         let epochs = Arc::clone(&self.epochs);
         let running = Arc::clone(&self.running);
         let expected_sinks_sub = Arc::clone(&expected_sinks);
+        let finalized_notify_sub = Arc::clone(&self.finalized_notify);
 
         let subscriber_handle = tokio::spawn(async move {
             let metrics_recorder = get_checkpoint_metrics_recorder();
@@ -489,6 +512,7 @@ impl CheckpointCoordinator {
                                 CheckpointMessage::Finalizer(epoch),
                             )
                             .unwrap();
+                            finalized_notify_sub.notify_waiters();
 
                             record_in_flight_gauge(&epochs, &metrics_recorder);
                         }

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -255,6 +255,11 @@ impl CheckpointControl {
     pub fn begin_terminal_checkpoint(&self) -> CheckpointEpoch {
         self.terminal_started.store(true, Ordering::SeqCst);
 
+        // Lock order: `epochs` then `terminal_epoch` — the ONE place both are
+        // held at once, which makes this order the pipeline-wide invariant.
+        // Every other path must either take `terminal_epoch` alone and drop it
+        // before touching `epochs` (see `await_terminal_finalized` /
+        // `is_terminal_finalized`), or nest inside `epochs` like here.
         let mut epochs = self.epochs.lock();
         if let Some(existing) = self.terminal_epoch.lock().clone() {
             return existing;

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -295,7 +295,13 @@ impl CheckpointControl {
 
     /// Returns true if a terminal checkpoint was begun and has finalized.
     pub fn is_terminal_finalized(&self) -> bool {
-        match self.terminal_epoch.lock().clone() {
+        // Bind (and drop) the terminal_epoch guard BEFORE locking epochs: a
+        // match-scrutinee temporary lives to the end of the match, which would
+        // acquire terminal_epoch -> epochs and invert
+        // begin_terminal_checkpoint's epochs -> terminal_epoch order (silent
+        // parking_lot deadlock). Same pattern as await_terminal_finalized.
+        let terminal = self.terminal_epoch.lock().clone();
+        match terminal {
             None => false,
             Some(epoch) => matches!(self.epochs.lock().get(&epoch), Some(EpochState::Finalized)),
         }

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -178,6 +178,14 @@ pub struct CheckpointControl {
     finalized_notify: Arc<tokio::sync::Notify>,
 }
 
+/// Lock discipline for [`CheckpointControl`]'s fields:
+/// `begin_terminal_checkpoint` is the only method allowed to hold `epochs`
+/// and `terminal_epoch` simultaneously (acquired in that order). Every other
+/// method takes ONE lock at a time, binding-and-dropping each guard before
+/// acquiring the next — see `is_terminal_finalized` for the match-scrutinee
+/// temporary that silently violates this. The subscriber/producer paths lock
+/// `epochs` then `expected_sinks`, so no method here may hold
+/// `expected_sinks` while acquiring `epochs`.
 impl CheckpointControl {
     /// Mark a sink as drained: it will never ack again, so drop it from the
     /// expected-ack set and finalize any in-flight epoch the remaining live
@@ -343,6 +351,36 @@ impl CheckpointControl {
                 _ = tokio::time::sleep(Duration::from_millis(200)) => {}
             }
         }
+    }
+
+    /// Sink ids still expected to ack the terminal epoch, sorted. Empty when
+    /// no terminal checkpoint was begun or it already finalized. Diagnostic
+    /// only — the answer can be stale by the time the caller logs it, so it
+    /// must not gate control flow.
+    pub fn pending_terminal_ack_sinks(&self) -> Vec<String> {
+        // One lock at a time (see the impl-level lock discipline): clone the
+        // terminal epoch, then the expected set, then inspect epochs.
+        let terminal = self.terminal_epoch.lock().clone();
+        let Some(epoch) = terminal else {
+            return Vec::new();
+        };
+        let expected: HashSet<String> = self.expected_sinks.lock().clone();
+        let mut pending: Vec<String> = {
+            let epochs = self.epochs.lock();
+            match epochs.get(&epoch) {
+                Some(EpochState::Finalized) => Vec::new(),
+                Some(EpochState::InProgress { acked_sinks, .. }) => expected
+                    .iter()
+                    .filter(|s| !acked_sinks.contains(*s))
+                    .cloned()
+                    .collect(),
+                // No acks yet (or the epoch is gone): every live sink is
+                // still outstanding.
+                Some(EpochState::Started { .. }) | None => expected.into_iter().collect(),
+            }
+        };
+        pending.sort();
+        pending
     }
 
     /// Returns true if a terminal checkpoint was begun and has finalized.

--- a/crates/streamling-core/src/lib.rs
+++ b/crates/streamling-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod retry;
 pub mod schema;
 pub mod serde;
 pub mod session;
+pub mod shutdown;
 pub mod side_output;
 pub mod sql_parse;
 pub mod telemetry;

--- a/crates/streamling-core/src/operators/broadcast.rs
+++ b/crates/streamling-core/src/operators/broadcast.rs
@@ -579,24 +579,38 @@ impl ExecutionPlan for MultiSinkExec {
         // failure as a stream error. `collect()` on this plan therefore
         // resolves only once all sinks have durably drained — which is what
         // the run loop's teardown ordering (and the shutdown drain guarantee)
-        // relies on.
+        // relies on. Note this means the plan's wall-clock now includes sink
+        // write latency (and any residual retry backoff), by design.
         let schema = self.schema();
         let output = async_stream::stream! {
             let mut out = output_consumer;
             while let Some(item) = futures::StreamExt::next(&mut out).await {
                 yield item;
             }
+            // Join ALL writers before yielding any failure: consumers like
+            // `collect()` stop pulling on the first error and drop this
+            // stream, and dropping it before the remaining handles are joined
+            // would abort the sibling writers mid-flush — the exact tail loss
+            // this gating exists to prevent. So: drain everyone first, then
+            // report the first failure.
+            let mut first_error: Option<datafusion::error::DataFusionError> = None;
             for handle in sink_handles {
-                match handle.await {
-                    Ok(Ok(())) => {}
-                    Ok(Err(e)) => yield Err(e),
-                    Err(join_err) => {
-                        yield Err(datafusion::error::DataFusionError::Execution(format!(
-                            "MultiSinkExec: sink writer task panicked: {}",
-                            join_err
-                        )));
+                let failure = match handle.await {
+                    Ok(Ok(())) => None,
+                    Ok(Err(e)) => Some(e),
+                    Err(join_err) => Some(datafusion::error::DataFusionError::Execution(
+                        format!("MultiSinkExec: sink writer task panicked: {}", join_err),
+                    )),
+                };
+                if let Some(e) = failure {
+                    tracing::warn!("MultiSinkExec: sink writer failed: {}", e);
+                    if first_error.is_none() {
+                        first_error = Some(e);
                     }
                 }
+            }
+            if let Some(e) = first_error {
+                yield Err(e);
             }
         };
 

--- a/crates/streamling-core/src/operators/broadcast.rs
+++ b/crates/streamling-core/src/operators/broadcast.rs
@@ -462,6 +462,15 @@ impl ExecutionPlan for MultiSinkExec {
 
         let total_sinks = self.sinks.len();
         let completed_sinks = Arc::new(Mutex::new(0));
+        // Handles for the per-sink writer tasks. The output stream below only
+        // ends after every one of these is joined: the tasks keep flushing
+        // their rebatched tails after the broadcast input ends, and completing
+        // the plan while they are still writing lets the pipeline start
+        // teardown (or exit) mid-flush — dropping the tail of every sink that
+        // didn't win the race (observed as ClickHouse receiving 0 rows in the
+        // multi-sink e2e test once shutdown began cancelling in-flight writes).
+        let mut sink_handles: Vec<tokio::task::JoinHandle<Result<()>>> =
+            Vec::with_capacity(total_sinks);
 
         for (i, sink) in self.sinks.iter().enumerate() {
             let sink = sink.clone();
@@ -476,7 +485,7 @@ impl ExecutionPlan for MultiSinkExec {
             let broadcast_stream = broadcast_stream.clone();
             let completed_sinks = completed_sinks.clone();
 
-            tokio::spawn(async move {
+            let handle = tokio::spawn(async move {
                 let data_sink_exec = sink
                     .downcast_ref::<DataSinkExec>()
                     .expect("MultiSinkExec: sink must be a DataSinkExec");
@@ -521,28 +530,43 @@ impl ExecutionPlan for MultiSinkExec {
                         .expect("Failed to execute sink input plan over broadcast data")
                 };
 
-                match data_sink.write_all(input_stream, &task_context).await {
-                    Ok(_) => {}
+                let write_result = data_sink.write_all(input_stream, &task_context).await;
+
+                // Count this sink as done on BOTH paths (success and failure)
+                // so the broadcast's all-sinks-completed stop can never stall
+                // on a failed sink.
+                {
+                    let mut count = completed_sinks.lock().await;
+                    *count += 1;
+                    if *count >= total_sinks {
+                        broadcast_stream.stop();
+                    }
+                }
+
+                match write_result {
+                    Ok(_) => {
+                        debug!("MultiSinkExec [{}]: Sink completed", sink_name);
+                        Ok(())
+                    }
                     Err(e) => {
+                        // Surface the failure as a plan error via the joined
+                        // handle below — previously this panicked inside a
+                        // detached task whose JoinHandle nobody awaited, so a
+                        // failed sink silently dropped out of the fan-out while
+                        // the pipeline kept running.
                         tracing::warn!(
                             "MultiSinkExec [{}]: Sink write_all failed: {}",
                             sink_name,
                             e
                         );
-                        panic!(
+                        Err(datafusion::error::DataFusionError::Execution(format!(
                             "MultiSinkExec [{}]: Sink write_all failed: {}",
                             sink_name, e
-                        );
+                        )))
                     }
                 }
-
-                debug!("MultiSinkExec [{}]: Sink completed", sink_name);
-                let mut count = completed_sinks.lock().await;
-                *count += 1;
-                if *count >= total_sinks {
-                    broadcast_stream.stop();
-                }
             });
+            sink_handles.push(handle);
         }
 
         let output_consumer = broadcast_stream.add_consumer();
@@ -550,7 +574,33 @@ impl ExecutionPlan for MultiSinkExec {
         // Start broadcasting after all consumers (sinks + output) are registered
         broadcast_stream.start(data);
 
-        Ok(Box::pin(output_consumer))
+        // Gate the plan's completion on every sink writer finishing: forward
+        // the output consumer, then join the writer tasks and surface any
+        // failure as a stream error. `collect()` on this plan therefore
+        // resolves only once all sinks have durably drained — which is what
+        // the run loop's teardown ordering (and the shutdown drain guarantee)
+        // relies on.
+        let schema = self.schema();
+        let output = async_stream::stream! {
+            let mut out = output_consumer;
+            while let Some(item) = futures::StreamExt::next(&mut out).await {
+                yield item;
+            }
+            for handle in sink_handles {
+                match handle.await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => yield Err(e),
+                    Err(join_err) => {
+                        yield Err(datafusion::error::DataFusionError::Execution(format!(
+                            "MultiSinkExec: sink writer task panicked: {}",
+                            join_err
+                        )));
+                    }
+                }
+            }
+        };
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, output)))
     }
 
     fn partition_statistics(&self, _partition: Option<usize>) -> Result<Arc<Statistics>> {

--- a/crates/streamling-core/src/operators/broadcast.rs
+++ b/crates/streamling-core/src/operators/broadcast.rs
@@ -581,6 +581,9 @@ impl ExecutionPlan for MultiSinkExec {
         // the run loop's teardown ordering (and the shutdown drain guarantee)
         // relies on. Note this means the plan's wall-clock now includes sink
         // write latency (and any residual retry backoff), by design.
+        // ASSUMPTION: downstream drains this stream to completion before
+        // dropping it (DataFusion's collect() does). Dropping it early skips
+        // the handle-join below and aborts in-flight sink writers mid-flush.
         let schema = self.schema();
         let output = async_stream::stream! {
             let mut out = output_consumer;

--- a/crates/streamling-core/src/plugin.rs
+++ b/crates/streamling-core/src/plugin.rs
@@ -12,7 +12,7 @@ use crate::data::COLUMN_NAME_OP;
 use crate::error::Result;
 use crate::telemetry::provider::metric_key;
 use crate::telemetry::recorder::merge_metadata_tags;
-use crate::{streamling_bail, streamling_err, streamling_user_bail, streamling_user_err};
+use crate::{streamling_err, streamling_user_bail, streamling_user_err};
 use abi_stable::StableAbi;
 use abi_stable::derive_macro_reexports::{NonExhaustive, TD_Opaque};
 use abi_stable::external_types::crossbeam_channel;
@@ -28,7 +28,6 @@ use std::fmt;
 use std::fmt::Debug;
 use std::path::Path;
 use std::pin::Pin;
-use std::sync::OnceLock;
 use std::sync::{Arc, RwLock};
 use streamling_plugin::r#async::{
     PluginAsyncRuntime, PluginAsyncRuntime_TO, PluginAsyncRuntimeObj,
@@ -39,7 +38,8 @@ pub use streamling_plugin::{
     PluginMsg, PluginOptions, PluginStateBackendConfig,
 };
 use tokio::runtime::Handle;
-use tracing::info;
+use std::time::Duration;
+use tracing::{info, warn};
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 struct PluginId {
@@ -89,8 +89,6 @@ lazy_static! {
         RwLock::new(HashMap::new());
 }
 
-static SHUTDOWN_WATCH_STARTED: OnceLock<()> = OnceLock::new();
-
 fn register_plugin_instance(instance_key: &str, channels: PluginChannels) {
     let mut reg = PLUGIN_INSTANCE_REGISTRY.write().unwrap();
     reg.insert(instance_key.to_string(), channels);
@@ -105,31 +103,6 @@ pub fn terminate_all_plugins() -> Result<()> {
     let ids: Vec<(String, PluginChannels)> = reg.drain().collect();
     drop(reg);
     terminate_plugins(ids)
-}
-
-fn start_shutdown_watcher_once() {
-    if SHUTDOWN_WATCH_STARTED.set(()).is_ok() {
-        tokio::spawn(async move {
-            #[cfg(unix)]
-            {
-                use tokio::signal::unix::{SignalKind, signal};
-                let mut sigterm =
-                    signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
-                let mut sigint =
-                    signal(SignalKind::interrupt()).expect("failed to install SIGINT handler");
-                tokio::select! {
-                    _ = sigterm.recv() => {},
-                    _ = sigint.recv() => {},
-                    _ = tokio::signal::ctrl_c() => {},
-                }
-            }
-            #[cfg(not(unix))]
-            {
-                let _ = tokio::signal::ctrl_c().await;
-            }
-            let _ = self::terminate_all_plugins();
-        });
-    }
 }
 
 #[repr(transparent)]
@@ -444,7 +417,6 @@ pub fn create_source_plugin(
         plugin_channels.clone(),
         Some(output_schema.into()),
     )?;
-    start_shutdown_watcher_once();
     register_plugin_instance(reference_name.as_str(), plugin_channels);
     merge_metadata_tags(
         &metric_key(&app_config.application_id, &reference_name),
@@ -498,7 +470,6 @@ pub fn create_transform_plugin(
         plugin_channels.clone(),
         Some(output_schema.into()),
     )?;
-    start_shutdown_watcher_once();
     register_plugin_instance(reference_name.as_str(), plugin_channels);
     merge_metadata_tags(
         &metric_key(&app_config.application_id, &reference_name),
@@ -546,7 +517,6 @@ pub fn create_sink_plugin(
         plugin_channels.clone(),
         None,
     )?;
-    start_shutdown_watcher_once();
     register_plugin_instance(reference_name.as_str(), plugin_channels);
     merge_metadata_tags(
         &metric_key(&app_config.application_id, &reference_name),
@@ -599,15 +569,25 @@ pub fn create_preprocessor_plugin(
 }
 
 pub fn terminate_plugins(plugins: Vec<(String, PluginChannels)>) -> Result<()> {
+    // Bound the send so a plugin whose input channel is full (a wedged
+    // dispatcher) cannot park this call — and thus the whole shutdown path —
+    // forever on a blocking crossbeam send. A failure to signal one plugin must
+    // not stop us from terminating the rest, so warn and continue rather than
+    // bailing; the host awaits the dispatchers afterwards and the shutdown
+    // watchdog is the final backstop.
+    const TERMINATE_SEND_TIMEOUT: Duration = Duration::from_secs(5);
     for (plugin_id, channels) in plugins {
         info!("Terminating plugin {}", plugin_id);
 
-        if let Err(e) = channels
-            .input
-            .sender
-            .send(NonExhaustive::new(PluginMsg::Terminate))
-        {
-            streamling_bail!("Failed to send termination message: {}", e);
+        if let Err(e) = channels.input.sender.send_timeout(
+            NonExhaustive::new(PluginMsg::Terminate),
+            TERMINATE_SEND_TIMEOUT,
+        ) {
+            warn!(
+                "Failed to send termination message to plugin {} within {:?}: {}. \
+                 Continuing to terminate remaining plugins.",
+                plugin_id, TERMINATE_SEND_TIMEOUT, e
+            );
         }
     }
 

--- a/crates/streamling-core/src/plugin.rs
+++ b/crates/streamling-core/src/plugin.rs
@@ -29,6 +29,7 @@ use std::fmt::Debug;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 use streamling_plugin::r#async::{
     PluginAsyncRuntime, PluginAsyncRuntime_TO, PluginAsyncRuntimeObj,
 };
@@ -38,7 +39,6 @@ pub use streamling_plugin::{
     PluginMsg, PluginOptions, PluginStateBackendConfig,
 };
 use tokio::runtime::Handle;
-use std::time::Duration;
 use tracing::{info, warn};
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]

--- a/crates/streamling-core/src/plugin/table_provider.rs
+++ b/crates/streamling-core/src/plugin/table_provider.rs
@@ -321,7 +321,26 @@ impl ExecutionPlan for PluginSourceExec {
                 }
             }
 
-            // Shutdown drain complete. Flush any checkpoint markers the plugin
+            // Shutdown drain complete. Coordinator messages still queued on
+            // our subscription never made the plugin round-trip (e.g. the
+            // terminal epoch's Marker, broadcast during the shutdown window).
+            // The plugin is about to be terminated, so forwarding them to it
+            // is pointless — but the SINKS still need to see the Marker for
+            // the epoch to collect acks and finalize. Fold them into the
+            // synthetic-final-batch flush below.
+            while let Ok(message) = checkpoint_receiver.try_recv() {
+                if let m @ (CheckpointMessage::Marker { .. } | CheckpointMessage::Finalizer(_)) =
+                    message
+                {
+                    debug!(
+                        "PluginSourceExec: attaching still-queued coordinator message to final flush: {:?}",
+                        m
+                    );
+                    checkpoint_buffer.push(m);
+                }
+            }
+
+            // Flush any checkpoint markers the plugin
             // emitted that never got a data batch to ride on, on a synthetic
             // empty batch, so the sinks can still ack their epochs before the
             // stream ends (the same shape as the hybrid source's pending-marker

--- a/crates/streamling-core/src/plugin/table_provider.rs
+++ b/crates/streamling-core/src/plugin/table_provider.rs
@@ -19,7 +19,7 @@ use futures::StreamExt;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 
-use crate::checkpoints::channels::{send, subscribe};
+use crate::checkpoints::channels::{send, subscribe_with_id, unsubscribe};
 use crate::operators::wrapping::WrappingDataSink;
 use crate::plugin::telemetry::process_plugin_metrics;
 use crate::telemetry::recorder::get_metrics_recorder;
@@ -33,7 +33,7 @@ use datafusion::physical_plan::stream::RecordBatchReceiverStreamBuilder;
 use std::sync::Arc;
 use streamling_plugin::{PluginChannels, PluginCheckpointEpoch, PluginMsg};
 use tracing::log::trace;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 #[derive(Debug)]
 struct PluginSourceExec {
@@ -118,7 +118,8 @@ impl ExecutionPlan for PluginSourceExec {
             .send(NonExhaustive::new(PluginMsg::Init))
             .unwrap();
 
-        let checkpoint_receiver = subscribe(CHECKPOINT_COORDINATOR_CHANNEL);
+        let (checkpoint_receiver, checkpoint_subscriber_id) =
+            subscribe_with_id(CHECKPOINT_COORDINATOR_CHANNEL);
 
         let plugin_input_sender = self.plugin_channels.input.sender.clone();
         let plugin_output_receiver = self.plugin_channels.output.receiver.clone();
@@ -133,6 +134,7 @@ impl ExecutionPlan for PluginSourceExec {
         let metrics_recorder = get_metrics_recorder();
         let metric_metadata_id = self.metric_metadata_id.clone();
         let projection = self.projection.clone();
+        let schema_for_flush = self.schema.clone();
 
         builder.spawn(async move {
             tokio::spawn(process_plugin_metrics(
@@ -149,9 +151,36 @@ impl ExecutionPlan for PluginSourceExec {
             let mut batches_with_markers: u64 = 0;
             let mut batches_without_markers: u64 = 0;
 
-            loop {
+            // Observe the process-wide shutdown signal so a plugin source stops
+            // producing and ends its stream (front-to-back drain), instead of
+            // emitting until the watchdog hard-exits. The plugin process itself
+            // keeps running until the run loop sends Terminate AFTER the sinks
+            // drain — here we only stop forwarding: drain the messages the
+            // plugin had already emitted at signal time (a snapshot, so a
+            // still-producing plugin cannot pin the drain), then end the
+            // stream so downstream sinks see stream-end and flush.
+            let shutdown_rx = crate::shutdown::subscribe();
+            // Some(n) once shutdown was observed: at most n more messages are
+            // forwarded before the stream ends.
+            let mut drain_remaining: Option<usize> = None;
+
+            'outer: loop {
                 loop {
+                    if drain_remaining.is_none() && *shutdown_rx.borrow() {
+                        let in_flight = plugin_output_receiver.len();
+                        info!(
+                            "PluginSourceExec: shutdown requested; draining {} in-flight plugin message(s), then ending stream",
+                            in_flight
+                        );
+                        drain_remaining = Some(in_flight);
+                    }
+                    if drain_remaining == Some(0) {
+                        break 'outer;
+                    }
                     if !plugin_output_receiver.is_empty() {
+                        if let Some(n) = drain_remaining.as_mut() {
+                            *n -= 1;
+                        }
                         if let Ok(message) = plugin_output_receiver.recv() {
                             match message.into_enum() {
                                 Ok(PluginMsg::NextBatch { data }) => {
@@ -168,6 +197,10 @@ impl ExecutionPlan for PluginSourceExec {
                                                     .send(Err(DataFusionError::from(e)
                                                         .context("projecting plugin source batch")))
                                                     .await;
+                                                unsubscribe(
+                                                    CHECKPOINT_COORDINATOR_CHANNEL,
+                                                    checkpoint_subscriber_id,
+                                                );
                                                 return Ok(());
                                             }
                                         };
@@ -286,6 +319,38 @@ impl ExecutionPlan for PluginSourceExec {
                     }
                 }
             }
+
+            // Shutdown drain complete. Flush any checkpoint markers the plugin
+            // emitted that never got a data batch to ride on, on a synthetic
+            // empty batch, so the sinks can still ack their epochs before the
+            // stream ends (the same shape as the hybrid source's pending-marker
+            // flush).
+            if !checkpoint_buffer.is_empty() {
+                info!(
+                    "PluginSourceExec: flushing {} pending checkpoint message(s) on a synthetic final batch",
+                    checkpoint_buffer.len()
+                );
+                let empty = RecordBatch::new_empty(schema_for_flush.clone());
+                let mut metadata = schema_for_flush.metadata().clone();
+                enrich_batch_metadata_with_checkpoints(&mut metadata, &checkpoint_buffer);
+                match enrich_batch_with_metadata(empty, metadata) {
+                    Ok(batch) => {
+                        if tx.send(Ok(batch)).await.is_err() {
+                            warn!(
+                                "PluginSourceExec: downstream closed before the synthetic final batch could be sent"
+                            );
+                        }
+                    }
+                    Err(e) => warn!(
+                        "PluginSourceExec: failed to build synthetic final batch: {:?}",
+                        e
+                    ),
+                }
+            }
+            // Drop our coordinator subscription cleanly so later broadcasts
+            // don't hit a dead sender.
+            unsubscribe(CHECKPOINT_COORDINATOR_CHANNEL, checkpoint_subscriber_id);
+            Ok(())
         });
 
         Ok(builder.build())

--- a/crates/streamling-core/src/plugin/table_provider.rs
+++ b/crates/streamling-core/src/plugin/table_provider.rs
@@ -456,6 +456,16 @@ impl DataSink for PluginSink {
                             "Sending extracted checkpoint Finalizer with epoch {} to plugin",
                             epoch.0
                         );
+                        // External plugins are bound by the Finalizer consumer
+                        // contract on `CheckpointMessage::Finalizer`: idempotent,
+                        // non-blocking, never gate on a specific epoch (during a
+                        // terminal checkpoint, in-flight timer epochs are dropped
+                        // without their Finalizers ever broadcasting). The host
+                        // cannot verify an out-of-repo plugin honors this; a
+                        // violating plugin stalls only its own dispatcher, which
+                        // the run loop awaits under the shutdown budget before
+                        // the watchdog hard-exits — it cannot wedge the process
+                        // past the grace period.
                         self.plugin_channels
                             .input
                             .sender

--- a/crates/streamling-core/src/plugin/table_provider.rs
+++ b/crates/streamling-core/src/plugin/table_provider.rs
@@ -113,11 +113,19 @@ impl ExecutionPlan for PluginSourceExec {
         _partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
+        // A disconnected input channel means the plugin already exited (e.g.
+        // it died during startup): surface an execution error instead of
+        // panicking the executor thread.
         self.plugin_channels
             .input
             .sender
             .send(NonExhaustive::new(PluginMsg::Init))
-            .unwrap();
+            .map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "plugin input channel closed before Init could be sent \
+                     (plugin exited early?): {e}"
+                ))
+            })?;
 
         let (checkpoint_receiver, checkpoint_subscriber_id) =
             subscribe_with_id(CHECKPOINT_COORDINATOR_CHANNEL);

--- a/crates/streamling-core/src/plugin/table_provider.rs
+++ b/crates/streamling-core/src/plugin/table_provider.rs
@@ -26,6 +26,7 @@ use crate::telemetry::recorder::get_metrics_recorder;
 use crate::topology::Telemetry;
 use crate::utils::metrics::metric_metadata_id_to_reference_name;
 use abi_stable::nonexhaustive_enum::NonExhaustive;
+use crossbeam::channel::TryRecvError;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
@@ -475,6 +476,57 @@ impl DataSink for PluginSink {
             self.metric_metadata_id.clone(),
         ));
 
+        // Forward plugin checkpoint acks to the coordinator independently of
+        // batch arrival. An ack lands on the plugin output channel only after
+        // the plugin's durable flush completes, and the terminal marker rides
+        // the LAST batch — so an ack drained only from inside the batch loop
+        // is never picked up: the loop is parked on a stream that ends only
+        // once the coordinator finalizes the terminal epoch, which needs this
+        // very ack. A dedicated task breaks that cycle. Same polling pattern
+        // as process_plugin_metrics (the channel is a sync crossbeam channel;
+        // a blocking recv() here would pin an executor thread); exits when the
+        // plugin output channel disconnects at plugin teardown.
+        let ack_receiver = self.plugin_channels.output.receiver.clone();
+        let sink_id = metric_metadata_id_to_reference_name(&self.metric_metadata_id)
+            .unwrap_or_else(|| self.metric_metadata_id.clone());
+        tokio::spawn(async move {
+            loop {
+                match ack_receiver.try_recv() {
+                    Ok(message) => match message.into_enum() {
+                        Ok(PluginMsg::CheckpointAck { epoch }) => {
+                            debug!(
+                                "Propagating checkpoint Ack with epoch {} from plugin",
+                                epoch.0
+                            );
+                            if let Err(e) = send(
+                                CHECKPOINT_COORDINATOR_CHANNEL,
+                                CheckpointMessage::Ack {
+                                    epoch: CheckpointEpoch(epoch.0),
+                                    sink_id: sink_id.clone(),
+                                },
+                            ) {
+                                warn!(
+                                    "Stopping plugin ack forwarder: coordinator channel rejected ack for epoch {}: {}",
+                                    epoch.0, e
+                                );
+                                break;
+                            }
+                        }
+                        _ => {
+                            warn!("Received unexpected message from plugin channel");
+                        }
+                    },
+                    Err(TryRecvError::Empty) => {
+                        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                    }
+                    Err(TryRecvError::Disconnected) => {
+                        debug!("Plugin output channel disconnected, stopping ack forwarder");
+                        break;
+                    }
+                }
+            }
+        });
+
         let mut row_count = 0;
 
         self.plugin_channels
@@ -545,35 +597,8 @@ impl DataSink for PluginSink {
                 }
             }
 
-            if !self.plugin_channels.output.receiver.is_empty()
-                && let Ok(message) = self.plugin_channels.output.receiver.recv()
-            {
-                match message.into_enum() {
-                    Ok(PluginMsg::CheckpointAck { epoch }) => {
-                        debug!(
-                            "Propagating checkpoint Ack with epoch {} from plugin",
-                            epoch.0
-                        );
-
-                        let sink_id =
-                            metric_metadata_id_to_reference_name(&self.metric_metadata_id)
-                                .unwrap_or_else(|| self.metric_metadata_id.clone());
-                        send(
-                            CHECKPOINT_COORDINATOR_CHANNEL,
-                            CheckpointMessage::Ack {
-                                epoch: CheckpointEpoch(epoch.0),
-                                sink_id,
-                            },
-                        )
-                        .unwrap();
-                    }
-                    _ => {
-                        warn!("Received unexpected message from plugin channel");
-                    }
-                }
-            }
-
-            // Metrics are now handled by a separate task spawned above
+            // Checkpoint acks and metrics are handled by the dedicated tasks
+            // spawned above — nothing to drain per-batch here.
 
             if let Some(num_records_before_stop) = self.num_records_before_stop
                 && row_count >= num_records_before_stop as usize
@@ -670,5 +695,120 @@ impl TableProvider for PluginSinkProvider {
             self.telemetry.as_ref(),
         ));
         Ok(Arc::new(DataSinkExec::new(input, telemetry_sink, None)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checkpoints::checkpoint_management::now_ms;
+    use abi_stable::external_types::crossbeam_channel as ffi_channel;
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::arrow::array::Int64Array;
+    use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+    use serial_test::serial;
+    use std::collections::HashMap;
+    use std::time::{Duration, Instant};
+    use streamling_plugin::ffi::{PluginChannel, PluginMetricsChannel};
+
+    fn test_channels() -> Arc<PluginChannels> {
+        Arc::new(PluginChannels {
+            input: PluginChannel::new(ffi_channel::bounded(64)),
+            output: PluginChannel::new(ffi_channel::bounded(64)),
+            metrics: PluginMetricsChannel::new(ffi_channel::bounded(64)),
+        })
+    }
+
+    /// Regression: in job mode the terminal checkpoint marker rides the LAST
+    /// batch, so the plugin's `CheckpointAck` lands on the output channel only
+    /// after `write_all`'s batch loop has already parked on the exhausted
+    /// stream. Ack propagation must therefore not be coupled to batch arrival:
+    /// the coordinator has to receive the ack even though no further batch
+    /// ever shows up (the upstream source is itself waiting on epoch
+    /// finalization before ending its stream).
+    ///
+    /// `#[serial]`: the coordinator channel is a process-wide global.
+    #[tokio::test]
+    #[serial]
+    async fn plugin_sink_forwards_ack_that_arrives_after_the_last_batch() {
+        let channels = test_channels();
+        let (coordinator_rx, coordinator_sub_id) =
+            subscribe_with_id(CHECKPOINT_COORDINATOR_CHANNEL);
+
+        // Fake plugin: consume the input channel; when the checkpoint marker
+        // arrives, ack it only after a delay — strictly after the sink's
+        // batch loop has seen stream end. Exits when the input channel closes.
+        let plugin_input_rx = channels.input.receiver.clone();
+        let plugin_output_tx = channels.output.sender.clone();
+        let fake_plugin = std::thread::spawn(move || {
+            while let Ok(msg) = plugin_input_rx.recv() {
+                if let Ok(PluginMsg::CheckpointMarker { epoch }) = msg.into_enum() {
+                    std::thread::sleep(Duration::from_millis(200));
+                    plugin_output_tx
+                        .send(NonExhaustive::new(PluginMsg::CheckpointAck { epoch }))
+                        .expect("test plugin failed to send ack");
+                    break;
+                }
+            }
+        });
+
+        // A single (final) batch carrying the terminal marker in its metadata.
+        let mut metadata = HashMap::new();
+        enrich_batch_metadata_with_checkpoints(
+            &mut metadata,
+            &[CheckpointMessage::Marker {
+                epoch: CheckpointEpoch(1),
+                created_at_ms: now_ms(),
+            }],
+        );
+        let schema = Arc::new(Schema::new_with_metadata(
+            vec![Field::new("id", DataType::Int64, false)],
+            metadata,
+        ));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int64Array::from(vec![1_i64]))],
+        )
+        .expect("failed to build test batch");
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            futures::stream::iter(vec![Ok(batch)]),
+        ));
+
+        let sink = PluginSink::new(
+            schema,
+            channels.clone(),
+            None,
+            "plugin::ack_after_last_batch_sink".to_string(),
+        );
+        let task_ctx = Arc::new(TaskContext::default());
+        let rows = tokio::time::timeout(Duration::from_secs(10), sink.write_all(stream, &task_ctx))
+            .await
+            .expect("write_all must complete once its input stream ends")
+            .expect("write_all failed");
+        assert_eq!(rows, 1);
+
+        // The ack must reach the coordinator even though no further batch
+        // arrives after the marker.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let (epoch, sink_id) = loop {
+            match coordinator_rx.try_recv() {
+                Ok(CheckpointMessage::Ack { epoch, sink_id }) => break (epoch, sink_id),
+                Ok(_) => {} // unrelated coordinator traffic
+                Err(_) => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "coordinator never received the plugin's checkpoint ack — \
+                         ack propagation is coupled to batch arrival again"
+                    );
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            }
+        };
+        assert_eq!(epoch, CheckpointEpoch(1));
+        assert_eq!(sink_id, "ack_after_last_batch_sink");
+
+        unsubscribe(CHECKPOINT_COORDINATOR_CHANNEL, coordinator_sub_id);
+        fake_plugin.join().expect("test plugin thread panicked");
     }
 }

--- a/crates/streamling-core/src/retry.rs
+++ b/crates/streamling-core/src/retry.rs
@@ -68,12 +68,15 @@ pub enum RetryOutcome {
 /// Like [`retry_forever_with_backoff_async`], but the loop gives up (returns
 /// [`RetryOutcome::Cancelled`]) when the shutdown watch flips to `true`.
 ///
-/// Cancellation is checked before the first attempt and during every backoff
-/// sleep, so a sink stuck retrying against a sick backend can no longer pin the
-/// drain forever — once shutdown is requested it stops between attempts. A
-/// single in-flight attempt is allowed to finish (or hit its own I/O timeout);
-/// callers relying on prompt cancellation must give each attempt a bounded
-/// timeout of its own.
+/// The FIRST attempt always runs, even when shutdown has already been
+/// requested: graceful drain means in-flight work still gets written — a sink
+/// flushing its final batches during shutdown must attempt the write, not
+/// abandon it (abandoning it is exactly the tail loss the drain exists to
+/// prevent). Cancellation is only checked during the backoff sleeps between
+/// attempts, so what shutdown cuts short is the infinite RE-try loop against a
+/// sick backend. A single in-flight attempt is allowed to finish (or hit its
+/// own I/O timeout); callers relying on prompt cancellation must give each
+/// attempt a bounded timeout of its own.
 pub async fn retry_forever_with_backoff_until_cancelled<Op, Fut>(
     mut operation: Op,
     operation_name: &str,
@@ -83,11 +86,6 @@ where
     Op: FnMut() -> Fut,
     Fut: core::future::Future<Output = Result<()>>,
 {
-    if *shutdown.borrow() {
-        warn!("{} not started: shutdown already requested", operation_name);
-        return RetryOutcome::Cancelled;
-    }
-
     let mut attempt: u32 = 0;
     let mut backoff_ms: u64 = INITIAL_BACKOFF_MS;
 
@@ -123,6 +121,16 @@ where
             }
         }
 
+        // Between attempts: give up if shutdown has been requested. The
+        // borrow check covers a watch that flipped before we got here (its
+        // `changed()` would never fire again).
+        if *shutdown.borrow() {
+            warn!(
+                "{} cancelled by shutdown after {} attempt(s)",
+                operation_name, attempt
+            );
+            return RetryOutcome::Cancelled;
+        }
         let jitter = (attempt as u64 % 100) * 7; // small deterministic jitter
         let sleep_ms = std::cmp::min(MAX_BACKOFF_MS, backoff_ms + jitter);
         tokio::select! {
@@ -429,12 +437,48 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_until_cancelled_returns_immediately_if_already_shutdown() {
+    async fn test_until_cancelled_first_attempt_runs_even_when_already_shutdown() {
+        // Graceful drain: work already in flight when shutdown is requested
+        // still gets its first attempt (a sink flushing final batches must
+        // write them, not abandon them). A successful first attempt completes.
         let (_tx, mut rx) = tokio::sync::watch::channel(true);
-        let operation = || async { Err::<(), _>(streamling_err!("should not be called")) };
+        let call_count = Arc::new(AtomicU32::new(0));
+        let cc = call_count.clone();
+        let operation = move || {
+            let count = cc.clone();
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        };
         let outcome =
             retry_forever_with_backoff_until_cancelled(operation, "test_cancel", &mut rx).await;
+        assert_eq!(outcome, RetryOutcome::Completed);
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_until_cancelled_no_retries_when_already_shutdown() {
+        // A FAILING first attempt is not retried once shutdown is requested:
+        // cancellation cuts the re-try loop, not the initial attempt.
+        let (_tx, mut rx) = tokio::sync::watch::channel(true);
+        let call_count = Arc::new(AtomicU32::new(0));
+        let cc = call_count.clone();
+        let operation = move || {
+            let count = cc.clone();
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                Err::<(), _>(streamling_err!("always fails"))
+            }
+        };
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(5),
+            retry_forever_with_backoff_until_cancelled(operation, "test_cancel", &mut rx),
+        )
+        .await
+        .expect("must return promptly, not keep retrying");
         assert_eq!(outcome, RetryOutcome::Cancelled);
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/streamling-core/src/retry.rs
+++ b/crates/streamling-core/src/retry.rs
@@ -55,6 +55,92 @@ where
     }
 }
 
+/// Outcome of a cancellable retry loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryOutcome {
+    /// The operation eventually succeeded.
+    Completed,
+    /// The shutdown signal fired before the operation succeeded; the loop gave
+    /// up between attempts.
+    Cancelled,
+}
+
+/// Like [`retry_forever_with_backoff_async`], but the loop gives up (returns
+/// [`RetryOutcome::Cancelled`]) when the shutdown watch flips to `true`.
+///
+/// Cancellation is checked before the first attempt and during every backoff
+/// sleep, so a sink stuck retrying against a sick backend can no longer pin the
+/// drain forever — once shutdown is requested it stops between attempts. A
+/// single in-flight attempt is allowed to finish (or hit its own I/O timeout);
+/// callers relying on prompt cancellation must give each attempt a bounded
+/// timeout of its own.
+pub async fn retry_forever_with_backoff_until_cancelled<Op, Fut>(
+    mut operation: Op,
+    operation_name: &str,
+    shutdown: &mut tokio::sync::watch::Receiver<bool>,
+) -> RetryOutcome
+where
+    Op: FnMut() -> Fut,
+    Fut: core::future::Future<Output = Result<()>>,
+{
+    if *shutdown.borrow() {
+        warn!("{} not started: shutdown already requested", operation_name);
+        return RetryOutcome::Cancelled;
+    }
+
+    let mut attempt: u32 = 0;
+    let mut backoff_ms: u64 = INITIAL_BACKOFF_MS;
+
+    loop {
+        attempt = attempt.saturating_add(1);
+        match operation().await {
+            Ok(()) => {
+                if attempt > 1 {
+                    warn!("{} recovered after {} attempts", operation_name, attempt);
+                }
+                return RetryOutcome::Completed;
+            }
+            Err(err) => {
+                if attempt > 5 {
+                    error!(
+                        error.internal = err.is_internal(),
+                        error.retriable = err.is_retriable(),
+                        "{} failed (attempt {}):\n{:?}\nRetrying...",
+                        operation_name,
+                        attempt,
+                        err
+                    );
+                } else {
+                    warn!(
+                        error.internal = err.is_internal(),
+                        error.retriable = err.is_retriable(),
+                        "{} failed (attempt {}):\n{:?}\nRetrying...",
+                        operation_name,
+                        attempt,
+                        err
+                    );
+                }
+            }
+        }
+
+        let jitter = (attempt as u64 % 100) * 7; // small deterministic jitter
+        let sleep_ms = std::cmp::min(MAX_BACKOFF_MS, backoff_ms + jitter);
+        tokio::select! {
+            _ = sleep(Duration::from_millis(sleep_ms)) => {}
+            res = shutdown.changed() => {
+                if res.is_ok() && *shutdown.borrow() {
+                    warn!(
+                        "{} cancelled by shutdown after {} attempt(s)",
+                        operation_name, attempt
+                    );
+                    return RetryOutcome::Cancelled;
+                }
+            }
+        }
+        backoff_ms = std::cmp::min(backoff_ms.saturating_mul(2), MAX_BACKOFF_MS);
+    }
+}
+
 /// Retry the provided operation indefinitely with exponential backoff and small jitter.
 /// Returns the successful value once the operation succeeds.
 /// The operation should return `Ok(T)` on success and `Err` with a StreamlingError on failure.
@@ -287,6 +373,68 @@ mod tests {
 
         assert_eq!(result, "success".to_string());
         assert_eq!(call_count.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_until_cancelled_completes_on_success() {
+        let (_tx, mut rx) = tokio::sync::watch::channel(false);
+        let call_count = Arc::new(AtomicU32::new(0));
+        let cc = call_count.clone();
+        let operation = || {
+            let count = cc.clone();
+            async move {
+                let c = count.fetch_add(1, Ordering::SeqCst) + 1;
+                if c < 3 {
+                    Err(streamling_err!("attempt {} failed", c))
+                } else {
+                    Ok(())
+                }
+            }
+        };
+        let outcome =
+            retry_forever_with_backoff_until_cancelled(operation, "test_cancel", &mut rx).await;
+        assert_eq!(outcome, RetryOutcome::Completed);
+        assert_eq!(call_count.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_until_cancelled_stops_on_shutdown() {
+        // Operation always fails; flipping the shutdown watch must break the
+        // otherwise-infinite retry loop promptly (between attempts).
+        let (tx, mut rx) = tokio::sync::watch::channel(false);
+        let call_count = Arc::new(AtomicU32::new(0));
+        let cc = call_count.clone();
+        let operation = move || {
+            let count = cc.clone();
+            async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                Err::<(), _>(streamling_err!("always fails"))
+            }
+        };
+
+        // Fire shutdown shortly after the loop starts.
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = tx.send(true);
+        });
+
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(5),
+            retry_forever_with_backoff_until_cancelled(operation, "test_cancel", &mut rx),
+        )
+        .await
+        .expect("cancellable retry must return, not hang");
+        assert_eq!(outcome, RetryOutcome::Cancelled);
+        assert!(call_count.load(Ordering::SeqCst) >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_until_cancelled_returns_immediately_if_already_shutdown() {
+        let (_tx, mut rx) = tokio::sync::watch::channel(true);
+        let operation = || async { Err::<(), _>(streamling_err!("should not be called")) };
+        let outcome =
+            retry_forever_with_backoff_until_cancelled(operation, "test_cancel", &mut rx).await;
+        assert_eq!(outcome, RetryOutcome::Cancelled);
     }
 
     #[tokio::test]

--- a/crates/streamling-core/src/shutdown.rs
+++ b/crates/streamling-core/src/shutdown.rs
@@ -32,13 +32,17 @@ pub fn subscribe() -> watch::Receiver<bool> {
 /// consumer — the run loop's watchdog and any component slicing its own
 /// bounded wait from the budget — so the values can never drift.
 pub fn shutdown_budget() -> std::time::Duration {
-    const DEFAULT_SHUTDOWN_BUDGET_SECS: u64 = 25;
-    let secs = std::env::var("STREAMLING__SHUTDOWN_BUDGET_SECS")
-        .ok()
-        .and_then(|s| s.parse::<u64>().ok())
-        .filter(|s| *s > 0)
-        .unwrap_or(DEFAULT_SHUTDOWN_BUDGET_SECS);
-    std::time::Duration::from_secs(secs)
+    use std::sync::OnceLock;
+    static BUDGET: OnceLock<std::time::Duration> = OnceLock::new();
+    *BUDGET.get_or_init(|| {
+        const DEFAULT_SHUTDOWN_BUDGET_SECS: u64 = 25;
+        let secs = std::env::var("STREAMLING__SHUTDOWN_BUDGET_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .filter(|s| *s > 0)
+            .unwrap_or(DEFAULT_SHUTDOWN_BUDGET_SECS);
+        std::time::Duration::from_secs(secs)
+    })
 }
 
 // NOTE: deliberately no unit test calls `request_shutdown()` here. The signal

--- a/crates/streamling-core/src/shutdown.rs
+++ b/crates/streamling-core/src/shutdown.rs
@@ -1,0 +1,52 @@
+//! Process-wide graceful-shutdown signal.
+//!
+//! One `watch` channel for the whole process: the pipeline run loop's single
+//! SIGTERM/SIGINT handler (or a clean job-mode completion) flips it, and every
+//! component that can wait or retry indefinitely — sources, sink retry loops,
+//! helper tasks — observes it and winds down instead of pinning the drain.
+//!
+//! Being global (like the checkpoint channel registry) means deep call sites
+//! such as the sink retry helpers can subscribe without threading a receiver
+//! through every constructor. The signal is one-way: once requested, shutdown
+//! is never un-requested.
+
+use once_cell::sync::Lazy;
+use tokio::sync::watch;
+
+static SHUTDOWN: Lazy<watch::Sender<bool>> = Lazy::new(|| watch::channel(false).0);
+
+/// Request process-wide graceful shutdown. Idempotent.
+pub fn request_shutdown() {
+    let _ = SHUTDOWN.send(true);
+}
+
+/// Subscribe to the shutdown signal. The receiver observes the current value
+/// immediately (`*rx.borrow()`) and wakes on `changed()` when it flips.
+pub fn subscribe() -> watch::Receiver<bool> {
+    SHUTDOWN.subscribe()
+}
+
+/// Whether shutdown has been requested.
+pub fn is_requested() -> bool {
+    *SHUTDOWN.subscribe().borrow()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn subscribe_observes_request() {
+        // NOTE: the channel is process-global, so this test only asserts the
+        // one-way transition (false -> true); it cannot assert the initial
+        // state without racing other tests in the binary.
+        let mut rx = subscribe();
+        request_shutdown();
+        assert!(is_requested());
+        // A subscriber created before the request wakes and sees true.
+        if !*rx.borrow() {
+            rx.changed().await.expect("sender is static, never dropped");
+        }
+        assert!(*rx.borrow());
+    }
+}

--- a/crates/streamling-core/src/shutdown.rs
+++ b/crates/streamling-core/src/shutdown.rs
@@ -26,9 +26,19 @@ pub fn subscribe() -> watch::Receiver<bool> {
     SHUTDOWN.subscribe()
 }
 
-/// Whether shutdown has been requested.
-pub fn is_requested() -> bool {
-    *SHUTDOWN.subscribe().borrow()
+/// The total time budget for graceful shutdown, from
+/// `STREAMLING__SHUTDOWN_BUDGET_SECS` (default 25s, sized to sit under the
+/// k8s default 30s grace period). The single source of truth for every
+/// consumer — the run loop's watchdog and any component slicing its own
+/// bounded wait from the budget — so the values can never drift.
+pub fn shutdown_budget() -> std::time::Duration {
+    const DEFAULT_SHUTDOWN_BUDGET_SECS: u64 = 25;
+    let secs = std::env::var("STREAMLING__SHUTDOWN_BUDGET_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|s| *s > 0)
+        .unwrap_or(DEFAULT_SHUTDOWN_BUDGET_SECS);
+    std::time::Duration::from_secs(secs)
 }
 
 // NOTE: deliberately no unit test calls `request_shutdown()` here. The signal

--- a/crates/streamling-core/src/shutdown.rs
+++ b/crates/streamling-core/src/shutdown.rs
@@ -31,22 +31,10 @@ pub fn is_requested() -> bool {
     *SHUTDOWN.subscribe().borrow()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn subscribe_observes_request() {
-        // NOTE: the channel is process-global, so this test only asserts the
-        // one-way transition (false -> true); it cannot assert the initial
-        // state without racing other tests in the binary.
-        let mut rx = subscribe();
-        request_shutdown();
-        assert!(is_requested());
-        // A subscriber created before the request wakes and sees true.
-        if !*rx.borrow() {
-            rx.changed().await.expect("sender is static, never dropped");
-        }
-        assert!(*rx.borrow());
-    }
-}
+// NOTE: deliberately no unit test calls `request_shutdown()` here. The signal
+// is process-global and one-way — flipping it in a test would permanently
+// contaminate every later test in the same binary that exercises production
+// code paths which subscribe to it (e.g. the Postgres/ClickHouse sink retry
+// loops). The end-to-end behaviour is covered by the SIGTERM drain e2e test
+// (`crates/streamling-e2e/tests/shutdown_drain.rs`), which runs the signal
+// path in a dedicated child process.

--- a/crates/streamling-e2e/src/lib.rs
+++ b/crates/streamling-e2e/src/lib.rs
@@ -508,6 +508,42 @@ impl TestContext {
         })?
     }
 
+    /// Run streamling with pipeline YAML, send SIGTERM after `signal_after`,
+    /// and require the process to exit within `exit_deadline` of the signal.
+    ///
+    /// This is the graceful-shutdown chaos harness: it asserts the process
+    /// observes SIGTERM, drains, and exits well inside the k8s grace period
+    /// instead of hanging until SIGKILL.
+    #[cfg(unix)]
+    pub async fn run_pipeline_with_sigterm(
+        &self,
+        pipeline_yaml: &str,
+        opts: PipelineOpts,
+        signal_after: std::time::Duration,
+        exit_deadline: std::time::Duration,
+    ) -> Result<ExitStatus> {
+        let pipeline_path = self.temp_dir.path().join("pipeline.yaml");
+        std::fs::write(&pipeline_path, pipeline_yaml)?;
+
+        let mut env_vars = self.build_env_vars();
+        if let Some(limit) = opts.record_limit {
+            env_vars.push((
+                "STREAMLING__NUM_RECORDS_BEFORE_STOP".to_string(),
+                limit.to_string(),
+            ));
+        }
+        env_vars.extend(opts.extra_env);
+
+        streamling::run_streamling_with_sigterm(
+            &pipeline_path,
+            self.config.streamling_bin.as_deref(),
+            &env_vars,
+            signal_after,
+            exit_deadline,
+        )
+        .await
+    }
+
     /// Run streamling with pipeline YAML and capture stdout/stderr for inspection
     ///
     /// This is useful for tests that need to inspect the print sink output.

--- a/crates/streamling-e2e/src/streamling.rs
+++ b/crates/streamling-e2e/src/streamling.rs
@@ -176,6 +176,113 @@ pub async fn run_streamling(
     Ok(status)
 }
 
+/// Run streamling, send SIGTERM after `signal_after`, and require the process
+/// to exit within `exit_deadline` of the signal (the graceful-shutdown
+/// contract: drain and exit well inside the k8s grace period).
+///
+/// The child is placed in its own process group and the signal is sent to the
+/// whole group, so the streamling binary receives it even when launched via
+/// `cargo run` (where the direct child is cargo, which does not forward
+/// signals). Returns the exit status; errors if the process misses the
+/// deadline (after SIGKILLing the group so no orphans leak into later tests).
+#[cfg(unix)]
+pub async fn run_streamling_with_sigterm(
+    pipeline_path: &Path,
+    binary_path: Option<&Path>,
+    env_vars: &[(String, String)],
+    signal_after: std::time::Duration,
+    exit_deadline: std::time::Duration,
+) -> Result<ExitStatus> {
+    let streamling_dir = find_streamling_dir();
+    let (program, args) = construct_program_with_args(binary_path);
+
+    let mut cmd = Command::new(&program);
+    for arg in &args {
+        cmd.arg(arg);
+    }
+    if let Some(ref dir) = streamling_dir {
+        cmd.current_dir(dir);
+        info!("Running streamling from directory: {}", dir.display());
+    }
+    cmd.env(
+        "STREAMLING__PIPELINE_DEFINITION_LOCATION",
+        pipeline_path.to_string_lossy().to_string(),
+    );
+    for (key, value) in env_vars {
+        cmd.env(key, value);
+    }
+    // New process group (pgid == child pid) so `kill -- -PGID` reaches the
+    // streamling binary through the `cargo run` wrapper.
+    cmd.process_group(0);
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    info!(
+        "Running streamling with pipeline: {} (SIGTERM after {:?}, exit deadline {:?})",
+        pipeline_path.display(),
+        signal_after,
+        exit_deadline
+    );
+
+    let mut child = cmd.spawn()?;
+    let pid = child.id().ok_or_else(|| {
+        E2eError::StreamlingFailed("child exited before a pid could be observed".to_string())
+    })?;
+
+    // Stream output so the drain behaviour is debuggable in test logs.
+    let stdout_handle = child.stdout.take().map(|stdout| {
+        tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                tracing::info!(target: "streamling", "{}", line);
+            }
+        })
+    });
+    let stderr_handle = child.stderr.take().map(|stderr| {
+        tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                tracing::warn!(target: "streamling", "{}", line);
+            }
+        })
+    });
+
+    let send_group_signal = |sig: &str| {
+        let _ = std::process::Command::new("kill")
+            .args([sig, "--", &format!("-{}", pid)])
+            .status();
+    };
+
+    tokio::time::sleep(signal_after).await;
+    info!("Sending SIGTERM to streamling process group {}", pid);
+    send_group_signal("-TERM");
+
+    let waited = tokio::time::timeout(exit_deadline, child.wait()).await;
+
+    if let Some(handle) = stdout_handle {
+        let _ = handle.await;
+    }
+    if let Some(handle) = stderr_handle {
+        let _ = handle.await;
+    }
+
+    match waited {
+        Ok(status) => Ok(status?),
+        Err(_) => {
+            // Missed the deadline: this is exactly the hang-until-SIGKILL bug.
+            // Kill the group so the test suite doesn't leak the process.
+            send_group_signal("-KILL");
+            let _ = child.wait().await;
+            Err(E2eError::StreamlingFailed(format!(
+                "streamling did not exit within {:?} of SIGTERM (graceful-shutdown hang)",
+                exit_deadline
+            )))
+        }
+    }
+}
+
 /// Run streamling and wait for it to process a specific number of records
 /// This is useful for tests that need streamling to run until a condition is met
 pub async fn run_streamling_with_limit(

--- a/crates/streamling-e2e/tests/shutdown_drain.rs
+++ b/crates/streamling-e2e/tests/shutdown_drain.rs
@@ -246,7 +246,13 @@ sinks:
 /// 3. Exit happens within the deadline (30s, the default k8s grace period) —
 ///    no lag-task rd_kafka_destroy deadlock, no wedged worker at teardown.
 /// 4. No records are lost: everything consumed before the signal is in the
-///    sink after exit.
+///    sink after exit. Records keep being PRODUCED right up to the signal (a
+///    background producer runs concurrently with the pipeline), so the signal
+///    genuinely lands mid-stream — the drain path is exercised on in-flight
+///    data, not only on an idle pipeline that finished long before the signal.
+///    Sequential zero-padded ids let us assert a gap-free prefix
+///    (`count == numeric(max(id))`): nothing consumed before the signal was
+///    dropped mid-drain.
 #[cfg(unix)]
 #[tokio::test]
 async fn test_sigterm_drains_and_exits_promptly() {
@@ -302,22 +308,44 @@ sinks:
         topic = ctx.kafka_topic,
     );
 
-    // Give the pipeline time to start and consume the seeded records, then
-    // SIGTERM while it idles on the live topic. The exit deadline matches the
-    // default k8s grace period: exceeding it is exactly the hang-then-SIGKILL
-    // failure this suite guards against.
-    let status = ctx
-        .run_pipeline_with_sigterm(
-            &pipeline,
-            PipelineOpts::new()
-                .env("STREAMLING__APPLICATION_ID", &application_id)
-                .env("STREAMLING__RECORD_BATCH_SIZE", "50")
-                .env("STREAMLING__CHECKPOINT_INTERVAL_SEC", "1"),
-            std::time::Duration::from_secs(15),
-            std::time::Duration::from_secs(30),
-        )
-        .await
-        .expect("streamling must exit within the grace period after SIGTERM");
+    // Run the pipeline and a background producer CONCURRENTLY: fresh records
+    // keep arriving right up to (and past) the signal, so SIGTERM lands while
+    // data is genuinely in flight. The exit deadline matches the default k8s
+    // grace period: exceeding it is exactly the hang-then-SIGKILL failure this
+    // suite guards against.
+    const SIGNAL_AFTER_SECS: u64 = 15;
+    let run = ctx.run_pipeline_with_sigterm(
+        &pipeline,
+        PipelineOpts::new()
+            .env("STREAMLING__APPLICATION_ID", &application_id)
+            .env("STREAMLING__RECORD_BATCH_SIZE", "50")
+            .env("STREAMLING__CHECKPOINT_INTERVAL_SEC", "1"),
+        std::time::Duration::from_secs(SIGNAL_AFTER_SECS),
+        std::time::Duration::from_secs(30),
+    );
+    let producer = async {
+        // Produce small batches every 250ms until just past the signal, ids
+        // continuing the seeded sequence so the whole stream stays sequential.
+        let mut next_id = NUM_RECORDS as i64 + 1;
+        let rounds = SIGNAL_AFTER_SECS * 4 + 4;
+        for _ in 0..rounds {
+            let batch: Vec<TestRecord> = (next_id..next_id + 10)
+                .map(|i| TestRecord {
+                    block: i,
+                    id: format!("sig_{i:05}"),
+                    data: format!("payload_{i}"),
+                    timestamp: 1000 + i,
+                })
+                .collect();
+            if ctx.kafka.produce_avro_records(&batch).await.is_err() {
+                break;
+            }
+            next_id += 10;
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        }
+    };
+    let (status, _) = tokio::join!(run, producer);
+    let status = status.expect("streamling must exit within the grace period after SIGTERM");
 
     assert!(
         status.success(),
@@ -325,15 +353,29 @@ sinks:
         status.code()
     );
 
-    // No tail loss: everything consumed before the signal must be durable in
-    // the sink. The upsert primary key makes the count duplicate-free.
-    let count = ctx
+    // No tail loss and no mid-stream gaps: ids are sequential and zero-padded,
+    // consumption is in order (single partition), and the upsert primary key
+    // makes the count duplicate-free — so everything the pipeline consumed up
+    // to the signal forms a contiguous prefix, and `count == numeric(max(id))`
+    // proves no consumed record was dropped during the drain.
+    let rows: Vec<(i64, Option<String>)> = ctx
         .postgres
-        .count("SELECT COUNT(*) FROM public.sigterm_drain_results")
+        .query("SELECT COUNT(*), MAX(id) FROM public.sigterm_drain_results")
         .await
-        .expect("Failed to count sink rows");
+        .expect("Failed to query sink rows");
+    let (count, max_id) = (rows[0].0, rows[0].1.clone().unwrap_or_default());
+    assert!(
+        count >= NUM_RECORDS as i64,
+        "all pre-seeded records must be drained to the sink (got {count})"
+    );
+    let max_numeric: i64 = max_id
+        .strip_prefix("sig_")
+        .and_then(|n| n.parse().ok())
+        .expect("max id should be a sig_NNNNN key");
     assert_eq!(
-        count, NUM_RECORDS as i64,
-        "all records consumed before SIGTERM must be drained to the sink"
+        count, max_numeric,
+        "sink rows must form a gap-free prefix of the produced stream \
+         (count {count} vs max id {max_numeric}): a gap means a record consumed \
+         before SIGTERM was dropped mid-drain"
     );
 }

--- a/crates/streamling-e2e/tests/shutdown_drain.rs
+++ b/crates/streamling-e2e/tests/shutdown_drain.rs
@@ -379,3 +379,161 @@ sinks:
          before SIGTERM was dropped mid-drain"
     );
 }
+
+// ============================================================================
+// Job mode: plugin sink terminal ack must finalize the terminal epoch
+// ============================================================================
+
+/// Build the in-repo example plugin (`plugin_examples/basic`, registers the
+/// `print_sink` sink plugin) as a cdylib and return the shared-library path.
+/// It lives in its own cargo workspace, so this is a separate (cached) build.
+async fn build_basic_example_plugin() -> std::path::PathBuf {
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("crates/streamling-e2e must sit two levels below the repo root")
+        .to_path_buf();
+    let plugin_dir = repo_root.join("plugin_examples/basic");
+
+    let status = tokio::process::Command::new("cargo")
+        .args(["build", "--lib"])
+        .current_dir(&plugin_dir)
+        .status()
+        .await
+        .expect("failed to invoke cargo build for plugin_examples/basic");
+    assert!(status.success(), "building plugin_examples/basic failed");
+
+    let debug_dir = plugin_dir.join("target/debug");
+    [
+        "libplugin_example_basic.so",
+        "libplugin_example_basic.dylib",
+    ]
+    .iter()
+    .map(|name| debug_dir.join(name))
+    .find(|p| p.exists())
+    .expect("built plugin cdylib not found in plugin_examples/basic/target/debug")
+}
+
+/// Job-mode pipelines with FFI plugin sinks must terminate: the terminal
+/// checkpoint marker rides the LAST batch of the stream, and the plugin's
+/// `CheckpointAck` reaches the host only after the plugin has processed the
+/// marker — strictly after the sink's batch loop has parked on the exhausted
+/// stream. The ack must still be forwarded to the checkpoint coordinator so
+/// the terminal epoch finalizes and the process exits.
+///
+/// Regression: ack propagation used to happen only from inside the sink's
+/// batch loop (at most one ack per incoming batch), so the terminal ack was
+/// never drained — the coordinator retried "Checkpoint epoch 1 timed out"
+/// forever and the job hung until an external kill. Streaming pipelines
+/// masked this because continuous batches kept draining the channel.
+#[tokio::test]
+async fn test_job_mode_plugin_sink_terminal_ack_exits() {
+    init_tracing();
+
+    let plugin_lib = build_basic_example_plugin().await;
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
+
+    // Small bounded table: the whole job completes within a few batches, so
+    // the terminal marker rides the last (often only) batch the sink sees.
+    clickhouse
+        .execute(
+            "CREATE TABLE plugin_drain_source (
+                block Int64,
+                id String,
+                data String,
+                timestamp Int64,
+                is_deleted UInt8
+            ) ENGINE = MergeTree()
+            ORDER BY (block, id)",
+        )
+        .await
+        .expect("Failed to create ClickHouse table");
+    let inserts = (1..=20)
+        .map(|i| format!("({i}, 'p_{i:04}', 'plugin_branch', {}, 0)", 100 + i))
+        .collect::<Vec<_>>()
+        .join(", ");
+    clickhouse
+        .execute(&format!("INSERT INTO plugin_drain_source VALUES {inserts}"))
+        .await
+        .expect("Failed to insert into ClickHouse table");
+
+    // Hybrid source scaffolding: the unbounded Kafka phase is never consumed
+    // in job mode but the provider is constructed at topology build time.
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+    clickhouse
+        .execute(
+            "CREATE TABLE kafka_offsets_plugin_drain (
+                topic String,
+                partition Int32,
+                offset UInt32
+            ) ENGINE = MergeTree()
+            ORDER BY (topic, partition)",
+        )
+        .await
+        .expect("Failed to create offset table");
+
+    let application_id = format!("plugin_drain_{}", ctx.test_id);
+
+    // `print_sink` is not a built-in sink type, so the config resolves it as
+    // a plugin sink and binds it to the plugin registered under that id.
+    let pipeline = format!(
+        r#"
+sources:
+  source_a:
+    type: hybrid
+    bounded_sources:
+      - source_type: clickhouse
+        table_name: plugin_drain_source
+        columns: block,id,data,timestamp
+    unbounded_source:
+      source_type: kafka
+      topic: {topic}
+      start_at: earliest
+    offset_table:
+      topic_name: {topic}
+      table_name: kafka_offsets_plugin_drain
+    primary_key: id
+
+transforms: {{}}
+
+sinks:
+  sink_a:
+    type: print_sink
+    from: source_a
+"#,
+        topic = ctx.kafka_topic,
+    );
+
+    // No record limit: termination is bounded-phase completion + job mode.
+    // A regression wedges the process on terminal-epoch finalization, so the
+    // harness timeout is the failure detector — keep it well below the suite
+    // timeout so a hang fails fast instead of stalling CI.
+    let status = ctx
+        .run_pipeline_with_opts(
+            &pipeline,
+            PipelineOpts::new()
+                .timeout(std::time::Duration::from_secs(120))
+                .env("STREAMLING__JOB_MODE", "true")
+                .env("STREAMLING__APPLICATION_ID", &application_id)
+                .env("STREAMLING__RECORD_BATCH_SIZE", "10")
+                .env("STREAMLING__CHECKPOINT_INTERVAL_SEC", "1")
+                .env(
+                    "STREAMLING__PLUGIN__PATH",
+                    plugin_lib.to_string_lossy().as_ref(),
+                ),
+        )
+        .await
+        .expect("Pipeline execution failed (hang on terminal ack, or crash)");
+    assert!(
+        status.success(),
+        "job-mode pipeline with a plugin sink must exit 0 after the terminal \
+         checkpoint finalizes"
+    );
+}

--- a/crates/streamling-e2e/tests/shutdown_drain.rs
+++ b/crates/streamling-e2e/tests/shutdown_drain.rs
@@ -1,0 +1,339 @@
+//! Graceful-shutdown / drain e2e tests.
+//!
+//! Regression tests for the shutdown investigation (shutdown-investigation.md):
+//! a multi-source/multi-sink pipeline must drain every record from every
+//! bounded source into every sink before terminating (job mode), and a SIGTERM
+//! must produce a prompt, clean exit with no tail loss (streaming mode) —
+//! instead of hanging until the k8s grace period expires and losing the last
+//! buffered batches.
+
+use serde::Serialize;
+use streamling_e2e::{init_tracing, PipelineOpts, TestContext, TestContextOptions};
+
+/// Test record for Kafka messages — id is String to match the ClickHouse
+/// schema for hybrid source unification.
+#[derive(Debug, Clone, Serialize)]
+struct TestRecord {
+    block: i64,
+    id: String,
+    data: String,
+    timestamp: i64,
+}
+
+const TEST_SCHEMA: &str = r#"{"type":"record","name":"TestMessage","fields":[
+    {"name":"block","type":"long"},
+    {"name":"id","type":"string"},
+    {"name":"data","type":"string"},
+    {"name":"timestamp","type":"long"}
+]}"#;
+
+// ============================================================================
+// Job mode: multi-source → multi-sink completion barrier
+// ============================================================================
+
+/// The repro shape (oasis-consensus-pubsub-repro1, scaled down): N bounded
+/// sources fanning 1:1 into N sinks, with deliberately different sizes so one
+/// branch completes while the other is still producing.
+///
+/// Contract under test:
+/// 1. The pipeline does NOT tear down when the first branch finishes — every
+///    sink receives its source's complete data set.
+/// 2. The first branch's drained sink is dropped from the coordinator's
+///    expected-ack set (`sink_completed`), so in-flight epochs — including the
+///    terminal one — still finalize on the remaining live sinks instead of
+///    stalling forever (the multi-source finalization stall).
+/// 3. Both completing sources share one terminal checkpoint epoch and each
+///    delivers its marker inline to its own sink, so the tail of BOTH branches
+///    is covered by a finalized checkpoint before exit.
+/// 4. The process exits 0 well within the harness timeout (no hang).
+///
+/// A 1s checkpoint interval keeps real epochs in flight while the branches
+/// complete at different times, which is exactly the window where the old
+/// coordinator stalled.
+#[tokio::test]
+async fn test_job_mode_multi_source_multi_sink_drains_all_records() {
+    init_tracing();
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
+
+    // Branch A: small bounded table (completes first).
+    clickhouse
+        .execute(
+            "CREATE TABLE drain_source_a (
+                block Int64,
+                id String,
+                data String,
+                timestamp Int64,
+                is_deleted UInt8
+            ) ENGINE = MergeTree()
+            ORDER BY (block, id)",
+        )
+        .await
+        .expect("Failed to create ClickHouse table A");
+    let insert_a = (1..=5)
+        .map(|i| format!("({i}, 'a_{i:04}', 'branch_a', {}, 0)", 100 + i))
+        .collect::<Vec<_>>()
+        .join(", ");
+    clickhouse
+        .execute(&format!("INSERT INTO drain_source_a VALUES {insert_a}"))
+        .await
+        .expect("Failed to insert into table A");
+
+    // Branch B: larger bounded table (still producing when A completes).
+    clickhouse
+        .execute(
+            "CREATE TABLE drain_source_b (
+                block Int64,
+                id String,
+                data String,
+                timestamp Int64,
+                is_deleted UInt8
+            ) ENGINE = MergeTree()
+            ORDER BY (block, id)",
+        )
+        .await
+        .expect("Failed to create ClickHouse table B");
+    let insert_b = (1..=200)
+        .map(|i| format!("({i}, 'b_{i:04}', 'branch_b', {}, 0)", 100 + i))
+        .collect::<Vec<_>>()
+        .join(", ");
+    clickhouse
+        .execute(&format!("INSERT INTO drain_source_b VALUES {insert_b}"))
+        .await
+        .expect("Failed to insert into table B");
+
+    // Each hybrid source needs an unbounded Kafka phase (never consumed in job
+    // mode, but the provider is constructed at topology build time) and an
+    // offset table.
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema on topic A");
+    let topic_b = ctx
+        .create_kafka_topic("drain_b")
+        .await
+        .expect("Failed to create topic B");
+    topic_b
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema on topic B");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE kafka_offsets_drain (
+                topic String,
+                partition Int32,
+                offset UInt32
+            ) ENGINE = MergeTree()
+            ORDER BY (topic, partition)",
+        )
+        .await
+        .expect("Failed to create offset table");
+
+    let application_id = format!("shutdown_drain_{}", ctx.test_id);
+
+    let pipeline = format!(
+        r#"
+sources:
+  source_a:
+    type: hybrid
+    bounded_sources:
+      - source_type: clickhouse
+        table_name: drain_source_a
+        columns: block,id,data,timestamp
+    unbounded_source:
+      source_type: kafka
+      topic: {topic_a}
+      start_at: earliest
+    offset_table:
+      topic_name: {topic_a}
+      table_name: kafka_offsets_drain
+    primary_key: id
+  source_b:
+    type: hybrid
+    bounded_sources:
+      - source_type: clickhouse
+        table_name: drain_source_b
+        columns: block,id,data,timestamp
+    unbounded_source:
+      source_type: kafka
+      topic: {topic_b}
+      start_at: earliest
+    offset_table:
+      topic_name: {topic_b}
+      table_name: kafka_offsets_drain
+    primary_key: id
+
+transforms: {{}}
+
+sinks:
+  sink_a:
+    type: postgres
+    from: source_a
+    table: drain_results_a
+    schema: public
+    primary_key: id
+    on_conflict: update
+    batch_size: 1
+  sink_b:
+    type: postgres
+    from: source_b
+    table: drain_results_b
+    schema: public
+    primary_key: id
+    on_conflict: update
+    batch_size: 1
+"#,
+        topic_a = ctx.kafka_topic,
+        topic_b = topic_b.topic,
+    );
+
+    // No record limit: termination is bounded-phase completion + job mode.
+    let status = ctx
+        .run_pipeline_with_opts(
+            &pipeline,
+            PipelineOpts::new()
+                .timeout(std::time::Duration::from_secs(120))
+                .env("STREAMLING__JOB_MODE", "true")
+                .env("STREAMLING__APPLICATION_ID", &application_id)
+                .env("STREAMLING__RECORD_BATCH_SIZE", "10")
+                .env("STREAMLING__CHECKPOINT_INTERVAL_SEC", "1"),
+        )
+        .await
+        .expect("Pipeline execution failed (hang or crash before completion)");
+    assert!(
+        status.success(),
+        "Job-mode multi-source pipeline should exit 0 after both branches drain"
+    );
+
+    // Every record from every source must be in its sink — the branch that
+    // finished LAST is the regression: the old run loop could tear down when
+    // the first branch's plugin/sink completed, cancelling the rest mid-flight.
+    let count_a = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.drain_results_a")
+        .await
+        .expect("Failed to count sink A");
+    assert_eq!(count_a, 5, "sink A must contain all of branch A's records");
+
+    let count_b = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.drain_results_b")
+        .await
+        .expect("Failed to count sink B");
+    assert_eq!(
+        count_b, 200,
+        "sink B must contain all of branch B's records"
+    );
+}
+
+// ============================================================================
+// Streaming mode: SIGTERM drains and exits promptly
+// ============================================================================
+
+/// The k8s-stop contract for a streaming (`job: false`) pipeline: on SIGTERM
+/// the process must drain in-flight work and exit cleanly, promptly.
+///
+/// Contract under test:
+/// 1. SIGTERM is observed (there is exactly one top-level handler) — the old
+///    code could swallow it entirely in listener-recreation windows, leaving
+///    the pipeline running until SIGKILL.
+/// 2. The source stops, the sink drains everything the source produced, the
+///    terminal checkpoint finalizes, and the process exits 0.
+/// 3. Exit happens within the deadline (30s, the default k8s grace period) —
+///    no lag-task rd_kafka_destroy deadlock, no wedged worker at teardown.
+/// 4. No records are lost: everything consumed before the signal is in the
+///    sink after exit.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_sigterm_drains_and_exits_promptly() {
+    init_tracing();
+
+    let ctx = TestContext::with_options(TestContextOptions::new())
+        .await
+        .expect("Failed to create test context");
+
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+
+    const NUM_RECORDS: usize = 500;
+    let records: Vec<TestRecord> = (1..=NUM_RECORDS as i64)
+        .map(|i| TestRecord {
+            block: i,
+            id: format!("sig_{i:05}"),
+            data: format!("payload_{i}"),
+            timestamp: 1000 + i,
+        })
+        .collect();
+    ctx.kafka
+        .produce_avro_records(&records)
+        .await
+        .expect("Failed to produce records");
+
+    let application_id = format!("sigterm_drain_{}", ctx.test_id);
+
+    let pipeline = format!(
+        r#"
+sources:
+  kafka_source:
+    type: kafka
+    topic: {topic}
+    starting_offsets: earliest
+    primary_key: id
+
+transforms: {{}}
+
+sinks:
+  pg_sink:
+    type: postgres
+    from: kafka_source
+    table: sigterm_drain_results
+    schema: public
+    primary_key: id
+    on_conflict: update
+    batch_size: 50
+    batch_flush_interval: 100ms
+"#,
+        topic = ctx.kafka_topic,
+    );
+
+    // Give the pipeline time to start and consume the seeded records, then
+    // SIGTERM while it idles on the live topic. The exit deadline matches the
+    // default k8s grace period: exceeding it is exactly the hang-then-SIGKILL
+    // failure this suite guards against.
+    let status = ctx
+        .run_pipeline_with_sigterm(
+            &pipeline,
+            PipelineOpts::new()
+                .env("STREAMLING__APPLICATION_ID", &application_id)
+                .env("STREAMLING__RECORD_BATCH_SIZE", "50")
+                .env("STREAMLING__CHECKPOINT_INTERVAL_SEC", "1"),
+            std::time::Duration::from_secs(15),
+            std::time::Duration::from_secs(30),
+        )
+        .await
+        .expect("streamling must exit within the grace period after SIGTERM");
+
+    assert!(
+        status.success(),
+        "SIGTERM shutdown must be a clean exit (code 0), got: {:?}",
+        status.code()
+    );
+
+    // No tail loss: everything consumed before the signal must be durable in
+    // the sink. The upsert primary key makes the count duplicate-free.
+    let count = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.sigterm_drain_results")
+        .await
+        .expect("Failed to count sink rows");
+    assert_eq!(
+        count, NUM_RECORDS as i64,
+        "all records consumed before SIGTERM must be drained to the sink"
+    );
+}

--- a/crates/streamling-e2e/tests/shutdown_drain.rs
+++ b/crates/streamling-e2e/tests/shutdown_drain.rs
@@ -381,6 +381,141 @@ sinks:
 }
 
 // ============================================================================
+// Streaming mode: SIGTERM during a BOUNDED phase drains and exits promptly
+// ============================================================================
+
+/// SIGTERM while a hybrid source is still in its bounded (ClickHouse) phase:
+/// the scan must end early, the terminal checkpoint must cover what was
+/// emitted, and the process must exit 0 well inside the k8s grace period.
+///
+/// Regression: the shutdown signal used to be observed only by the Kafka
+/// unbounded phase (via the hybrid shutdown watcher) and by the post-stream
+/// check in the hybrid forwarding loop — a bounded scan sat in
+/// `stream.next()` until the whole table had been read, blew the shutdown
+/// budget, and the watchdog force-exited without a terminal drain. The table
+/// here is large enough that the scan is still running when the signal
+/// lands; if a fast machine finishes it first the test degrades to the
+/// (already covered) streaming-phase path rather than flaking.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_sigterm_during_bounded_phase_drains_and_exits() {
+    init_tracing();
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE bounded_sigterm_source (
+                block Int64,
+                id String,
+                data String,
+                timestamp Int64,
+                is_deleted UInt8
+            ) ENGINE = MergeTree()
+            ORDER BY (block, id)",
+        )
+        .await
+        .expect("Failed to create ClickHouse table");
+    // Server-side seed: large enough that the bounded scan (throttled by the
+    // downstream Postgres sink) is still in flight when the signal fires.
+    clickhouse
+        .execute(
+            "INSERT INTO bounded_sigterm_source
+             SELECT number, concat('bp_', toString(number)), 'bounded_payload',
+                    1000 + number, 0
+             FROM numbers(500000)",
+        )
+        .await
+        .expect("Failed to seed ClickHouse table");
+
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+    clickhouse
+        .execute(
+            "CREATE TABLE kafka_offsets_bounded_sigterm (
+                topic String,
+                partition Int32,
+                offset UInt32
+            ) ENGINE = MergeTree()
+            ORDER BY (topic, partition)",
+        )
+        .await
+        .expect("Failed to create offset table");
+
+    let application_id = format!("bounded_sigterm_{}", ctx.test_id);
+
+    let pipeline = format!(
+        r#"
+sources:
+  source_a:
+    type: hybrid
+    bounded_sources:
+      - source_type: clickhouse
+        table_name: bounded_sigterm_source
+        columns: block,id,data,timestamp
+    unbounded_source:
+      source_type: kafka
+      topic: {topic}
+      start_at: earliest
+    offset_table:
+      topic_name: {topic}
+      table_name: kafka_offsets_bounded_sigterm
+    primary_key: id
+
+transforms: {{}}
+
+sinks:
+  pg_sink:
+    type: postgres
+    from: source_a
+    table: bounded_sigterm_results
+    schema: public
+    primary_key: id
+    on_conflict: update
+    batch_size: 200
+    batch_flush_interval: 100ms
+"#,
+        topic = ctx.kafka_topic,
+    );
+
+    let status = ctx
+        .run_pipeline_with_sigterm(
+            &pipeline,
+            PipelineOpts::new()
+                .env("STREAMLING__APPLICATION_ID", &application_id)
+                .env("STREAMLING__RECORD_BATCH_SIZE", "100")
+                .env("STREAMLING__CHECKPOINT_INTERVAL_SEC", "1"),
+            std::time::Duration::from_secs(6),
+            std::time::Duration::from_secs(30),
+        )
+        .await
+        .expect("streamling must exit within the grace period after SIGTERM mid-bounded-scan");
+    assert!(
+        status.success(),
+        "SIGTERM during a bounded phase must be a clean exit (code 0), got: {:?}",
+        status.code()
+    );
+
+    // The scan ran for several seconds before the signal — some prefix of the
+    // table must have been drained into the sink. Completeness is NOT
+    // expected: ending the scan early is the point of the test.
+    let count = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.bounded_sigterm_results")
+        .await
+        .expect("Failed to count sink rows");
+    assert!(
+        count > 0,
+        "sink must contain the drained prefix of the bounded scan"
+    );
+}
+
+// ============================================================================
 // Job mode: plugin sink terminal ack must finalize the terminal epoch
 // ============================================================================
 

--- a/crates/streamling-plugin/src/api.rs
+++ b/crates/streamling-plugin/src/api.rs
@@ -215,6 +215,12 @@ pub trait SourcePlugin: SupportsGracefulShutdown + Send + Sync {
     /// Returning a successful result indicates that the checkpoint marker was processed
     /// successfully, and the mark should be propagated downstream.
     async fn process_checkpoint_marker(&self, epoch: CheckpointEpoch) -> Result<(), PluginError>;
+    /// Called when `epoch` finalized end-to-end (every live sink acked it).
+    /// Contract: MUST be idempotent, MUST NOT block, and MUST NEVER wait for
+    /// one specific epoch's Finalizer — at shutdown the host drops in-flight
+    /// timer epochs without ever sending their Finalizers, and only a later
+    /// terminal epoch (covering their work) finalizes. An implementation that
+    /// gates on an exact epoch will stall the shutdown drain.
     async fn process_checkpoint_finalizer(&self, epoch: CheckpointEpoch)
     -> Result<(), PluginError>;
 }
@@ -233,6 +239,8 @@ pub trait TransformPlugin: SupportsGracefulShutdown + Send + Sync {
     /// Returning a successful result indicates that the checkpoint marker was processed
     /// successfully, and the mark should be propagated downstream.
     async fn process_checkpoint_marker(&self, epoch: CheckpointEpoch) -> Result<(), PluginError>;
+    /// See `SourcePlugin::process_checkpoint_finalizer` for the consumer
+    /// contract (idempotent, non-blocking, never wait for a specific epoch).
     async fn process_checkpoint_finalizer(&self, epoch: CheckpointEpoch)
     -> Result<(), PluginError>;
 }
@@ -248,7 +256,12 @@ pub trait SinkPlugin: SupportsGracefulShutdown + Send + Sync {
     async fn process_batch(&self, data: RecordBatch) -> Result<(), PluginError>;
     /// Returning a successful result indicates that the checkpoint marker was processed
     /// successfully, and an acknowledgment should be sent back to the source.
+    /// For a sink, "processed successfully" means DURABLY flushed: the ack
+    /// tells the source everything up to this marker survives a crash, so
+    /// buffered-but-unpublished data must be flushed before returning `Ok`.
     async fn process_checkpoint_marker(&self, epoch: CheckpointEpoch) -> Result<(), PluginError>;
+    /// See `SourcePlugin::process_checkpoint_finalizer` for the consumer
+    /// contract (idempotent, non-blocking, never wait for a specific epoch).
     async fn process_checkpoint_finalizer(&self, epoch: CheckpointEpoch)
     -> Result<(), PluginError>;
 }

--- a/crates/streamling-plugin/src/ffi.rs
+++ b/crates/streamling-plugin/src/ffi.rs
@@ -465,6 +465,13 @@ pub enum PluginMsg {
     NextBatch { data: SafeArrowArray },
     CheckpointMarker { epoch: PluginCheckpointEpoch },
     CheckpointAck { epoch: PluginCheckpointEpoch },
+    /// The epoch finalized end-to-end (every live sink acked it). Consumer
+    /// contract: handling MUST be idempotent, MUST NOT block, and MUST NEVER
+    /// wait for one specific epoch's Finalizer — at shutdown the host drops
+    /// in-flight timer epochs without ever sending their Finalizers, and only
+    /// a later terminal epoch (covering their work) finalizes. Treat this as
+    /// "everything up to and including `epoch` is durable", not as a
+    /// guaranteed per-epoch event.
     CheckpointFinalizer { epoch: PluginCheckpointEpoch },
     Terminate,
     Topology { config: RString },

--- a/crates/streamling-plugin/src/ffi.rs
+++ b/crates/streamling-plugin/src/ffi.rs
@@ -462,9 +462,15 @@ pub struct PluginChannels {
 #[non_exhaustive]
 pub enum PluginMsg {
     Init,
-    NextBatch { data: SafeArrowArray },
-    CheckpointMarker { epoch: PluginCheckpointEpoch },
-    CheckpointAck { epoch: PluginCheckpointEpoch },
+    NextBatch {
+        data: SafeArrowArray,
+    },
+    CheckpointMarker {
+        epoch: PluginCheckpointEpoch,
+    },
+    CheckpointAck {
+        epoch: PluginCheckpointEpoch,
+    },
     /// The epoch finalized end-to-end (every live sink acked it). Consumer
     /// contract: handling MUST be idempotent, MUST NOT block, and MUST NEVER
     /// wait for one specific epoch's Finalizer — at shutdown the host drops
@@ -472,8 +478,14 @@ pub enum PluginMsg {
     /// a later terminal epoch (covering their work) finalizes. Treat this as
     /// "everything up to and including `epoch` is durable", not as a
     /// guaranteed per-epoch event.
-    CheckpointFinalizer { epoch: PluginCheckpointEpoch },
+    CheckpointFinalizer {
+        epoch: PluginCheckpointEpoch,
+    },
     Terminate,
-    Topology { config: RString },
-    Error { message: RString },
+    Topology {
+        config: RString,
+    },
+    Error {
+        message: RString,
+    },
 }

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -2418,18 +2418,29 @@ impl Streamling {
         #[cfg(unix)]
         {
             use tokio::signal::unix::{SignalKind, signal};
-            let mut sigterm = match signal(SignalKind::terminate()) {
-                Ok(s) => s,
+            let handlers = (|| {
+                Ok::<_, std::io::Error>((
+                    signal(SignalKind::terminate())?,
+                    signal(SignalKind::interrupt())?,
+                ))
+            })();
+            let (mut sigterm, mut sigint) = match handlers {
+                Ok(h) => h,
                 Err(e) => {
-                    error!("Failed to install SIGTERM handler: {}", e);
-                    return;
-                }
-            };
-            let mut sigint = match signal(SignalKind::interrupt()) {
-                Ok(s) => s,
-                Err(e) => {
-                    error!("Failed to install SIGINT handler: {}", e);
-                    return;
+                    // Installation failed: the caller treats this function
+                    // returning as "signal received" and starts a drain, so
+                    // returning here would trigger a SPURIOUS shutdown at
+                    // startup. Pend forever instead — the process keeps
+                    // running and degrades to the OS default SIGTERM
+                    // disposition (immediate kill, no graceful drain), which
+                    // is the pre-existing behaviour without a handler.
+                    error!(
+                        "Failed to install SIGTERM/SIGINT handlers ({}); \
+                         graceful shutdown on signal is DISABLED for this run",
+                        e
+                    );
+                    futures::future::pending::<()>().await;
+                    unreachable!("pending() never resolves");
                 }
             };
             tokio::select! {

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -549,9 +549,11 @@ impl Streamling {
         // checkpoint) and sink futures (to signal completion). Valid before the
         // coordinator is started since it shares the coordinator's state.
         let checkpoint_control = checkpoint_coordinator.control();
-        // Process-wide shutdown signal. A single SIGTERM/SIGINT handler flips it
-        // (installed below); every source observes it and drains front-to-back.
-        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        // Process-wide shutdown signal (streamling_core::shutdown). A single
+        // SIGTERM/SIGINT handler flips it (installed below); every source
+        // observes it and drains front-to-back, and deep call sites (sink
+        // retry loops) subscribe to it directly.
+        let shutdown_rx = streamling_core::shutdown::subscribe();
         let mut checkpoint_sink_names: Vec<String> = Vec::new();
 
         let mut pipeline_plans: HashMap<String, LogicalPlan> = HashMap::new();
@@ -2178,11 +2180,10 @@ impl Streamling {
         // replaces the per-component signal handlers (notably the plugin
         // watcher that used to kill plugins first, inverting the drain order).
         if !dry_run {
-            let shutdown_tx = shutdown_tx.clone();
             tokio::spawn(async move {
                 Self::wait_for_shutdown_signal().await;
                 info!("Shutdown signal received; draining pipeline front-to-back");
-                let _ = shutdown_tx.send(true);
+                streamling_core::shutdown::request_shutdown();
                 Self::arm_shutdown_watchdog(Self::shutdown_budget());
             });
         }
@@ -2231,13 +2232,23 @@ impl Streamling {
             }
         };
 
-        // Teardown. Everything below is bounded by a single deadline; the
-        // watchdog (armed here for the clean-completion path that never saw a
-        // SIGTERM) hard-exits the process at the deadline no matter what.
-        let deadline = std::time::Instant::now() + Self::shutdown_budget();
+        // Teardown. Everything below is bounded by a single deadline shared
+        // with the watchdog: arming is idempotent and returns the deadline of
+        // the FIRST arming (SIGTERM time, if one arrived), so after a long
+        // drain the bounded waits below correctly see less time remaining
+        // instead of overrunning into the hard exit. A 2s margin keeps these
+        // waits expiring before the watchdog fires. Dry runs never arm the
+        // watchdog (there is nothing to drain).
+        let deadline = if dry_run {
+            std::time::Instant::now() + Self::shutdown_budget()
+        } else {
+            let watchdog_deadline = Self::arm_shutdown_watchdog(Self::shutdown_budget());
+            watchdog_deadline
+                .checked_sub(Duration::from_secs(2))
+                .unwrap_or(watchdog_deadline)
+        };
         let remaining = || deadline.saturating_duration_since(std::time::Instant::now());
         if !dry_run {
-            Self::arm_shutdown_watchdog(Self::shutdown_budget());
             // The sinks drained. Before tearing anything down, wait (bounded)
             // for the terminal checkpoint to finalize so the tail is durably
             // checkpointed and its Finalizer reaches components that commit on
@@ -2254,7 +2265,7 @@ impl Streamling {
             }
             // Ensure sources observe shutdown even on a clean job-mode completion
             // (so any lingering helper tasks — lag reporters — wind down).
-            let _ = shutdown_tx.send(true);
+            streamling_core::shutdown::request_shutdown();
         }
 
         // Issue SourceComplete to plugin sources so the checkpoint channels are
@@ -2327,25 +2338,34 @@ impl Streamling {
     /// Arm a last-resort watchdog: a plain OS thread that hard-exits the process
     /// after `budget`, so a wedged FFI/rdkafka teardown or a plugin that never
     /// finishes its drain can never hold the process past the k8s grace period.
-    /// Idempotent — the first arming wins; later calls are no-ops.
-    fn arm_shutdown_watchdog(budget: Duration) {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        static ARMED: AtomicBool = AtomicBool::new(false);
-        if ARMED.swap(true, Ordering::SeqCst) {
-            return;
-        }
-        let _ = std::thread::Builder::new()
-            .name("shutdown-watchdog".to_string())
-            .spawn(move || {
-                std::thread::sleep(budget);
-                // A plain OS thread's exit cannot be blocked by a wedged tokio
-                // worker or a hung FFI call, so this always fires.
-                eprintln!(
-                    "[streamling] shutdown budget of {:?} exceeded; forcing process exit",
-                    budget
-                );
-                std::process::exit(0);
-            });
+    ///
+    /// Idempotent — the first arming wins and later calls are no-ops. Always
+    /// returns the deadline of the FIRST arming so callers slice their bounded
+    /// waits against the watchdog's real deadline (e.g. teardown after a long
+    /// SIGTERM-triggered drain must not assume a fresh budget).
+    ///
+    /// The forced exit is non-zero: this path only fires when teardown failed
+    /// to complete in time, and it must surface to k8s/alerting as an abnormal
+    /// exit, not a clean completion.
+    fn arm_shutdown_watchdog(budget: Duration) -> std::time::Instant {
+        use std::sync::OnceLock;
+        static WATCHDOG_DEADLINE: OnceLock<std::time::Instant> = OnceLock::new();
+        *WATCHDOG_DEADLINE.get_or_init(|| {
+            let deadline = std::time::Instant::now() + budget;
+            let _ = std::thread::Builder::new()
+                .name("shutdown-watchdog".to_string())
+                .spawn(move || {
+                    std::thread::sleep(budget);
+                    // A plain OS thread's exit cannot be blocked by a wedged
+                    // tokio worker or a hung FFI call, so this always fires.
+                    eprintln!(
+                        "[streamling] shutdown budget of {:?} exceeded; forcing process exit",
+                        budget
+                    );
+                    std::process::exit(1);
+                });
+            deadline
+        })
     }
 
     /// Await SIGTERM / SIGINT / Ctrl-C — the single shutdown trigger for the

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -2126,20 +2126,32 @@ impl Streamling {
                 let checkpoint_control = checkpoint_control.clone();
                 let sink_future = async move {
                     let result = session_manager.new_df(sink_plan).collect().await;
-                    if let Err(err) = &result {
-                        error!(
-                            "Sink future [{}] completed with error: {}",
-                            future_name, err
-                        );
-                    }
-                    // The sink has drained its input and will not ack any
-                    // further checkpoint epochs. Tell the coordinator so it
-                    // drops these sinks from the expected-ack set and can
-                    // finalize in-flight epochs the remaining live sinks
-                    // already acked, instead of blocking on a sink that is
-                    // gone (the multi-source completion case).
-                    for sink_name in &sink_names {
-                        checkpoint_control.sink_completed(sink_name);
+                    match &result {
+                        Ok(_) => {
+                            // The sink has SUCCESSFULLY drained its input and
+                            // will not ack any further checkpoint epochs. Tell
+                            // the coordinator so it drops these sinks from the
+                            // expected-ack set and can finalize in-flight
+                            // epochs the remaining live sinks already acked,
+                            // instead of blocking on a sink that is gone (the
+                            // multi-source completion case).
+                            for sink_name in &sink_names {
+                                checkpoint_control.sink_completed(sink_name);
+                            }
+                        }
+                        Err(err) => {
+                            // A FAILED sink must NOT be deregistered: its
+                            // missing acks are the coordinator's only signal
+                            // that the epochs it touched are not durable.
+                            // Removing it would let those epochs (including
+                            // the terminal one) finalize as if the data had
+                            // been written. The pipeline is failing anyway —
+                            // let the epochs stall and the error propagate.
+                            error!(
+                                "Sink future [{}] completed with error: {}",
+                                future_name, err
+                            );
+                        }
                     }
                     result
                 };

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -545,6 +545,13 @@ impl Streamling {
         let mut plugins: BTreeMap<String, InitializedPlugin> = BTreeMap::new();
 
         let mut checkpoint_coordinator = CheckpointCoordinator::new();
+        // Control handle shared with bounded sources (to begin the terminal
+        // checkpoint) and sink futures (to signal completion). Valid before the
+        // coordinator is started since it shares the coordinator's state.
+        let checkpoint_control = checkpoint_coordinator.control();
+        // Process-wide shutdown signal. A single SIGTERM/SIGINT handler flips it
+        // (installed below); every source observes it and drains front-to-back.
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
         let mut checkpoint_sink_names: Vec<String> = Vec::new();
 
         let mut pipeline_plans: HashMap<String, LogicalPlan> = HashMap::new();
@@ -772,20 +779,29 @@ impl Streamling {
                     let offset_table = &hybrid.offset_table;
                     let primary_key_opt = &hybrid.primary_key;
 
-                    let hybrid_source_provider = Arc::new(HybridTableProvider::new_from_topology(
-                        reference_name.clone(),
-                        bounded_sources.clone(),
-                        unbounded_source.clone(),
-                        offset_table.clone(),
-                        &app_config,
-                        &state_backend_factory,
-                        session_manager.clone(),
-                        // Per-phase event-time config flows directly to the
-                        // inner WrappingSourceTableProviders (one per bounded
-                        // phase + one for unbounded), each carrying its own
-                        // `metric_key_hybrid_src_*` suffix. R9 falls out.
-                        hybrid.telemetry.as_ref(),
-                    )?);
+                    let hybrid_source_provider = Arc::new(
+                        HybridTableProvider::new_from_topology(
+                            reference_name.clone(),
+                            bounded_sources.clone(),
+                            unbounded_source.clone(),
+                            offset_table.clone(),
+                            &app_config,
+                            &state_backend_factory,
+                            session_manager.clone(),
+                            // Per-phase event-time config flows directly to the
+                            // inner WrappingSourceTableProviders (one per bounded
+                            // phase + one for unbounded), each carrying its own
+                            // `metric_key_hybrid_src_*` suffix. R9 falls out.
+                            hybrid.telemetry.as_ref(),
+                        )?
+                        // In job mode this source emits the terminal checkpoint
+                        // when its bounded phases complete; in streaming mode it
+                        // does so on shutdown. Give it the control handle (to gate
+                        // teardown on that epoch finalizing) and the shutdown
+                        // signal (to drain rather than drop on SIGTERM).
+                        .with_checkpoint_control(checkpoint_control.clone())
+                        .with_shutdown(shutdown_rx.clone()),
+                    );
 
                     let provider_with_telemetry = Arc::new(WrappingSourceTableProvider::new(
                         hybrid_source_provider.clone(),
@@ -2054,6 +2070,9 @@ impl Streamling {
                 .map(|e| e.name.as_str())
                 .collect::<Vec<&str>>()
                 .join(", ");
+            // Captured for the sink-completion signal below: one entry per
+            // sink driven by this future (a fan-out future drives several).
+            let sink_names: Vec<String> = sinks.iter().map(|e| e.name.clone()).collect();
             let sink_plan = if sinks.len() > 1 {
                 // Fan-out: each sink gets its own RebatchExec injected by
                 // the MultiSinkExtensionPlanner, so the raw source_plan
@@ -2102,6 +2121,7 @@ impl Streamling {
 
             if !dry_run {
                 let session_manager = session_manager.clone();
+                let checkpoint_control = checkpoint_control.clone();
                 let sink_future = async move {
                     let result = session_manager.new_df(sink_plan).collect().await;
                     if let Err(err) = &result {
@@ -2109,6 +2129,15 @@ impl Streamling {
                             "Sink future [{}] completed with error: {}",
                             future_name, err
                         );
+                    }
+                    // The sink has drained its input and will not ack any
+                    // further checkpoint epochs. Tell the coordinator so it
+                    // drops these sinks from the expected-ack set and can
+                    // finalize in-flight epochs the remaining live sinks
+                    // already acked, instead of blocking on a sink that is
+                    // gone (the multi-source completion case).
+                    for sink_name in &sink_names {
+                        checkpoint_control.sink_completed(sink_name);
                     }
                     result
                 };
@@ -2144,49 +2173,90 @@ impl Streamling {
             );
         }
 
-        let app_result = if !plugins.is_empty() {
-            let plugin_futures: Vec<ExecutionFuture> = plugins
-                .into_values()
-                .map(|plugin| plugin.execution_future)
-                .collect();
+        // One top-level shutdown trigger. On SIGTERM/SIGINT it flips the shared
+        // signal (sources drain front-to-back) and arms the watchdog. This
+        // replaces the per-component signal handlers (notably the plugin
+        // watcher that used to kill plugins first, inverting the drain order).
+        if !dry_run {
+            let shutdown_tx = shutdown_tx.clone();
+            tokio::spawn(async move {
+                Self::wait_for_shutdown_signal().await;
+                info!("Shutdown signal received; draining pipeline front-to-back");
+                let _ = shutdown_tx.send(true);
+                Self::arm_shutdown_watchdog(Self::shutdown_budget());
+            });
+        }
 
-            // We terminate the application in two cases:
-            // 1. If ANY plugin future completes (assuming an error)
-            // 2. If ANY sink future fails
-            let result: Result<()> = tokio::select! {
-                plugin_outcome = futures::future::select_all(plugin_futures) => {
-                    let (res, _idx, _rest) = plugin_outcome;
-                    match res {
-                        Ok(()) => {
-                            debug!("Terminating because a plugin future completed gracefully");
-                            Ok(())
+        // Plugin dispatchers run as detached tasks; their execution futures are
+        // join wrappers. We keep them in a set so that AFTER the sinks drain we
+        // can send Terminate and AWAIT the dispatchers finishing their flush,
+        // rather than dropping them and letting the runtime cancel them
+        // mid-flush at process exit (the job-mode tail-loss bug).
+        let mut plugin_set: futures::stream::FuturesUnordered<ExecutionFuture> =
+            plugins.into_values().map(|p| p.execution_future).collect();
+
+        // Drive to completion. The terminal condition is "all sinks drained"
+        // (every source ended its stream, via bounded completion or shutdown).
+        // A plugin dispatcher exiting on its own is NOT terminal unless it
+        // errored — otherwise we would drop in-flight sink work and lose the
+        // tail, exactly the previous behaviour.
+        let app_result: Result<()> = {
+            use futures::StreamExt as _;
+            let sinks_fut = futures::future::try_join_all(sink_futures);
+            tokio::pin!(sinks_fut);
+            if plugin_set.is_empty() {
+                (&mut sinks_fut).await.map(|_| ()).map_err(Into::into)
+            } else {
+                loop {
+                    tokio::select! {
+                        sinks = &mut sinks_fut => {
+                            break sinks.map(|_| ()).map_err(|e| {
+                                debug!("Terminating because a sink future completed with error");
+                                e.into()
+                            });
                         }
-                        Err(msg) => {
-                            debug!("Terminating because a plugin future completed with error: {}", msg);
-                            Err(streamling_err!("Plugin error: {}", msg))
+                        Some(plugin_res) = plugin_set.next() => {
+                            match plugin_res {
+                                Ok(()) => {
+                                    debug!("A plugin future completed; continuing to drain sinks");
+                                    continue;
+                                }
+                                Err(msg) => {
+                                    break Err(streamling_err!("Plugin error: {}", msg));
+                                }
+                            }
                         }
                     }
-                },
-                result = futures::future::try_join_all(sink_futures) => {
-                    result
-                        .map(|_| ())
-                        .map_err(|e| {
-                            debug!("Terminating because a sink future completed with error");
-                            e.into()
-                        })
                 }
-            };
-
-            result
-        } else {
-            futures::future::try_join_all(sink_futures)
-                .await
-                .map(|_| ())
-                .map_err(Into::into)
+            }
         };
 
-        // Issue SourceComplete message to plugins. This is needed to fully clean up checkpoint channels when plugins
-        // terminate.
+        // Teardown. Everything below is bounded by a single deadline; the
+        // watchdog (armed here for the clean-completion path that never saw a
+        // SIGTERM) hard-exits the process at the deadline no matter what.
+        let deadline = std::time::Instant::now() + Self::shutdown_budget();
+        let remaining = || deadline.saturating_duration_since(std::time::Instant::now());
+        if !dry_run {
+            Self::arm_shutdown_watchdog(Self::shutdown_budget());
+            // The sinks drained. Before tearing anything down, wait (bounded)
+            // for the terminal checkpoint to finalize so the tail is durably
+            // checkpointed and its Finalizer reaches components that commit on
+            // it. No-op in the streaming case where no terminal checkpoint was
+            // begun, and skipped on error (none will arrive).
+            if app_result.is_ok()
+                && timeout(remaining(), checkpoint_control.await_terminal_finalized())
+                    .await
+                    .is_err()
+            {
+                warn!("Terminal checkpoint did not finalize within budget; proceeding with shutdown");
+            }
+            // Ensure sources observe shutdown even on a clean job-mode completion
+            // (so any lingering helper tasks — lag reporters — wind down).
+            let _ = shutdown_tx.send(true);
+        }
+
+        // Issue SourceComplete to plugin sources so the checkpoint channels are
+        // fully cleaned up when the plugins terminate.
         {
             use streamling_core::checkpoints::channels::send as checkpoint_send;
             use streamling_core::checkpoints::checkpoint_management::CheckpointMessage;
@@ -2202,23 +2272,111 @@ impl Streamling {
         }
 
         shutdown_plugin_side_outputs();
+
+        // Terminate plugins, then AWAIT their dispatchers finishing their drain
+        // (bounded) so the last buffered batches are flushed durably before the
+        // runtime is dropped. This is the fix for the plugin/pubsub tail loss.
         terminate_all_plugins()?;
-        // Stop checkpoint coordinator only if it was started (not in dry_run mode)
-        // Stop it before checking app_result to ensure cleanup happens even if there's an error
+        if !plugin_set.is_empty() {
+            use futures::StreamExt as _;
+            let drain = async {
+                while let Some(res) = plugin_set.next().await {
+                    if let Err(msg) = res {
+                        warn!("Plugin exited with error during drain: {}", msg);
+                    }
+                }
+            };
+            match timeout(remaining(), drain).await {
+                Ok(()) => info!("All plugin dispatchers drained cleanly"),
+                Err(_) => warn!(
+                    "Plugin drain exceeded the shutdown budget; {} dispatcher(s) may not have flushed",
+                    plugin_set.len()
+                ),
+            }
+        }
+
+        // Stop the checkpoint coordinator only if it was started (not dry_run).
         if !dry_run {
-            // Use timeout to prevent hanging if checkpoint coordinator tasks are stuck
-            match timeout(Duration::from_secs(30), checkpoint_coordinator.stop()).await {
+            match timeout(remaining(), checkpoint_coordinator.stop()).await {
                 Ok(_) => {}
                 Err(_) => {
-                    warn!(
-                        "Checkpoint coordinator stop timed out after 5 seconds, continuing anyway"
-                    );
+                    warn!("Checkpoint coordinator stop timed out; continuing anyway");
                 }
             }
         }
 
         app_result?;
         Ok(())
+    }
+
+    /// The total time budget for graceful shutdown, from
+    /// `STREAMLING__SHUTDOWN_BUDGET_SECS` (default 25s, sized to sit under the
+    /// k8s default 30s grace period). The whole drain + teardown must fit here.
+    fn shutdown_budget() -> Duration {
+        const DEFAULT_SHUTDOWN_BUDGET_SECS: u64 = 25;
+        let secs = std::env::var("STREAMLING__SHUTDOWN_BUDGET_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .filter(|s| *s > 0)
+            .unwrap_or(DEFAULT_SHUTDOWN_BUDGET_SECS);
+        Duration::from_secs(secs)
+    }
+
+    /// Arm a last-resort watchdog: a plain OS thread that hard-exits the process
+    /// after `budget`, so a wedged FFI/rdkafka teardown or a plugin that never
+    /// finishes its drain can never hold the process past the k8s grace period.
+    /// Idempotent — the first arming wins; later calls are no-ops.
+    fn arm_shutdown_watchdog(budget: Duration) {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        static ARMED: AtomicBool = AtomicBool::new(false);
+        if ARMED.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let _ = std::thread::Builder::new()
+            .name("shutdown-watchdog".to_string())
+            .spawn(move || {
+                std::thread::sleep(budget);
+                // A plain OS thread's exit cannot be blocked by a wedged tokio
+                // worker or a hung FFI call, so this always fires.
+                eprintln!(
+                    "[streamling] shutdown budget of {:?} exceeded; forcing process exit",
+                    budget
+                );
+                std::process::exit(0);
+            });
+    }
+
+    /// Await SIGTERM / SIGINT / Ctrl-C — the single shutdown trigger for the
+    /// whole process, replacing the per-component signal handlers.
+    async fn wait_for_shutdown_signal() {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{SignalKind, signal};
+            let mut sigterm = match signal(SignalKind::terminate()) {
+                Ok(s) => s,
+                Err(e) => {
+                    error!("Failed to install SIGTERM handler: {}", e);
+                    return;
+                }
+            };
+            let mut sigint = match signal(SignalKind::interrupt()) {
+                Ok(s) => s,
+                Err(e) => {
+                    error!("Failed to install SIGINT handler: {}", e);
+                    return;
+                }
+            };
+            tokio::select! {
+                _ = sigterm.recv() => info!("Received SIGTERM"),
+                _ = sigint.recv() => info!("Received SIGINT"),
+                _ = tokio::signal::ctrl_c() => info!("Received Ctrl-C"),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+            info!("Received Ctrl-C");
+        }
     }
 
     fn find_plan_and_schema(

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -2361,17 +2361,12 @@ impl Streamling {
         Ok(())
     }
 
-    /// The total time budget for graceful shutdown, from
-    /// `STREAMLING__SHUTDOWN_BUDGET_SECS` (default 25s, sized to sit under the
-    /// k8s default 30s grace period). The whole drain + teardown must fit here.
+    /// The total time budget for graceful shutdown. Delegates to the shared
+    /// definition in `streamling_core::shutdown` so every consumer (this run
+    /// loop's watchdog, the hybrid source's terminal-finalize wait) reads the
+    /// same value and they can never drift.
     fn shutdown_budget() -> Duration {
-        const DEFAULT_SHUTDOWN_BUDGET_SECS: u64 = 25;
-        let secs = std::env::var("STREAMLING__SHUTDOWN_BUDGET_SECS")
-            .ok()
-            .and_then(|s| s.parse::<u64>().ok())
-            .filter(|s| *s > 0)
-            .unwrap_or(DEFAULT_SHUTDOWN_BUDGET_SECS);
-        Duration::from_secs(secs)
+        streamling_core::shutdown::shutdown_budget()
     }
 
     /// Arm a last-resort watchdog: a plain OS thread that hard-exits the process
@@ -2391,7 +2386,7 @@ impl Streamling {
         static WATCHDOG_DEADLINE: OnceLock<std::time::Instant> = OnceLock::new();
         *WATCHDOG_DEADLINE.get_or_init(|| {
             let deadline = std::time::Instant::now() + budget;
-            let _ = std::thread::Builder::new()
+            let spawn_result = std::thread::Builder::new()
                 .name("shutdown-watchdog".to_string())
                 .spawn(move || {
                     std::thread::sleep(budget);
@@ -2403,6 +2398,16 @@ impl Streamling {
                     );
                     std::process::exit(1);
                 });
+            if let Err(e) = spawn_result {
+                // Without the watchdog nothing guarantees the process exits
+                // before the grace period; make that loudly visible instead of
+                // failing silently (behaviour then degrades to pre-watchdog).
+                eprintln!(
+                    "[streamling] FAILED to spawn shutdown watchdog thread: {}; \
+                     a wedged teardown can no longer be force-exited",
+                    e
+                );
+            }
             deadline
         })
     }

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -2248,7 +2248,9 @@ impl Streamling {
                     .await
                     .is_err()
             {
-                warn!("Terminal checkpoint did not finalize within budget; proceeding with shutdown");
+                warn!(
+                    "Terminal checkpoint did not finalize within budget; proceeding with shutdown"
+                );
             }
             // Ensure sources observe shutdown even on a clean job-mode completion
             // (so any lingering helper tasks — lag reporters — wind down).

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -2226,8 +2226,8 @@ impl Streamling {
             let mut sink_set: futures::stream::FuturesUnordered<_> =
                 sink_futures.into_iter().collect();
             let mut first_error: Option<streamling_core::error::StreamlingError> = None;
-            let mut fail_drain = |err: streamling_core::error::StreamlingError,
-                                  first_error: &mut Option<
+            let fail_drain = |err: streamling_core::error::StreamlingError,
+                              first_error: &mut Option<
                 streamling_core::error::StreamlingError,
             >| {
                 if first_error.is_none() {

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -2213,34 +2213,61 @@ impl Streamling {
         // A plugin dispatcher exiting on its own is NOT terminal unless it
         // errored — otherwise we would drop in-flight sink work and lose the
         // tail, exactly the previous behaviour.
+        // The sinks are driven individually (not try_join_all): a failing sink
+        // must not CANCEL its siblings mid-flush — dropping their futures would
+        // abort in-flight writes and re-widen the very tail-loss window this
+        // change closes. Instead, the first failure triggers the same graceful
+        // drain as SIGTERM (sources stop, streams end, the remaining sinks
+        // finish flushing — all bounded by the watchdog), and the error is
+        // propagated once every sink has wound down. No epoch a failed sink
+        // touched is ever acked, so at-least-once is preserved either way.
         let app_result: Result<()> = {
             use futures::StreamExt as _;
-            let sinks_fut = futures::future::try_join_all(sink_futures);
-            tokio::pin!(sinks_fut);
-            if plugin_set.is_empty() {
-                (&mut sinks_fut).await.map(|_| ()).map_err(Into::into)
-            } else {
-                loop {
-                    tokio::select! {
-                        sinks = &mut sinks_fut => {
-                            break sinks.map(|_| ()).map_err(|e| {
-                                debug!("Terminating because a sink future completed with error");
-                                e.into()
-                            });
+            let mut sink_set: futures::stream::FuturesUnordered<_> =
+                sink_futures.into_iter().collect();
+            let mut first_error: Option<streamling_core::error::StreamlingError> = None;
+            let mut fail_drain = |err: streamling_core::error::StreamlingError,
+                                  first_error: &mut Option<
+                streamling_core::error::StreamlingError,
+            >| {
+                if first_error.is_none() {
+                    if !dry_run {
+                        warn!(
+                            "Pipeline component failed; draining remaining sinks before exit: {}",
+                            err
+                        );
+                        streamling_core::shutdown::request_shutdown();
+                        Self::arm_shutdown_watchdog(Self::shutdown_budget());
+                    }
+                    *first_error = Some(err);
+                }
+            };
+            while !sink_set.is_empty() {
+                tokio::select! {
+                    Some(sink_res) = sink_set.next() => {
+                        if let Err(e) = sink_res {
+                            debug!("A sink future completed with error");
+                            fail_drain(e.into(), &mut first_error);
                         }
-                        Some(plugin_res) = plugin_set.next() => {
-                            match plugin_res {
-                                Ok(()) => {
-                                    debug!("A plugin future completed; continuing to drain sinks");
-                                    continue;
-                                }
-                                Err(msg) => {
-                                    break Err(streamling_err!("Plugin error: {}", msg));
-                                }
+                    }
+                    Some(plugin_res) = plugin_set.next() => {
+                        match plugin_res {
+                            Ok(()) => {
+                                debug!("A plugin future completed; continuing to drain sinks");
+                            }
+                            Err(msg) => {
+                                fail_drain(
+                                    streamling_err!("Plugin error: {}", msg),
+                                    &mut first_error,
+                                );
                             }
                         }
                     }
                 }
+            }
+            match first_error {
+                None => Ok(()),
+                Some(e) => Err(e),
             }
         };
 


### PR DESCRIPTION
## Summary
This PR implements a terminal checkpoint mechanism and graceful shutdown flow for Streamling pipelines. It enables bounded sources to emit a final checkpoint covering all produced data, ensures sinks flush and ack this checkpoint before teardown, and allows the pipeline to drain front-to-back on SIGTERM/SIGINT instead of abruptly terminating.

## Key Changes

### Checkpoint Coordinator Enhancements
- Added `CheckpointControl` handle: a cloneable interface for signaling checkpoint lifecycle events (sink completion, terminal checkpoint initiation) from outside the coordinator's subscriber task
- Implemented terminal checkpoint support:
  - `begin_terminal_checkpoint()`: Mints a final epoch when a bounded source completes or shutdown is requested
  - `await_terminal_finalized()`: Blocks until the terminal epoch is acked by all live sinks
  - `is_terminal_finalized()`: Checks if terminal checkpoint has finalized
- Added `sink_completed()`: Removes a drained sink from the expected-ack set and finalizes in-flight epochs the remaining sinks have already acked, preventing deadlock when multi-source pipelines have branches completing at different times
- Refactored expected-sinks tracking from `Arc>` to `Arc>>` to allow dynamic removal
- Added `terminal_started` and `terminal_epoch` state to gate the timer producer and prevent it from clearing the terminal epoch
- Implemented proper channel subscription cleanup via `unsubscribe()` in `stop()`

### Pipeline Shutdown Flow
- Introduced process-wide shutdown signal (`tokio::sync::watch::channel`) that sources observe to drain gracefully instead of advancing phases
- Replaced per-component signal handlers with a single top-level SIGTERM/SIGINT handler that:
  - Flips the shared shutdown signal
  - Arms a shutdown watchdog with a configurable budget
- Modified sink futures to signal `checkpoint_control.sink_completed()` after draining, enabling finalization of in-flight epochs
- Implemented bounded teardown: all cleanup operations (terminal checkpoint finalization, plugin termination) are bounded by a single deadline enforced by the watchdog

### Hybrid Source Integration
- Added `checkpoint_control` and `shutdown_rx` fields to `HybridTableProvider`
- Builder methods `with_checkpoint_control()` and `with_shutdown()` for configuration
- Implemented shutdown watcher task that stops the inner unbounded source when shutdown is requested
- Modified phase-transition logic to emit terminal checkpoint when:
  - All bounded phases complete (job mode)
  - Shutdown is requested during any phase (streaming mode)
  - Unbounded stream ends
- Added `emit_terminal_checkpoint()` helper to emit the terminal marker and finalizer inline after the last batch

### Retry Mechanism Enhancement
- Added `retry_forever_with_backoff_until_cancelled()`: A cancellable retry loop that gives up when a shutdown watch flips to `true`
- Returns `RetryOutcome::Completed` or `RetryOutcome::Cancelled` to distinguish success from cancellation
- Allows sinks stuck retrying against a sick backend to stop between attempts on shutdown instead of blocking the drain indefinitely

### Plugin Sink Ack Propagation
- Plugin sinks forward checkpoint acks to the coordinator on a dedicated task instead of draining them once per incoming batch, so the terminal epoch finalizes even though its ack lands after the last batch (job-mode pipelines with plugin sinks previously hung on terminal-epoch finalization)

### Testing & Cleanup
- E2e shutdown-drain suite (`crates/streamling-e2e/tests/shutdown_drain.rs`): job-mode multi-source drain barrier, SIGTERM drain in streaming mode, SIGTERM during a bounded (ClickHouse) phase, and job-mode plugin-sink terminal-ack round-trip — each asserts clean exit within a deadline and sink completeness
- Added `#[serial]` attribute to checkpoint tests to prevent race conditions from concurrent global channel access
- Removed obsolete `start_shutdown_watcher_once()` from plugin module (replaced by unified shutdown handler)
- Added `serial_test` dev dependency for test serialization

## Semantics note: bounded exactly-once fallback on shutdown

Two deliberate trade-offs weaken exactly-once to at-least-once in narrow windows — both bounded, logged, and safe for the idempotent/cumulative consumers audited in this PR:

1. **Terminal Finalizer skip**: if any sink fails to ack the terminal epoch within the finalize timeout (shutdown budget minus a 10s margin; for budgets of 2s or less it collapses to zero), the Finalizer is deliberately withheld so no consumer commits past unconfirmed data. The tail of that run replays on restart. Observable via a warning naming the sinks that never acked and the `checkpoint_terminal_finalizer_skipped` counter.
2. **Multi-source timer freeze**: the first completing bounded source stops periodic checkpoints pipeline-wide; still-running branches ride the shared terminal epoch until they finish. A crash in that window replays those branches from their last finalized epoch (documented on `begin_terminal_checkpoint`; per-branch epochs are a deferred coordinator redesign).

New connector authors must keep Finalizer consumers idempotent and commits cumulative — see the contract on `CheckpointMessage`.

## Notable Implementation Details

- **Lock ordering**: `CheckpointControl::sink_completed()` carefully avoids holding both `epochs` and `expected_sinks` locks simultaneously to prevent deadlock, since the subscriber/producer paths lock in epochs-then-expected order
- **Terminal epoch protection**: The timer producer re-checks `terminal_started` under the epochs lock before clearing/inserting, preventing it from racing a fresh timer epoch over the terminal one
- **Graceful degradation**: Terminal checkpoint is optional (None in tests); pipelines without it continue to work as before
- **Tail durability**: The pipeline waits (bounded) for terminal checkpoint finalization before tearing down, ensuring the tail is durably checkpointed and finalizers reach components that commit on them
- **Multi-source completion**: The sink-completion path deregisters drained branches from the expected-ack set, so epochs shared across sources still finalize when branches finish at different times

---

&gt; [!NOTE]
&gt; **High Risk**
&gt; Changes checkpoint finalization, commit/ack ordering, and shutdown behavior across Kafka, hybrid, ClickHouse, Postgres, plugins, and multi-sink paths—bugs could cause hung shutdown, duplicate replay, or acking epochs for unflushed data.
&gt; 
&gt; **Overview**
&gt; This PR wires **graceful shutdown and a terminal checkpoint** through the pipeline so bounded jobs and SIGTERM drain in-flight work instead of hanging until the watchdog kills the process or leaving tail data uncheckpointed.
&gt; 
&gt; **Process-wide shutdown** (`streamling_core::shutdown`) replaces scattered per-component signal handlers with one watch channel and a shared `STREAMLING__SHUTDOWN_BUDGET_SECS` budget. Sources and retry loops subscribe and stop between pages/attempts; sinks use **shutdown-cancellable retries** (`retry_forever_with_backoff_until_cancelled`) with per-attempt timeouts so they fail rather than ack checkpoints for data never written.
&gt; 
&gt; **Checkpoint coordinator** gains a cloneable **`CheckpointControl`**: `begin_terminal_checkpoint` mints a final epoch and stops the timer producer; `sink_completed` drops drained sinks from the expected-ack set so multi-source pipelines don’t deadlock; `await_terminal_finalized` gates teardown. Checkpoint **broadcasts** prune dead subscribers instead of aborting the whole send; components **unsubscribe** on exit and treat coordinator **acks as best-effort** during shutdown.
&gt; 
&gt; **Hybrid sources** emit terminal Marker/Finalizer on synthetic batches (bounded wait; **Finalizer skipped** if sinks never ack), stop Kafka on shutdown, and end bounded ClickHouse scans early. **Kafka** drains the in-flight batch, flushes buffered checkpoint messages, and unsubscribes from the coordinator channel. **ClickHouse/Postgres** sinks propagate write failures; **`parallel_execute`** and **MultiSinkExec** join all sink writers before the plan completes.
&gt; 
&gt; **Plugin** sinks forward checkpoint acks on a dedicated task (fixing terminal-epoch hangs after the last batch). **E2E** adds a SIGTERM harness asserting exit within a deadline.
&gt; 
&gt; <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f68513189a3e78dc37c0b21bd83533c64dcd2a8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>