### PR TITLE
fix: recover PostgreSQL sinks from read-only failover (SQLSTATE 25006)

### DIFF
--- a/crates/streamling-core/src/utils/pg.rs
+++ b/crates/streamling-core/src/utils/pg.rs
@@ -60,7 +60,22 @@ impl PostgresConnection {
             .acquire_timeout(Duration::from_secs(config.pool_acquire_timeout_secs))
             .idle_timeout(Duration::from_secs(config.pool_idle_timeout_secs))
             .max_lifetime(Duration::from_secs(config.pool_max_lifetime_secs))
-            .test_before_acquire(true)
+            .test_before_acquire(false)
+            // Discard idle connections that can no longer accept writes. After a
+            // primary→replica failover, pooled connections keep pointing at a
+            // read-only server and every write fails with SQLSTATE 25006 until
+            // the process restarts; evicting them here forces the pool to
+            // reconnect, so sinks resume as soon as a writable primary is
+            // reachable again. The SHOW round-trip also doubles as the liveness
+            // ping `test_before_acquire` used to perform.
+            .before_acquire(|conn, _meta| {
+                Box::pin(async move {
+                    let read_only: String = sqlx::query_scalar("SHOW transaction_read_only")
+                        .fetch_one(&mut *conn)
+                        .await?;
+                    Ok(read_only == "off")
+                })
+            })
             .after_connect(move |conn, _meta| {
                 Box::pin(async move {
                     conn.execute(

--- a/crates/streamling-e2e/src/resources/postgres.rs
+++ b/crates/streamling-e2e/src/resources/postgres.rs
@@ -155,6 +155,15 @@ impl PostgresResource {
         Ok(())
     }
 
+    /// Execute SQL on the cluster-level admin connection (the `postgres` DB),
+    /// not on the isolated test database. Used for cross-database operations
+    /// like `ALTER DATABASE ... SET default_transaction_read_only = on` and
+    /// `pg_terminate_backend(...)` in failover tests.
+    pub async fn admin_execute(&self, sql: &str) -> Result<()> {
+        sqlx::query(sql).execute(&self.admin_pool).await?;
+        Ok(())
+    }
+
     /// Execute a count query and return the result
     pub async fn count(&self, query: &str) -> Result<i64> {
         let row = sqlx::query(query).fetch_one(&self.pool).await?;

--- a/crates/streamling-e2e/tests/postgres_sink.rs
+++ b/crates/streamling-e2e/tests/postgres_sink.rs
@@ -4,6 +4,7 @@
 //! Ported from crates/streamling/tests/pipeline_postgres_sink.rs
 
 use serde::Serialize;
+use std::time::Duration;
 use streamling_e2e::{init_tracing, PipelineOpts, TestContext};
 
 // ============================================================================
@@ -1410,4 +1411,193 @@ sinks:
         .await
         .expect("Failed to query count");
     assert_eq!(count, 50, "All 50 records should be written");
+}
+
+// ============================================================================
+// Scenario 13: Read-only failover recovery (SQLSTATE 25006)
+// ============================================================================
+
+/// Simulate a primary→replica failover by flipping the test database to
+/// `default_transaction_read_only = on` while the sink is mid-flight, then
+/// flipping it back. The sink's existing connections are terminated each time
+/// so their next reconnect inherits the new GUC. Verifies that
+///   1) writes are provably blocked during the read-only window (the pool's
+///      `before_acquire` gate evicts read-only connections instead of reusing
+///      them forever),
+///   2) the retry loop survives the window without exiting, and
+///   3) all records land once writes are accepted again — without a restart.
+///
+/// Records are produced in two waves: wave 2 arrives only after the database
+/// is read-only, so the pipeline cannot finish before the failover is
+/// exercised — the test cannot pass vacuously.
+///
+/// Scope is per-database via `ALTER DATABASE "<test_db>" SET ...`, so parallel
+/// tests against other isolated databases are unaffected.
+#[tokio::test]
+async fn test_postgres_sink_read_only_failover() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("Failed to create test context");
+
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+
+    let make_records = |range: std::ops::RangeInclusive<i64>| -> Vec<TestRecord> {
+        range
+            .map(|i| TestRecord {
+                id: i,
+                value: format!("ro_value_{}", i),
+                timestamp: 1000 + i,
+            })
+            .collect()
+    };
+
+    // Wave 1: enough records to get the sink writing, but not enough to let
+    // the pipeline (record_limit = 50) finish before the failover is injected.
+    ctx.kafka
+        .produce_avro_records(&make_records(1..=25))
+        .await
+        .expect("Failed to produce wave 1");
+
+    let pipeline = format!(
+        r#"
+sources:
+  kafka_source:
+    type: kafka
+    topic: {topic}
+    starting_offsets: earliest
+    primary_key: id
+
+transforms: {{}}
+
+sinks:
+  pg_sink:
+    type: postgres
+    from: kafka_source
+    table: test_read_only_failover
+    schema: public
+    primary_key: id
+    on_conflict: update
+    batch_size: 5
+    batch_flush_interval: 200ms
+"#,
+        topic = ctx.kafka_topic,
+    );
+
+    // Run the pipeline in the background so the test can flip the read-only
+    // GUC while the sink is mid-flight.
+    let pipeline_path = ctx.temp_dir.path().join("pipeline.yaml");
+    std::fs::write(&pipeline_path, &pipeline).expect("Failed to write pipeline file");
+    let mut env_vars = ctx.build_env_vars();
+    env_vars.push((
+        "STREAMLING__NUM_RECORDS_BEFORE_STOP".to_string(),
+        "50".to_string(),
+    ));
+    let binary_path = ctx.config.streamling_bin.clone();
+
+    let pipeline_task = tokio::spawn(async move {
+        streamling_e2e::streamling::run_streamling(
+            &pipeline_path,
+            binary_path.as_deref(),
+            &env_vars,
+        )
+        .await
+    });
+
+    // Wait until the sink has written at least one row, confirming the happy
+    // path is live before we break it.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let n = ctx
+            .postgres
+            .count("SELECT COUNT(*) FROM public.test_read_only_failover")
+            .await
+            .unwrap_or(0);
+        if n > 0 {
+            break;
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("sink did not write any rows within 30s");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let db = ctx.pg_database.clone();
+    let quoted_db = db.replace('"', "\"\"");
+    let escaped_db = db.replace('\'', "''");
+
+    // Flip read-only on and force existing sink sessions to reconnect into the
+    // new default, so the next INSERT raises SQLSTATE 25006.
+    ctx.postgres
+        .admin_execute(&format!(
+            "ALTER DATABASE \"{}\" SET default_transaction_read_only = on",
+            quoted_db
+        ))
+        .await
+        .expect("ALTER DATABASE on failed");
+    ctx.postgres
+        .admin_execute(&format!(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+             WHERE datname = '{}' AND pid <> pg_backend_pid()",
+            escaped_db
+        ))
+        .await
+        .expect("pg_terminate_backend (on) failed");
+
+    // Wave 2: produced only after the database is read-only, so these rows
+    // cannot land until the failover resolves.
+    ctx.kafka
+        .produce_avro_records(&make_records(26..=50))
+        .await
+        .expect("Failed to produce wave 2");
+
+    // Hold the read-only window long enough for the sink to hit 25006 and
+    // exercise the connection-eviction path.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Writes must be blocked while the database is read-only; if all 50 rows
+    // are present the failover was never actually exercised.
+    let mid_count = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.test_read_only_failover")
+        .await
+        .expect("Failed to query count during read-only window");
+    assert!(
+        mid_count < 50,
+        "read-only window did not block writes (count = {})",
+        mid_count
+    );
+
+    // Resolve the failover. Deliberately do NOT terminate backends here: the
+    // sink's pooled sessions still carry `default_transaction_read_only = on`
+    // from when they connected, so recovery depends entirely on the pool's
+    // `before_acquire` gate evicting them — exactly what this test defends.
+    ctx.postgres
+        .admin_execute(&format!(
+            "ALTER DATABASE \"{}\" SET default_transaction_read_only = off",
+            quoted_db
+        ))
+        .await
+        .expect("ALTER DATABASE off failed");
+
+    let status = tokio::time::timeout(Duration::from_secs(90), pipeline_task)
+        .await
+        .expect("pipeline did not finish within 90s after recovery")
+        .expect("pipeline task panicked")
+        .expect("pipeline returned error");
+    assert!(
+        status.success(),
+        "Streamling should exit successfully after recovery"
+    );
+
+    let count = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.test_read_only_failover")
+        .await
+        .expect("Failed to query count after recovery");
+    assert_eq!(count, 50, "All 50 records should be written after recovery");
 }


### PR DESCRIPTION
After a primary→replica failover, pooled connections keep pointing at a read-only server and every write fails with SQLSTATE 25006 until the process restarts. Gate idle-connection reuse with a before_acquire hook that runs SHOW transaction_read_only and evicts read-only sessions, so the pool reconnects and sinks resume as soon as a writable primary is reachable — no new retry machinery needed; the existing retry-forever loop in the sink already covers the failure window.

The SHOW round-trip replaces the test_before_acquire ping (any query proves liveness), so idle-acquire cost is unchanged.

The e2e test produces records in two waves (the second only after the database is read-only) so it cannot pass without exercising the window, and deliberately does not terminate backends when the failover resolves — recovery must come from the eviction gate itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared PostgreSQL pool acquisition for all sinks and pg aggregation; mis-eviction or query failures could affect connection reuse, but behavior is narrowly scoped to read-only detection and existing sink retries still apply.
> 
> **Overview**
> PostgreSQL sink pools no longer reuse connections that are in read-only mode after a primary→replica failover. **`test_before_acquire`** is turned off and replaced with a **`before_acquire`** hook that runs **`SHOW transaction_read_only`** and drops connections unless the value is **`off`**, forcing reconnects to a writable primary while still using that round-trip as the liveness check.
> 
> E2E coverage adds **`admin_execute`** on the cluster admin pool for **`ALTER DATABASE ... default_transaction_read_only`** and **`pg_terminate_backend`**, plus **`test_postgres_sink_read_only_failover`**, which runs the sink mid-flight through a simulated read-only window (two Kafka waves, backends killed only when entering read-only, not on recovery) and asserts all 50 rows land without restarting the process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d983a69b20fb966d3f93ea7fae31b52dd6ae389b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->