### PR TITLE
fix(ci): publish nightlies only on manual dispatch

### DIFF
--- a/.github/workflows/streamling.yml
+++ b/.github/workflows/streamling.yml
@@ -457,15 +457,12 @@ jobs:
           echo "  - $TAG_LATEST"
 
   # ==========================================================================
-  # Rolling 'nightly' prerelease from every green main commit.
+  # Manually triggered immutable nightly prerelease from main.
   # Linux binaries only; versioned releases remain the 'latest' release.
   # ==========================================================================
   publish-prerelease:
     needs: [validate-and-test, e2e-tests, build-release-main]
-    if: github.ref_name == 'main'
-    # Serialize delete/recreate of the rolling tag across overlapping main runs.
-    concurrency:
-      group: publish-prerelease
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -492,10 +489,11 @@ jobs:
             echo "No release artifact directories found" >&2
             exit 1
           fi
-      - name: Publish rolling prerelease
+      - name: Publish nightly prerelease
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          gh release delete nightly --cleanup-tag --yes || true
-          gh release create nightly --prerelease --target "$GITHUB_SHA" --title "nightly (${GITHUB_SHA:0:7})" --notes "Rolling prerelease from main @ $GITHUB_SHA. Linux binaries only; use the versioned releases for macOS/Windows." release-assets/*
+          set -euo pipefail
+          tag="nightly-$(date -u +%Y%m%d)-${GITHUB_SHA:0:7}"
+          gh release create "$tag" --prerelease --target "$GITHUB_SHA" --title "$tag" --notes "Nightly prerelease from main @ $GITHUB_SHA. Linux binaries only; use the versioned releases for macOS/Windows." release-assets/*


### PR DESCRIPTION
## Summary

- publish nightly prereleases only from a manual `workflow_dispatch` on `main`
- use immutable tags named `nightly-YYYYMMDD-<short-sha>`
- stop deleting and recreating the fixed `nightly` release

## Why

The rolling `nightly` tag had already been used by an immutable release, so GitHub permanently rejected attempts to recreate it with HTTP 422. This removes prerelease publication from main pushes and gives each manually triggered nightly a unique public tag.

The existing main binary build remains shared by e2e and Docker image jobs.

## Validation

- `actionlint` (ignoring the repository's existing custom Blacksmith runner-label warnings)
- UTC tag-generation assertion
- `just fix`
- `just lint`
