### PR TITLE
feat: add opt-in Postgres dynamic table cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,9 +985,9 @@ transforms:
 ```
 
 The cache is off by default and is used only when both settings are present. The initial lookup
-loads the full table. Each later `dynamic_table_check` batch reads `MAX(time_column)` and appends
-only rows newer than the cached maximum. Index the time column so these checks and range reads stay
-cheap.
+loads the full table through bounded PostgreSQL cursor pages. Each later `dynamic_table_check`
+batch reads `MAX(time_column)` and appends only rows newer than the cached maximum. Index the time
+column so these checks and range reads stay cheap.
 
 PostgreSQL dynamic tables are append-only when the in-memory cache is enabled. Updating or deleting
 existing membership, including removals, is not supported in this mode. Keeping `time_column` current

--- a/README.md
+++ b/README.md
@@ -985,9 +985,39 @@ transforms:
 ```
 
 The cache is off by default and is used only when both settings are present. Each
-`dynamic_table_check` batch reads `MAX(time_column)` and reloads the cache only when it changes.
-Index the time column so this check stays cheap. Tables without a reliable update timestamp, or
-deployments with `cache_enabled: false`, continue to use batched PostgreSQL lookups.
+`dynamic_table_check` batch reads only `MAX(time_column)` and reloads the cache when it changes.
+Index the time column so this check stays cheap.
+
+Keeping `time_column` current is a user requirement and part of the cache's correctness contract.
+Every process that can insert, update, or delete table membership must use the same serialized-writer
+protocol:
+
+```sql
+BEGIN;
+SELECT pg_advisory_xact_lock(hashtextextended('public.persistent_data', 0));
+-- Perform the mutation and assign updated_at after taking the lock.
+UPDATE public.persistent_data
+SET value = 'new-value', updated_at = clock_timestamp()
+WHERE value = 'old-value';
+COMMIT;
+```
+
+Use the schema-qualified table name as the lock key, exactly as shown. Transaction-scoped advisory
+locks coordinate only writers that follow this protocol. The mutation must atomically make
+`MAX(time_column)` different; normally it should set a non-null timestamp strictly newer than the
+previous maximum. For a physical delete, also bump a surviving row or retained change-marker row in
+the same transaction. `NOW()` and `CURRENT_TIMESTAMP` are unsafe here because PostgreSQL fixes them
+at transaction start, which can precede waiting for the writer lock; use `clock_timestamp()` after
+the lock instead.
+
+Streamling takes this lock automatically for its own cached appends and creates new backing tables
+with `updated_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()`. It does not alter existing tables.
+Tables created by older Streamling versions with nullable `TIMESTAMPTZ DEFAULT NOW()` need no schema
+or data migration: cached Streamling appends explicitly write `clock_timestamp()` after taking the
+lock. Future mutations from other writers must still follow the protocol above. Cache initialization
+checks that the configured column exists and supports `MAX`, but it cannot verify that other writers
+obey the protocol. If that cannot be guaranteed, leave caching disabled; uncached tables continue to
+use batched PostgreSQL lookups.
 
 ### Usage with SQL Transforms
 

--- a/README.md
+++ b/README.md
@@ -964,7 +964,7 @@ transforms:
     backend_entity_name: persistent_data
 ```
 
-Enable the full-table cache in the application config (or with
+Enable the in-memory cache in the application config (or with
 `STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__CACHE_ENABLED=true`):
 
 ```yaml
@@ -984,11 +984,12 @@ transforms:
     time_column: updated_at
 ```
 
-The cache is off by default and is used only when both settings are present. Each
-`dynamic_table_check` batch reads only `MAX(time_column)` and reloads the cache when it changes.
-Index the time column so this check stays cheap.
+The cache is off by default and is used only when both settings are present. The initial lookup
+loads the full table. Each later `dynamic_table_check` batch reads `MAX(time_column)` and appends
+only rows newer than the cached maximum. Index the time column so these checks and range reads stay
+cheap.
 
-PostgreSQL dynamic tables are append-only when the full-table cache is enabled. Updating or deleting
+PostgreSQL dynamic tables are append-only when the in-memory cache is enabled. Updating or deleting
 existing membership, including removals, is not supported in this mode. Keeping `time_column` current
 is a user requirement and part of the cache's correctness contract. Every process that appends table
 membership must use the same serialized-writer protocol:

--- a/README.md
+++ b/README.md
@@ -973,7 +973,7 @@ dynamic_table_backend:
     cache_enabled: true
 ```
 
-Then set `time_column` on each backing table whose timestamp advances on every change:
+Then set `time_column` on each backing table whose timestamp advances on every append:
 
 ```yaml
 transforms:
@@ -988,33 +988,31 @@ The cache is off by default and is used only when both settings are present. Eac
 `dynamic_table_check` batch reads only `MAX(time_column)` and reloads the cache when it changes.
 Index the time column so this check stays cheap.
 
-Keeping `time_column` current is a user requirement and part of the cache's correctness contract.
-Every process that can insert, update, or delete table membership must use the same serialized-writer
-protocol:
+PostgreSQL dynamic tables are append-only when the full-table cache is enabled. Updating or deleting
+existing membership, including removals, is not supported in this mode. Keeping `time_column` current
+is a user requirement and part of the cache's correctness contract. Every process that appends table
+membership must use the same serialized-writer protocol:
 
 ```sql
 BEGIN;
 SELECT pg_advisory_xact_lock(hashtextextended('public.persistent_data', 0));
--- Perform the mutation and assign updated_at after taking the lock.
-UPDATE public.persistent_data
-SET value = 'new-value', updated_at = clock_timestamp()
-WHERE value = 'old-value';
+INSERT INTO public.persistent_data (value, updated_at)
+VALUES ('new-value', clock_timestamp())
+ON CONFLICT (value) DO NOTHING;
 COMMIT;
 ```
 
 Use the schema-qualified table name as the lock key, exactly as shown. Transaction-scoped advisory
-locks coordinate only writers that follow this protocol. The mutation must atomically make
-`MAX(time_column)` different; normally it should set a non-null timestamp strictly newer than the
-previous maximum. For a physical delete, also bump a surviving row or retained change-marker row in
-the same transaction. `NOW()` and `CURRENT_TIMESTAMP` are unsafe here because PostgreSQL fixes them
-at transaction start, which can precede waiting for the writer lock; use `clock_timestamp()` after
-the lock instead.
+locks coordinate only writers that follow this protocol. Each successful append must atomically make
+`MAX(time_column)` different by assigning a non-null timestamp strictly newer than the previous
+maximum. `NOW()` and `CURRENT_TIMESTAMP` are unsafe here because PostgreSQL fixes them at transaction
+start, which can precede waiting for the writer lock; use `clock_timestamp()` after the lock instead.
 
 Streamling takes this lock automatically for its own cached appends and creates new backing tables
 with `updated_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()`. It does not alter existing tables.
 Tables created by older Streamling versions with nullable `TIMESTAMPTZ DEFAULT NOW()` need no schema
 or data migration: cached Streamling appends explicitly write `clock_timestamp()` after taking the
-lock. Future mutations from other writers must still follow the protocol above. Cache initialization
+lock. Future appends from other writers must still follow the protocol above. Cache initialization
 checks that the configured column exists and supports `MAX`, but it cannot verify that other writers
 obey the protocol. If that cannot be guaranteed, leave caching disabled; uncached tables continue to
 use batched PostgreSQL lookups.

--- a/README.md
+++ b/README.md
@@ -964,6 +964,31 @@ transforms:
     backend_entity_name: persistent_data
 ```
 
+Enable the full-table cache in the application config (or with
+`STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__CACHE_ENABLED=true`):
+
+```yaml
+dynamic_table_backend:
+  postgres:
+    cache_enabled: true
+```
+
+Then set `time_column` on each backing table whose timestamp advances on every change:
+
+```yaml
+transforms:
+  persistent_table:
+    type: dynamic_table
+    backend_type: Postgres
+    backend_entity_name: persistent_data
+    time_column: updated_at
+```
+
+The cache is off by default and is used only when both settings are present. Each
+`dynamic_table_check` batch reads `MAX(time_column)` and reloads the cache only when it changes.
+Index the time column so this check stays cheap. Tables without a reliable update timestamp, or
+deployments with `cache_enabled: false`, continue to use batched PostgreSQL lookups.
+
 ### Usage with SQL Transforms
 
 Dynamic tables are accessed within SQL transforms using the `dynamic_table_check` UDF (User Defined Function). This function checks if a value exists in the specified dynamic table.

--- a/crates/streamling-config/default_config.yaml
+++ b/crates/streamling-config/default_config.yaml
@@ -34,6 +34,7 @@ dynamic_table_backend:
     user: "graph-node"
     password: ""
     sslmode: "require"
+    cache_enabled: false
 external_http_handler:
   trigger_max_count: "2000"
   operator_timeout_sec: "300"

--- a/crates/streamling-config/src/app_config.rs
+++ b/crates/streamling-config/src/app_config.rs
@@ -162,7 +162,7 @@ pub struct PostgresDynamicTableBackendConfig {
     pub sslmode: String,
     pub max_connections: Option<u32>,
     pub dt_schema_name: Option<String>,
-    /// Enables full-table caching for dynamic tables that explicitly set `time_column`.
+    /// Enables incremental in-memory caching for dynamic tables that explicitly set `time_column`.
     #[serde(default)]
     pub cache_enabled: bool,
 }

--- a/crates/streamling-config/src/app_config.rs
+++ b/crates/streamling-config/src/app_config.rs
@@ -162,6 +162,9 @@ pub struct PostgresDynamicTableBackendConfig {
     pub sslmode: String,
     pub max_connections: Option<u32>,
     pub dt_schema_name: Option<String>,
+    /// Enables full-table caching for dynamic tables that explicitly set `time_column`.
+    #[serde(default)]
+    pub cache_enabled: bool,
 }
 
 impl std::fmt::Debug for PostgresDynamicTableBackendConfig {
@@ -180,6 +183,7 @@ impl std::fmt::Debug for PostgresDynamicTableBackendConfig {
             .field("sslmode", &self.sslmode)
             .field("max_connections", &self.max_connections)
             .field("dt_schema_name", &self.dt_schema_name)
+            .field("cache_enabled", &self.cache_enabled)
             .finish()
     }
 }

--- a/crates/streamling-core/src/dynamic_table/postgres.rs
+++ b/crates/streamling-core/src/dynamic_table/postgres.rs
@@ -22,6 +22,7 @@ use tracing::{debug, error, info, trace};
 const DEFAULT_MAX_CONNECTIONS: u32 = 20;
 const DEFAULT_SCHEMA_NAME: &str = "streamling";
 const IDENTIFIER_PATTERN: &str = r"^[A-Za-z_][A-Za-z0-9_]*$";
+const CACHE_WRITE_LOCK_QUERY: &str = "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))";
 /// Statement timeout for each individual database query (30 seconds)
 const STATEMENT_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -367,6 +368,27 @@ impl PostgresDynamicTableBackend {
         values
     }
 
+    async fn validate_cache_time_column(
+        &self,
+        pool: &PgPool,
+    ) -> Result<(), DynamicTableBackendError> {
+        let query = format!(
+            r#"SELECT MAX("{}")::TEXT FROM {} WHERE FALSE"#,
+            self.time_column_name, self.full_table_name
+        );
+
+        sqlx::query(&query).execute(pool).await.map_err(|e| {
+            let err = DynamicTableBackendError::Initialization(format!(
+                "Failed to validate cache time column '{}' for table {}: {}",
+                self.time_column_name, self.full_table_name, e
+            ));
+            error!("{}", err);
+            err
+        })?;
+
+        Ok(())
+    }
+
     /// Check if a batch of values exist in the table (internal method that doesn't split batches)
     /// Retries forever with exponential backoff. Statement timeout prevents individual queries from hanging.
     /// Uses Arc to wrap values so retry clones are cheap (reference count increment only).
@@ -448,6 +470,8 @@ impl PostgresDynamicTableBackend {
         let values: Arc<[String]> = Arc::from(values.into_boxed_slice());
         let full_table_name: Arc<str> = Arc::from(self.full_table_name.as_str());
         let column_name: Arc<str> = Arc::from(self.column_name.as_str());
+        let time_column_name: Arc<str> = Arc::from(self.time_column_name.as_str());
+        let serialize_write = self.cache.is_some();
         let operation_name = format!("DynamicTable append_batch ({})", self.full_table_name);
 
         retry_forever_with_backoff_async_returning(
@@ -457,33 +481,80 @@ impl PostgresDynamicTableBackend {
                 let values = values.clone();
                 let full_table_name = full_table_name.clone();
                 let column_name = column_name.clone();
+                let time_column_name = time_column_name.clone();
                 async move {
                     // Create batch insert query with UNNEST for multiple values
                     let placeholders: Vec<String> =
                         (1..=values.len()).map(|i| format!("${}", i)).collect();
-                    let query = format!(
-                        r#"
-                        INSERT INTO {} ("{}")
-                        SELECT DISTINCT unnest(ARRAY[{}])
-                        ON CONFLICT ("{}") DO NOTHING
-                        "#,
-                        full_table_name,
-                        column_name,
-                        placeholders.join(", "),
-                        column_name
-                    );
+                    let query = if serialize_write {
+                        format!(
+                            r#"
+                            INSERT INTO {} ("{}", "{}")
+                            SELECT new_value, CLOCK_TIMESTAMP()
+                            FROM (
+                                SELECT DISTINCT unnest(ARRAY[{}]) AS new_value
+                            ) AS new_values
+                            ON CONFLICT ("{}") DO NOTHING
+                            "#,
+                            full_table_name,
+                            column_name,
+                            time_column_name,
+                            placeholders.join(", "),
+                            column_name
+                        )
+                    } else {
+                        format!(
+                            r#"
+                            INSERT INTO {} ("{}")
+                            SELECT DISTINCT unnest(ARRAY[{}])
+                            ON CONFLICT ("{}") DO NOTHING
+                            "#,
+                            full_table_name,
+                            column_name,
+                            placeholders.join(", "),
+                            column_name
+                        )
+                    };
 
                     let mut sqlx_query = sqlx::query(&query);
                     for value in values.iter() {
                         sqlx_query = sqlx_query.bind(value);
                     }
 
-                    sqlx_query
-                        .execute(pool.as_ref())
-                        .await
-                        .streamling_with_context(|| {
-                            format!("failed to append values to table {}", full_table_name)
+                    if serialize_write {
+                        let mut transaction = pool.begin().await.streamling_with_context(|| {
+                            format!("failed to begin cached write to table {full_table_name}")
                         })?;
+
+                        // ponytail: cached writes serialize per table; add a dedicated version row
+                        // only if write throughput makes this lock material.
+                        sqlx::query(CACHE_WRITE_LOCK_QUERY)
+                            .bind(full_table_name.as_ref())
+                            .execute(&mut *transaction)
+                            .await
+                            .streamling_with_context(|| {
+                                format!(
+                                    "failed to serialize cached writes to table {full_table_name}"
+                                )
+                            })?;
+
+                        sqlx_query
+                            .execute(&mut *transaction)
+                            .await
+                            .streamling_with_context(|| {
+                                format!("failed to append values to table {full_table_name}")
+                            })?;
+                        transaction.commit().await.streamling_with_context(|| {
+                            format!("failed to commit cached write to table {full_table_name}")
+                        })?;
+                    } else {
+                        sqlx_query
+                            .execute(pool.as_ref())
+                            .await
+                            .streamling_with_context(|| {
+                                format!("failed to append values to table {full_table_name}")
+                            })?;
+                    }
 
                     Ok(())
                 }
@@ -609,7 +680,7 @@ impl PostgresDynamicTableBackend {
                             r#"
                             CREATE TABLE IF NOT EXISTS {} (
                                 "{}" TEXT PRIMARY KEY,
-                                "{}" TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+                                "{}" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CLOCK_TIMESTAMP()
                             );
                         "#,
                             self.full_table_name, self.column_name, self.time_column_name
@@ -637,6 +708,10 @@ impl PostgresDynamicTableBackend {
                         "Table {} already exists, skipping creation",
                         self.full_table_name
                     );
+                }
+
+                if self.cache.is_some() {
+                    self.validate_cache_time_column(pool_arc.as_ref()).await?;
                 }
 
                 Ok::<Arc<PgPool>, DynamicTableBackendError>(pool_arc)

--- a/crates/streamling-core/src/dynamic_table/postgres.rs
+++ b/crates/streamling-core/src/dynamic_table/postgres.rs
@@ -23,6 +23,8 @@ const DEFAULT_MAX_CONNECTIONS: u32 = 20;
 const DEFAULT_SCHEMA_NAME: &str = "streamling";
 const IDENTIFIER_PATTERN: &str = r"^[A-Za-z_][A-Za-z0-9_]*$";
 const CACHE_WRITE_LOCK_QUERY: &str = "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))";
+const CACHE_LOAD_CURSOR_NAME: &str = "streamling_dynamic_table_cache";
+const CACHE_LOAD_PAGE_SIZE: usize = 1_000;
 /// Statement timeout for each individual database query (30 seconds)
 const STATEMENT_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -314,74 +316,101 @@ impl PostgresDynamicTableBackend {
     ) -> PostgresDynamicTableCache {
         // Serialized append-only writers assign CLOCK_TIMESTAMP after taking the
         // table lock; use a dedicated version cursor if that contract changes.
-        let query: Arc<str> = if updated_since.is_some() {
+        let max_query: Arc<str> = format!(
+            r#"SELECT MAX("{}")::TEXT FROM {}"#,
+            self.time_column_name, self.full_table_name
+        )
+        .into();
+        let declare_cursor_query: Arc<str> = if updated_since.is_some() {
             format!(
                 r#"
-                SELECT
-                    COALESCE(
-                        ARRAY_AGG("{}"::TEXT) FILTER (WHERE "{}" IS NOT NULL),
-                        ARRAY[]::TEXT[]
-                    ),
-                    (SELECT MAX("{}")::TEXT FROM {})
+                DECLARE {CACHE_LOAD_CURSOR_NAME} NO SCROLL CURSOR FOR
+                SELECT "{}"::TEXT
                 FROM {}
-                WHERE "{}" > $1::TIMESTAMPTZ
+                WHERE "{}" IS NOT NULL AND "{}" > $1::TIMESTAMPTZ
                 "#,
-                self.column_name,
-                self.column_name,
-                self.time_column_name,
-                self.full_table_name,
-                self.full_table_name,
-                self.time_column_name
+                self.column_name, self.full_table_name, self.column_name, self.time_column_name
             )
         } else {
             format!(
                 r#"
-                SELECT
-                    COALESCE(
-                        ARRAY_AGG("{}"::TEXT) FILTER (WHERE "{}" IS NOT NULL),
-                        ARRAY[]::TEXT[]
-                    ),
-                    MAX("{}")::TEXT
+                DECLARE {CACHE_LOAD_CURSOR_NAME} NO SCROLL CURSOR FOR
+                SELECT "{}"::TEXT
                 FROM {}
+                WHERE "{}" IS NOT NULL
                 "#,
-                self.column_name, self.column_name, self.time_column_name, self.full_table_name
+                self.column_name, self.full_table_name, self.column_name
             )
         }
         .into();
+        let fetch_page_query: Arc<str> =
+            format!("FETCH FORWARD {CACHE_LOAD_PAGE_SIZE} FROM {CACHE_LOAD_CURSOR_NAME}").into();
         let updated_since = updated_since.map(str::to_owned);
         let full_table_name: Arc<str> = Arc::from(self.full_table_name.as_str());
         let operation_name = format!("DynamicTable load_cache ({})", self.full_table_name);
 
-        let (values, updated_at): (Vec<String>, Option<String>) =
-            retry_forever_with_backoff_async_returning(
-                || {
-                    let pool = pool.clone();
-                    let query = query.clone();
-                    let updated_since = updated_since.clone();
-                    let full_table_name = full_table_name.clone();
-                    async move {
-                        let sqlx_query = sqlx::query_as(query.as_ref());
-                        let sqlx_query = if let Some(updated_since) = updated_since {
-                            sqlx_query.bind(updated_since)
-                        } else {
-                            sqlx_query
-                        };
-                        sqlx_query
-                            .fetch_one(pool.as_ref())
+        retry_forever_with_backoff_async_returning(
+            || {
+                let pool = pool.clone();
+                let max_query = max_query.clone();
+                let declare_cursor_query = declare_cursor_query.clone();
+                let fetch_page_query = fetch_page_query.clone();
+                let updated_since = updated_since.clone();
+                let full_table_name = full_table_name.clone();
+                async move {
+                    let mut transaction = pool.begin().await.streamling_with_context(|| {
+                        format!("failed to begin cache load for table {full_table_name}")
+                    })?;
+                    sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY")
+                        .execute(&mut *transaction)
+                        .await
+                        .streamling_with_context(|| {
+                            format!("failed to configure cache load for table {full_table_name}")
+                        })?;
+
+                    let updated_at = sqlx::query_scalar::<_, Option<String>>(max_query.as_ref())
+                        .fetch_one(&mut *transaction)
+                        .await
+                        .streamling_with_context(|| {
+                            format!("failed to read cache version from table {full_table_name}")
+                        })?;
+
+                    let cursor_query = sqlx::query(declare_cursor_query.as_ref());
+                    let cursor_query = if let Some(updated_since) = updated_since {
+                        cursor_query.bind(updated_since)
+                    } else {
+                        cursor_query
+                    };
+                    cursor_query
+                        .execute(&mut *transaction)
+                        .await
+                        .streamling_with_context(|| {
+                            format!("failed to open cache cursor for table {full_table_name}")
+                        })?;
+
+                    let mut values = HashSet::new();
+                    loop {
+                        let page: Vec<String> = sqlx::query_scalar(fetch_page_query.as_ref())
+                            .fetch_all(&mut *transaction)
                             .await
                             .streamling_with_context(|| {
-                                format!("failed to load cache from table {full_table_name}")
-                            })
+                                format!("failed to fetch cache page from table {full_table_name}")
+                            })?;
+                        if page.is_empty() {
+                            break;
+                        }
+                        values.extend(page.into_iter().map(String::into_boxed_str));
                     }
-                },
-                &operation_name,
-            )
-            .await;
 
-        PostgresDynamicTableCache {
-            updated_at,
-            values: values.into_iter().map(String::into_boxed_str).collect(),
-        }
+                    transaction.commit().await.streamling_with_context(|| {
+                        format!("failed to finish cache load for table {full_table_name}")
+                    })?;
+                    Ok(PostgresDynamicTableCache { updated_at, values })
+                }
+            },
+            &operation_name,
+        )
+        .await
     }
 
     async fn refresh_cache(&self, pool: Arc<PgPool>) {

--- a/crates/streamling-core/src/dynamic_table/postgres.rs
+++ b/crates/streamling-core/src/dynamic_table/postgres.rs
@@ -226,7 +226,14 @@ impl PostgresDynamicTableBackendFactory {
 #[derive(Debug)]
 struct PostgresDynamicTableCache {
     updated_at: Option<String>,
-    values: Arc<HashSet<Box<str>>>,
+    values: HashSet<Box<str>>,
+}
+
+impl PostgresDynamicTableCache {
+    fn append(&mut self, update: Self) {
+        self.updated_at = update.updated_at;
+        self.values.extend(update.values);
+    }
 }
 
 /// A lightweight PostgreSQL backend instance that shares the connection pool
@@ -300,20 +307,48 @@ impl PostgresDynamicTableBackend {
         .await
     }
 
-    async fn load_cache(&self, pool: Arc<PgPool>) -> PostgresDynamicTableCache {
-        let query: Arc<str> = format!(
-            r#"
-            SELECT
-                COALESCE(
-                    ARRAY_AGG("{}"::TEXT) FILTER (WHERE "{}" IS NOT NULL),
-                    ARRAY[]::TEXT[]
-                ),
-                MAX("{}")::TEXT
-            FROM {}
-            "#,
-            self.column_name, self.column_name, self.time_column_name, self.full_table_name
-        )
+    async fn load_cache(
+        &self,
+        pool: Arc<PgPool>,
+        updated_since: Option<&str>,
+    ) -> PostgresDynamicTableCache {
+        // ponytail: serialized append-only writers assign CLOCK_TIMESTAMP after taking the
+        // table lock; use a dedicated version cursor if that contract changes.
+        let query: Arc<str> = if updated_since.is_some() {
+            format!(
+                r#"
+                SELECT
+                    COALESCE(
+                        ARRAY_AGG("{}"::TEXT) FILTER (WHERE "{}" IS NOT NULL),
+                        ARRAY[]::TEXT[]
+                    ),
+                    (SELECT MAX("{}")::TEXT FROM {})
+                FROM {}
+                WHERE "{}" > $1::TIMESTAMPTZ
+                "#,
+                self.column_name,
+                self.column_name,
+                self.time_column_name,
+                self.full_table_name,
+                self.full_table_name,
+                self.time_column_name
+            )
+        } else {
+            format!(
+                r#"
+                SELECT
+                    COALESCE(
+                        ARRAY_AGG("{}"::TEXT) FILTER (WHERE "{}" IS NOT NULL),
+                        ARRAY[]::TEXT[]
+                    ),
+                    MAX("{}")::TEXT
+                FROM {}
+                "#,
+                self.column_name, self.column_name, self.time_column_name, self.full_table_name
+            )
+        }
         .into();
+        let updated_since = updated_since.map(str::to_owned);
         let full_table_name: Arc<str> = Arc::from(self.full_table_name.as_str());
         let operation_name = format!("DynamicTable load_cache ({})", self.full_table_name);
 
@@ -322,9 +357,16 @@ impl PostgresDynamicTableBackend {
                 || {
                     let pool = pool.clone();
                     let query = query.clone();
+                    let updated_since = updated_since.clone();
                     let full_table_name = full_table_name.clone();
                     async move {
-                        sqlx::query_as(query.as_ref())
+                        let sqlx_query = sqlx::query_as(query.as_ref());
+                        let sqlx_query = if let Some(updated_since) = updated_since {
+                            sqlx_query.bind(updated_since)
+                        } else {
+                            sqlx_query
+                        };
+                        sqlx_query
                             .fetch_one(pool.as_ref())
                             .await
                             .streamling_with_context(|| {
@@ -338,34 +380,63 @@ impl PostgresDynamicTableBackend {
 
         PostgresDynamicTableCache {
             updated_at,
-            values: Arc::new(values.into_iter().map(String::into_boxed_str).collect()),
+            values: values.into_iter().map(String::into_boxed_str).collect(),
         }
     }
 
-    async fn cached_values(&self, pool: Arc<PgPool>) -> Arc<HashSet<Box<str>>> {
+    async fn refresh_cache(&self, pool: Arc<PgPool>) {
         let cache = self
             .cache
             .as_ref()
-            .expect("cache is present when cached_values is called");
+            .expect("cache is present when refresh_cache is called");
         let updated_at = self.latest_update(pool.clone()).await;
 
         if let Some(cached) = cache.read().await.as_ref()
             && cached.updated_at == updated_at
         {
-            return cached.values.clone();
+            return;
         }
 
         let mut cached = cache.write().await;
         if let Some(current) = cached.as_ref()
             && current.updated_at == updated_at
         {
-            return current.values.clone();
+            return;
         }
 
-        let refreshed = self.load_cache(pool).await;
-        let values = refreshed.values.clone();
-        *cached = Some(refreshed);
-        values
+        let updated_since = cached
+            .as_ref()
+            .and_then(|current| current.updated_at.as_deref())
+            .map(str::to_owned);
+        let refreshed = self.load_cache(pool, updated_since.as_deref()).await;
+
+        if let Some(current) = cached.as_mut() {
+            current.append(refreshed);
+        } else {
+            *cached = Some(refreshed);
+        }
+    }
+
+    fn build_contains_result(
+        &self,
+        string_array: &StringArray,
+        existing_set: &HashSet<Box<str>>,
+    ) -> ArrayRef {
+        let mut builder = BooleanBuilder::with_capacity(string_array.len());
+        for i in 0..string_array.len() {
+            if string_array.is_null(i) {
+                builder.append_null();
+            } else {
+                let value = string_array.value(i);
+                let contains_value = existing_set.contains(value);
+                builder.append_value(contains_value);
+                trace!(
+                    "[contains] for table name '{}' with value '{}' result '{:?}'",
+                    self.full_table_name, value, contains_value
+                );
+            }
+        }
+        Arc::new(builder.finish())
     }
 
     async fn validate_cache_time_column(
@@ -373,8 +444,8 @@ impl PostgresDynamicTableBackend {
         pool: &PgPool,
     ) -> Result<(), DynamicTableBackendError> {
         let query = format!(
-            r#"SELECT MAX("{}")::TEXT FROM {} WHERE FALSE"#,
-            self.time_column_name, self.full_table_name
+            r#"SELECT MAX("{}")::TEXT FROM {} WHERE "{}" >= CURRENT_TIMESTAMP AND FALSE"#,
+            self.time_column_name, self.full_table_name, self.time_column_name
         );
 
         sqlx::query(&query).execute(pool).await.map_err(|e| {
@@ -793,7 +864,18 @@ impl DynamicTableBackend for PostgresDynamicTableBackend {
             .downcast_ref::<StringArray>()
             .ok_or(DynamicTableBackendError::StringArrayExpected)?;
 
-        // Collect non-null values with their indices (owned strings for retry)
+        if let Some(cache) = &self.cache {
+            // Check for table changes on every invocation, including empty/all-null batches.
+            self.refresh_cache(pool).await;
+            let cached = cache.read().await;
+            let existing_set = &cached
+                .as_ref()
+                .expect("cache is loaded after refresh_cache")
+                .values;
+            return Ok(self.build_contains_result(string_array, existing_set));
+        }
+
+        // Uncached queries need owned strings for retries.
         let value_indices: Vec<(usize, String)> = (0..string_array.len())
             .filter_map(|i| {
                 if !string_array.is_null(i) {
@@ -804,77 +886,46 @@ impl DynamicTableBackend for PostgresDynamicTableBackend {
             })
             .collect();
 
-        // Check for table changes on every invocation, including empty/all-null batches.
-        let cached_values = if self.cache.is_some() {
-            Some(self.cached_values(pool.clone()).await)
-        } else {
-            None
-        };
-
-        let mut builder = BooleanBuilder::with_capacity(string_array.len());
-
         if value_indices.is_empty() {
-            // Handle case where all values are null
-            for _ in 0..string_array.len() {
-                builder.append_null();
-            }
-        } else {
-            // Use the opt-in full-table cache, otherwise query only the requested values.
-            let existing_set = if let Some(cached_values) = cached_values {
-                cached_values
-            } else if value_indices.len() <= self.max_batch_size {
-                // Single batch - process directly
-                Arc::new(self.contains_batch(pool, value_indices).await)
-            } else {
-                // Split into multiple batches and process concurrently
-                let chunks: Vec<Vec<(usize, String)>> = value_indices
-                    .chunks(self.max_batch_size)
-                    .map(|chunk| chunk.to_vec())
-                    .collect();
-
-                trace!(
-                    "Splitting {} values into {} concurrent batches for contains() on table {}",
-                    chunks.iter().map(|c| c.len()).sum::<usize>(),
-                    chunks.len(),
-                    self.full_table_name
-                );
-
-                // Process all chunks concurrently
-                let futures: Vec<_> = chunks
-                    .into_iter()
-                    .map(|chunk| {
-                        let pool = pool.clone();
-                        async move { self.contains_batch(pool, chunk).await }
-                    })
-                    .collect();
-
-                // Wait for all batches to complete and combine results
-                let results = join_all(futures).await;
-                let mut combined_set = HashSet::new();
-                for chunk_set in results {
-                    combined_set.extend(chunk_set);
-                }
-                Arc::new(combined_set)
-            };
-
-            // Build result array maintaining original order
-            for i in 0..string_array.len() {
-                if string_array.is_null(i) {
-                    builder.append_null();
-                } else {
-                    let value = string_array.value(i);
-                    let contains_value = existing_set.contains(value);
-                    builder.append_value(contains_value);
-                    trace!(
-                        "[contains] for table name '{}' with value '{}' result '{:?}'",
-                        self.full_table_name, value, contains_value
-                    );
-                }
-            }
+            return Ok(self.build_contains_result(string_array, &HashSet::new()));
         }
 
-        let boolean_array = builder.finish();
-        Ok(Arc::new(boolean_array))
+        let existing_set = if value_indices.len() <= self.max_batch_size {
+            // Single batch - process directly
+            self.contains_batch(pool, value_indices).await
+        } else {
+            // Split into multiple batches and process concurrently
+            let chunks: Vec<Vec<(usize, String)>> = value_indices
+                .chunks(self.max_batch_size)
+                .map(|chunk| chunk.to_vec())
+                .collect();
+
+            trace!(
+                "Splitting {} values into {} concurrent batches for contains() on table {}",
+                chunks.iter().map(|c| c.len()).sum::<usize>(),
+                chunks.len(),
+                self.full_table_name
+            );
+
+            // Process all chunks concurrently
+            let futures: Vec<_> = chunks
+                .into_iter()
+                .map(|chunk| {
+                    let pool = pool.clone();
+                    async move { self.contains_batch(pool, chunk).await }
+                })
+                .collect();
+
+            // Wait for all batches to complete and combine results
+            let results = join_all(futures).await;
+            let mut combined_set = HashSet::new();
+            for chunk_set in results {
+                combined_set.extend(chunk_set);
+            }
+            combined_set
+        };
+
+        Ok(self.build_contains_result(string_array, &existing_set))
     }
 }
 
@@ -894,6 +945,25 @@ mod tests {
             dt_schema_name: None,
             cache_enabled,
         }
+    }
+
+    #[test]
+    fn cache_append_preserves_existing_values() {
+        let mut cache = PostgresDynamicTableCache {
+            updated_at: Some("old".to_string()),
+            values: HashSet::from([Box::<str>::from("existing")]),
+        };
+        let update = PostgresDynamicTableCache {
+            updated_at: Some("new".to_string()),
+            values: HashSet::from([Box::<str>::from("appended")]),
+        };
+
+        cache.append(update);
+
+        assert_eq!(cache.updated_at.as_deref(), Some("new"));
+        assert_eq!(cache.values.len(), 2);
+        assert!(cache.values.contains("existing"));
+        assert!(cache.values.contains("appended"));
     }
 
     #[tokio::test]

--- a/crates/streamling-core/src/dynamic_table/postgres.rs
+++ b/crates/streamling-core/src/dynamic_table/postgres.rs
@@ -11,11 +11,12 @@ use regex::Regex;
 use sqlx::pool::PoolOptions;
 use sqlx::postgres::PgConnectOptions;
 use sqlx::{Executor, PgPool, Postgres};
+use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use streamling_config::app_config::PostgresDynamicTableBackendConfig;
-use tokio::sync::OnceCell;
+use tokio::sync::{OnceCell, RwLock};
 use tracing::{debug, error, info, trace};
 
 const DEFAULT_MAX_CONNECTIONS: u32 = 20;
@@ -194,16 +195,16 @@ impl PostgresDynamicTableBackendFactory {
             err
         })?;
 
-        // Use provided time_column or default to "updated_at"
-        let time_column_name = time_column.unwrap_or_else(|| "updated_at".to_string());
-        Self::validate_identifier(&time_column_name).map_err(|e| {
-            let err = DynamicTableBackendError::Initialization(format!(
-                "Invalid time column name: {}",
-                e
-            ));
-            error!("{}", err);
-            err
-        })?;
+        if let Some(time_column_name) = &time_column {
+            Self::validate_identifier(time_column_name).map_err(|e| {
+                let err = DynamicTableBackendError::Initialization(format!(
+                    "Invalid time column name: {}",
+                    e
+                ));
+                error!("{}", err);
+                err
+            })?;
+        }
 
         let full_table_name = format!("{}.{}", schema_name, backend_entity_name);
         trace!("Full table name: {}", full_table_name);
@@ -215,10 +216,16 @@ impl PostgresDynamicTableBackendFactory {
             full_table_name,
             schema_name,
             column_name,
-            time_column_name,
+            time_column,
             max_batch_size,
         ))
     }
+}
+
+#[derive(Debug)]
+struct PostgresDynamicTableCache {
+    updated_at: Option<String>,
+    values: Arc<HashSet<Box<str>>>,
 }
 
 /// A lightweight PostgreSQL backend instance that shares the connection pool
@@ -230,6 +237,7 @@ pub struct PostgresDynamicTableBackend {
     dt_schema_name: String,
     column_name: String,
     time_column_name: String,
+    cache: Option<RwLock<Option<PostgresDynamicTableCache>>>,
     max_batch_size: usize,
 }
 
@@ -240,13 +248,16 @@ impl PostgresDynamicTableBackend {
         full_table_name: String,
         dt_schema_name: String,
         column_name: String,
-        time_column_name: String,
+        time_column_name: Option<String>,
         max_batch_size: usize,
     ) -> Self {
         debug!(
             "Creating PostgreSQL dynamic table backend instance for table: {}",
             full_table_name
         );
+
+        let cache = (config.cache_enabled && time_column_name.is_some()).then(|| RwLock::new(None));
+        let time_column_name = time_column_name.unwrap_or_else(|| "updated_at".to_string());
 
         Self {
             pool,
@@ -255,8 +266,105 @@ impl PostgresDynamicTableBackend {
             dt_schema_name,
             column_name,
             time_column_name,
+            cache,
             max_batch_size,
         }
+    }
+
+    async fn latest_update(&self, pool: Arc<PgPool>) -> Option<String> {
+        let query: Arc<str> = format!(
+            r#"SELECT MAX("{}")::TEXT FROM {}"#,
+            self.time_column_name, self.full_table_name
+        )
+        .into();
+        let full_table_name: Arc<str> = Arc::from(self.full_table_name.as_str());
+        let operation_name = format!("DynamicTable latest_update ({})", self.full_table_name);
+
+        retry_forever_with_backoff_async_returning(
+            || {
+                let pool = pool.clone();
+                let query = query.clone();
+                let full_table_name = full_table_name.clone();
+                async move {
+                    sqlx::query_scalar::<_, Option<String>>(query.as_ref())
+                        .fetch_one(pool.as_ref())
+                        .await
+                        .streamling_with_context(|| {
+                            format!("failed to read latest update from table {full_table_name}")
+                        })
+                }
+            },
+            &operation_name,
+        )
+        .await
+    }
+
+    async fn load_cache(&self, pool: Arc<PgPool>) -> PostgresDynamicTableCache {
+        let query: Arc<str> = format!(
+            r#"
+            SELECT
+                COALESCE(
+                    ARRAY_AGG("{}"::TEXT) FILTER (WHERE "{}" IS NOT NULL),
+                    ARRAY[]::TEXT[]
+                ),
+                MAX("{}")::TEXT
+            FROM {}
+            "#,
+            self.column_name, self.column_name, self.time_column_name, self.full_table_name
+        )
+        .into();
+        let full_table_name: Arc<str> = Arc::from(self.full_table_name.as_str());
+        let operation_name = format!("DynamicTable load_cache ({})", self.full_table_name);
+
+        let (values, updated_at): (Vec<String>, Option<String>) =
+            retry_forever_with_backoff_async_returning(
+                || {
+                    let pool = pool.clone();
+                    let query = query.clone();
+                    let full_table_name = full_table_name.clone();
+                    async move {
+                        sqlx::query_as(query.as_ref())
+                            .fetch_one(pool.as_ref())
+                            .await
+                            .streamling_with_context(|| {
+                                format!("failed to load cache from table {full_table_name}")
+                            })
+                    }
+                },
+                &operation_name,
+            )
+            .await;
+
+        PostgresDynamicTableCache {
+            updated_at,
+            values: Arc::new(values.into_iter().map(String::into_boxed_str).collect()),
+        }
+    }
+
+    async fn cached_values(&self, pool: Arc<PgPool>) -> Arc<HashSet<Box<str>>> {
+        let cache = self
+            .cache
+            .as_ref()
+            .expect("cache is present when cached_values is called");
+        let updated_at = self.latest_update(pool.clone()).await;
+
+        if let Some(cached) = cache.read().await.as_ref()
+            && cached.updated_at == updated_at
+        {
+            return cached.values.clone();
+        }
+
+        let mut cached = cache.write().await;
+        if let Some(current) = cached.as_ref()
+            && current.updated_at == updated_at
+        {
+            return current.values.clone();
+        }
+
+        let refreshed = self.load_cache(pool).await;
+        let values = refreshed.values.clone();
+        *cached = Some(refreshed);
+        values
     }
 
     /// Check if a batch of values exist in the table (internal method that doesn't split batches)
@@ -266,9 +374,9 @@ impl PostgresDynamicTableBackend {
         &self,
         pool: Arc<PgPool>,
         value_indices: Vec<(usize, String)>,
-    ) -> std::collections::HashSet<String> {
+    ) -> HashSet<Box<str>> {
         if value_indices.is_empty() {
-            return std::collections::HashSet::new();
+            return HashSet::new();
         }
 
         // Wrap in Arc once before the retry loop to avoid cloning Vec on each retry
@@ -316,7 +424,10 @@ impl PostgresDynamicTableBackend {
                             )
                         })?;
 
-                    Ok(existing_values.into_iter().collect())
+                    Ok(existing_values
+                        .into_iter()
+                        .map(String::into_boxed_str)
+                        .collect())
                 }
             },
             &operation_name,
@@ -618,6 +729,13 @@ impl DynamicTableBackend for PostgresDynamicTableBackend {
             })
             .collect();
 
+        // Check for table changes on every invocation, including empty/all-null batches.
+        let cached_values = if self.cache.is_some() {
+            Some(self.cached_values(pool.clone()).await)
+        } else {
+            None
+        };
+
         let mut builder = BooleanBuilder::with_capacity(string_array.len());
 
         if value_indices.is_empty() {
@@ -626,10 +744,12 @@ impl DynamicTableBackend for PostgresDynamicTableBackend {
                 builder.append_null();
             }
         } else {
-            // Split into batches if exceeding max_batch_size
-            let existing_set = if value_indices.len() <= self.max_batch_size {
+            // Use the opt-in full-table cache, otherwise query only the requested values.
+            let existing_set = if let Some(cached_values) = cached_values {
+                cached_values
+            } else if value_indices.len() <= self.max_batch_size {
                 // Single batch - process directly
-                self.contains_batch(pool, value_indices).await
+                Arc::new(self.contains_batch(pool, value_indices).await)
             } else {
                 // Split into multiple batches and process concurrently
                 let chunks: Vec<Vec<(usize, String)>> = value_indices
@@ -655,11 +775,11 @@ impl DynamicTableBackend for PostgresDynamicTableBackend {
 
                 // Wait for all batches to complete and combine results
                 let results = join_all(futures).await;
-                let mut combined_set = std::collections::HashSet::new();
+                let mut combined_set = HashSet::new();
                 for chunk_set in results {
                     combined_set.extend(chunk_set);
                 }
-                combined_set
+                Arc::new(combined_set)
             };
 
             // Build result array maintaining original order
@@ -680,5 +800,63 @@ impl DynamicTableBackend for PostgresDynamicTableBackend {
 
         let boolean_array = builder.finish();
         Ok(Arc::new(boolean_array))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn postgres_config(cache_enabled: bool) -> PostgresDynamicTableBackendConfig {
+        PostgresDynamicTableBackendConfig {
+            host: "localhost".to_string(),
+            port: 5432,
+            db: "postgres".to_string(),
+            user: "postgres".to_string(),
+            password: "postgres".to_string(),
+            sslmode: "disable".to_string(),
+            max_connections: None,
+            dt_schema_name: None,
+            cache_enabled,
+        }
+    }
+
+    #[tokio::test]
+    async fn cache_requires_flag_and_explicit_time_column() {
+        let disabled_factory = PostgresDynamicTableBackendFactory::new(postgres_config(false))
+            .expect("factory should be valid");
+
+        let disabled = disabled_factory
+            .create_backend(
+                "disabled".to_string(),
+                None,
+                None,
+                Some("updated_at".to_string()),
+                1000,
+            )
+            .await
+            .expect("backend should be valid");
+        assert!(disabled.cache.is_none());
+
+        let enabled_factory = PostgresDynamicTableBackendFactory::new(postgres_config(true))
+            .expect("factory should be valid");
+        let missing_time_column = enabled_factory
+            .create_backend("missing_time_column".to_string(), None, None, None, 1000)
+            .await
+            .expect("backend should be valid");
+        assert!(missing_time_column.cache.is_none());
+        assert_eq!(missing_time_column.time_column_name, "updated_at");
+
+        let cached = enabled_factory
+            .create_backend(
+                "cached".to_string(),
+                None,
+                None,
+                Some("updated_at".to_string()),
+                1000,
+            )
+            .await
+            .expect("backend should be valid");
+        assert!(cached.cache.is_some());
     }
 }

--- a/crates/streamling-core/src/dynamic_table/postgres.rs
+++ b/crates/streamling-core/src/dynamic_table/postgres.rs
@@ -312,7 +312,7 @@ impl PostgresDynamicTableBackend {
         pool: Arc<PgPool>,
         updated_since: Option<&str>,
     ) -> PostgresDynamicTableCache {
-        // ponytail: serialized append-only writers assign CLOCK_TIMESTAMP after taking the
+        // Serialized append-only writers assign CLOCK_TIMESTAMP after taking the
         // table lock; use a dedicated version cursor if that contract changes.
         let query: Arc<str> = if updated_since.is_some() {
             format!(
@@ -597,7 +597,7 @@ impl PostgresDynamicTableBackend {
                             format!("failed to begin cached write to table {full_table_name}")
                         })?;
 
-                        // ponytail: cached writes serialize per table; add a dedicated version row
+                        // Cached writes serialize per table; add a dedicated version row
                         // only if write throughput makes this lock material.
                         sqlx::query(CACHE_WRITE_LOCK_QUERY)
                             .bind(full_table_name.as_ref())
@@ -792,6 +792,19 @@ impl PostgresDynamicTableBackend {
     }
 }
 
+/// Remove duplicate values from `(index, value)` pairs, keeping only the first
+/// occurrence of each value. This shrinks the SQL parameter list and may reduce
+/// batch count in `contains()` without changing results, because
+/// `build_contains_result` looks up every original row value in the returned
+/// set — not in `value_indices`.
+fn deduplicate_value_indices(value_indices: Vec<(usize, String)>) -> Vec<(usize, String)> {
+    let mut seen: HashSet<String> = HashSet::new();
+    value_indices
+        .into_iter()
+        .filter(|(_, value)| seen.insert(value.clone()))
+        .collect()
+}
+
 #[async_trait]
 impl DynamicTableBackend for PostgresDynamicTableBackend {
     async fn append(&self, values: ArrayRef) -> Result<(), DynamicTableBackendError> {
@@ -889,6 +902,9 @@ impl DynamicTableBackend for PostgresDynamicTableBackend {
         if value_indices.is_empty() {
             return Ok(self.build_contains_result(string_array, &HashSet::new()));
         }
+
+        // Deduplicate values so each unique value is queried only once.
+        let value_indices = deduplicate_value_indices(value_indices);
 
         let existing_set = if value_indices.len() <= self.max_batch_size {
             // Single batch - process directly
@@ -1003,5 +1019,39 @@ mod tests {
             .await
             .expect("backend should be valid");
         assert!(cached.cache.is_some());
+    }
+    #[test]
+    fn deduplicate_value_indices_removes_duplicates() {
+        let input = vec![
+            (0, "a".to_string()),
+            (1, "b".to_string()),
+            (2, "a".to_string()), // duplicate of 0
+            (3, "c".to_string()),
+            (4, "b".to_string()), // duplicate of 1
+            (5, "a".to_string()), // duplicate of 0
+        ];
+
+        let result = deduplicate_value_indices(input);
+
+        // Only first occurrence of each value survives.
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0], (0, "a".to_string()));
+        assert_eq!(result[1], (1, "b".to_string()));
+        assert_eq!(result[2], (3, "c".to_string()));
+    }
+
+    #[test]
+    fn deduplicate_value_indices_preserves_all_unique() {
+        let input: Vec<(usize, String)> = (0..5).map(|i| (i, format!("val{}", i))).collect();
+
+        let result = deduplicate_value_indices(input);
+
+        assert_eq!(result.len(), 5);
+    }
+
+    #[test]
+    fn deduplicate_value_indices_empty_input() {
+        let result = deduplicate_value_indices(vec![]);
+        assert!(result.is_empty());
     }
 }

--- a/crates/streamling-core/src/dynamic_table/postgres.rs
+++ b/crates/streamling-core/src/dynamic_table/postgres.rs
@@ -14,7 +14,7 @@ use sqlx::{Executor, PgPool, Postgres};
 use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use streamling_config::app_config::PostgresDynamicTableBackendConfig;
 use tokio::sync::{OnceCell, RwLock};
 use tracing::{debug, error, info, trace};
@@ -261,12 +261,15 @@ impl PostgresDynamicTableBackend {
         time_column_name: Option<String>,
         max_batch_size: usize,
     ) -> Self {
+        let cache_enabled = config.cache_enabled && time_column_name.is_some();
         debug!(
-            "Creating PostgreSQL dynamic table backend instance for table: {}",
-            full_table_name
+            table = %full_table_name,
+            cache_enabled,
+            time_column = ?time_column_name.as_deref(),
+            "Creating PostgreSQL dynamic table backend"
         );
 
-        let cache = (config.cache_enabled && time_column_name.is_some()).then(|| RwLock::new(None));
+        let cache = cache_enabled.then(|| RwLock::new(None));
         let time_column_name = time_column_name.unwrap_or_else(|| "updated_at".to_string());
 
         Self {
@@ -313,7 +316,7 @@ impl PostgresDynamicTableBackend {
         &self,
         pool: Arc<PgPool>,
         updated_since: Option<&str>,
-    ) -> PostgresDynamicTableCache {
+    ) -> (PostgresDynamicTableCache, usize) {
         // Serialized append-only writers assign CLOCK_TIMESTAMP after taking the
         // table lock; use a dedicated version cursor if that contract changes.
         let max_query: Arc<str> = format!(
@@ -389,6 +392,7 @@ impl PostgresDynamicTableBackend {
                         })?;
 
                     let mut values = HashSet::new();
+                    let mut pages_loaded = 0;
                     loop {
                         let page: Vec<String> = sqlx::query_scalar(fetch_page_query.as_ref())
                             .fetch_all(&mut *transaction)
@@ -399,13 +403,17 @@ impl PostgresDynamicTableBackend {
                         if page.is_empty() {
                             break;
                         }
+                        pages_loaded += 1;
                         values.extend(page.into_iter().map(String::into_boxed_str));
                     }
 
                     transaction.commit().await.streamling_with_context(|| {
                         format!("failed to finish cache load for table {full_table_name}")
                     })?;
-                    Ok(PostgresDynamicTableCache { updated_at, values })
+                    Ok((
+                        PostgresDynamicTableCache { updated_at, values },
+                        pages_loaded,
+                    ))
                 }
             },
             &operation_name,
@@ -437,11 +445,32 @@ impl PostgresDynamicTableBackend {
             .as_ref()
             .and_then(|current| current.updated_at.as_deref())
             .map(str::to_owned);
-        let refreshed = self.load_cache(pool, updated_since.as_deref()).await;
+        let load_started_at = Instant::now();
+        let (refreshed, pages_loaded) = self.load_cache(pool, updated_since.as_deref()).await;
+        let elapsed_ms = load_started_at.elapsed().as_millis();
 
         if let Some(current) = cached.as_mut() {
+            let added_entries = refreshed.values.len();
             current.append(refreshed);
+            debug!(
+                table = %self.full_table_name,
+                added_entries,
+                total_entries = current.values.len(),
+                pages_loaded,
+                elapsed_ms = ?elapsed_ms,
+                previous_watermark = ?updated_since.as_deref(),
+                watermark = ?current.updated_at.as_deref(),
+                "Refreshed PostgreSQL dynamic table cache"
+            );
         } else {
+            info!(
+                table = %self.full_table_name,
+                total_entries = refreshed.values.len(),
+                pages_loaded,
+                elapsed_ms = ?elapsed_ms,
+                watermark = ?refreshed.updated_at.as_deref(),
+                "Populated PostgreSQL dynamic table cache"
+            );
             *cached = Some(refreshed);
         }
     }

--- a/crates/streamling-e2e/tests/dynamic_table.rs
+++ b/crates/streamling-e2e/tests/dynamic_table.rs
@@ -564,9 +564,15 @@ async fn test_postgres_dynamic_table_cache_loads_and_refreshes_after_append() {
         .await
         .expect("failed to begin seed transaction");
     lock_cached_table(&mut seed_transaction, "cached_members").await;
+    // Cross a cache-load page boundary during initial cache population.
     sqlx::query(
         "INSERT INTO public.cached_members (value, updated_at) \
-         VALUES ('initial', clock_timestamp())",
+         SELECT value, clock_timestamp() \
+         FROM ( \
+             SELECT 'seed_' || value::TEXT AS value \
+             FROM generate_series(1, 1000) AS seed(value) \
+             UNION ALL SELECT 'initial' \
+         ) seeded",
     )
     .execute(&mut *seed_transaction)
     .await

--- a/crates/streamling-e2e/tests/dynamic_table.rs
+++ b/crates/streamling-e2e/tests/dynamic_table.rs
@@ -619,3 +619,154 @@ async fn test_postgres_dynamic_table_cache_loads_and_refreshes_after_append() {
         ["appended_member", "initial"]
     );
 }
+
+/// Verify that deduplication in the uncached `contains()` path produces identical
+/// results for duplicate values. This exercises the exact code path the dedup
+/// changes: with MAX_BATCH_SIZE=3 and 6 total values (3 unique), without dedup
+/// the query would split into 2 batches; with dedup it fits in 1. If dedup
+/// dropped or mis-mapped a value, a duplicate of an existing value would be
+/// incorrectly filtered out.
+#[tokio::test]
+async fn test_uncached_dedup_identical_results_for_duplicate_values() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("failed to create test context");
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("failed to register schema");
+
+    // Pre-seed the backing table so the positive filter has known membership.
+    ctx.postgres
+        .execute("CREATE TABLE public.dedup_membership (value TEXT PRIMARY KEY)")
+        .await
+        .expect("failed to create backing table");
+    ctx.postgres
+        .execute("INSERT INTO public.dedup_membership (value) VALUES ('group_a'), ('group_c')")
+        .await
+        .expect("failed to seed backing table");
+
+    // Produce records with duplicate values in the column being checked.
+    // group_a ×3, group_b ×2, group_c ×1 → 6 values, 3 unique.
+    // With MAX_BATCH_SIZE=3 the dedup collapses 6 values into 3, turning a
+    // 2-batch query into a 1-batch query.
+    ctx.kafka
+        .produce_avro_records(&[
+            TestRecord {
+                id: "r1".into(),
+                data: "group_a".into(),
+            },
+            TestRecord {
+                id: "r2".into(),
+                data: "group_b".into(),
+            },
+            TestRecord {
+                id: "r3".into(),
+                data: "group_a".into(),
+            },
+            TestRecord {
+                id: "r4".into(),
+                data: "group_a".into(),
+            },
+            TestRecord {
+                id: "r5".into(),
+                data: "group_c".into(),
+            },
+            TestRecord {
+                id: "r6".into(),
+                data: "group_b".into(),
+            },
+        ])
+        .await
+        .expect("failed to produce records");
+
+    // source_drain (blackhole) consumes all 6 source records directly, triggering
+    // shutdown via num_records_before_stop. Without it, only 4 records reach the
+    // postgres sink (2 filtered out by dynamic_table_check) and the pipeline hangs.
+    let pipeline_yaml = format!(
+        r#"
+sources:
+  input:
+    type: kafka
+    topic: {topic}
+    starting_offsets: earliest
+    primary_key: id
+
+transforms:
+  membership:
+    type: dynamic_table
+    backend_type: Postgres
+    backend_entity_name: dedup_membership
+    schema: public
+    column: value
+  matched:
+    type: sql
+    sql: "SELECT id, data FROM input WHERE dynamic_table_check('membership', data)"
+    primary_key: id
+
+sinks:
+  matched_output:
+    type: postgres
+    from: matched
+    table: dedup_output
+    schema: public
+    primary_key: id
+    on_conflict: update
+    batch_size: 1
+    batch_flush_interval: 100ms
+  source_drain:
+    type: blackhole
+    from: input
+"#,
+        topic = ctx.kafka_topic,
+    );
+
+    let opts = PipelineOpts::new()
+        .record_limit(6)
+        .timeout(Duration::from_secs(60))
+        .env(
+            "STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__HOST",
+            &ctx.postgres.host,
+        )
+        .env(
+            "STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__PORT",
+            ctx.postgres.port.to_string(),
+        )
+        .env(
+            "STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__DB",
+            &ctx.pg_database,
+        )
+        .env(
+            "STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__USER",
+            &ctx.postgres.user,
+        )
+        .env(
+            "STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__PASSWORD",
+            &ctx.postgres.password,
+        )
+        .env(
+            "STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__SSLMODE",
+            "disable",
+        )
+        // Force a small batch size so 6 values would split into 2 queries
+        // without dedup, but 3 unique values fit in 1 query with dedup.
+        .env("STREAMLING__DYNAMIC_TABLE_BACKEND__MAX_BATCH_SIZE", "3");
+
+    let status = ctx
+        .run_pipeline_with_opts(&pipeline_yaml, opts)
+        .await
+        .expect("pipeline failed");
+    assert!(status.success(), "pipeline should exit successfully");
+
+    // group_a (×3) and group_c (×1) exist in the table → 4 records pass.
+    // group_b (×2) does NOT exist → 2 records filtered.
+    // If dedup dropped a duplicate, a group_a record would be missing.
+    let output = output_ids(&ctx, "dedup_output").await;
+    assert_eq!(
+        output,
+        vec!["r1", "r3", "r4", "r5"],
+        "all duplicates of existing values must pass identically"
+    );
+}

--- a/crates/streamling-e2e/tests/dynamic_table.rs
+++ b/crates/streamling-e2e/tests/dynamic_table.rs
@@ -1,0 +1,622 @@
+//! PostgreSQL dynamic-table cache end-to-end tests.
+
+use serde::Serialize;
+use std::time::{Duration, Instant};
+use streamling_e2e::{init_tracing, PipelineOpts, TestContext};
+
+#[derive(Debug, Clone, Serialize)]
+struct TestRecord {
+    id: String,
+    data: String,
+}
+
+const TEST_SCHEMA: &str = r#"{
+    "type": "record",
+    "name": "DynamicTableTestRecord",
+    "fields": [
+        {"name": "id", "type": "string"},
+        {"name": "data", "type": "string"}
+    ]
+}"#;
+const CACHE_WRITE_LOCK_QUERY: &str = "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))";
+
+fn record(id: &str) -> TestRecord {
+    TestRecord {
+        id: id.to_string(),
+        data: format!("data_for_{id}"),
+    }
+}
+
+fn pipeline(
+    ctx: &TestContext,
+    backing_table: &str,
+    output_table: &str,
+    drain_source: bool,
+) -> String {
+    let drain = drain_source.then_some(
+        r#"
+  source_drain:
+    type: blackhole
+    from: input
+"#,
+    );
+
+    format!(
+        r#"
+sources:
+  input:
+    type: kafka
+    topic: {topic}
+    starting_offsets: earliest
+    primary_key: id
+
+transforms:
+  membership:
+    type: dynamic_table
+    backend_type: Postgres
+    backend_entity_name: {backing_table}
+    schema: public
+    column: value
+    time_column: updated_at
+  matched:
+    type: sql
+    sql: "SELECT id, data FROM input WHERE dynamic_table_check('membership', id)"
+    primary_key: id
+
+sinks:
+  matched_output:
+    type: postgres
+    from: matched
+    table: {output_table}
+    schema: public
+    primary_key: id
+    on_conflict: update
+    batch_size: 1
+    batch_flush_interval: 100ms
+{drain}
+"#,
+        topic = ctx.kafka_topic,
+        drain = drain.unwrap_or_default(),
+    )
+}
+
+fn append_pipeline(ctx: &TestContext, backing_table: &str, cached: bool) -> String {
+    let time_column = cached.then_some("    time_column: updated_at\n");
+
+    format!(
+        r#"
+sources:
+  input:
+    type: kafka
+    topic: {topic}
+    starting_offsets: earliest
+    primary_key: id
+
+transforms:
+  membership_writer:
+    type: dynamic_table
+    backend_type: Postgres
+    backend_entity_name: {backing_table}
+    schema: public
+    column: value
+{time_column}    sql: "SELECT id FROM input"
+
+sinks:
+  source_drain:
+    type: blackhole
+    from: input
+"#,
+        topic = ctx.kafka_topic,
+        time_column = time_column.unwrap_or_default(),
+    )
+}
+
+fn cached_postgres_opts(ctx: &TestContext, record_limit: u64, timeout: Duration) -> PipelineOpts {
+    PipelineOpts::new()
+        .record_limit(record_limit)
+        .timeout(timeout)
+        .env(
+            "STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__HOST",
+            &ctx.postgres.host,
+        )
+        .env(
+            "STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__PORT",
+            ctx.postgres.port.to_string(),
+        )
+        .env(
+            "STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__DB",
+            &ctx.pg_database,
+        )
+        .env(
+            "STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__USER",
+            &ctx.postgres.user,
+        )
+        .env(
+            "STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__PASSWORD",
+            &ctx.postgres.password,
+        )
+        .env(
+            "STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__SSLMODE",
+            "disable",
+        )
+        .env(
+            "STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__CACHE_ENABLED",
+            "true",
+        )
+        .env("STREAMLING__RECORD_BATCH_SIZE", "1")
+}
+
+async fn wait_for_count(ctx: &TestContext, table: &str, expected: i64) {
+    let query = format!("SELECT COUNT(*) FROM public.{table}");
+    wait_for_query_count(ctx, &query, expected, table).await;
+}
+
+async fn wait_for_query_count(ctx: &TestContext, query: &str, expected: i64, description: &str) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut last_count = None;
+
+    while Instant::now() < deadline {
+        if let Ok(count) = ctx.postgres.count(query).await {
+            last_count = Some(count);
+            if count >= expected {
+                return;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    panic!("timed out waiting for {description} to reach {expected}; last count: {last_count:?}");
+}
+
+async fn output_ids(ctx: &TestContext, table: &str) -> Vec<String> {
+    let query = format!("SELECT id FROM public.{table} ORDER BY id");
+    ctx.postgres
+        .query::<(String,)>(&query)
+        .await
+        .expect("failed to read dynamic-table output")
+        .into_iter()
+        .map(|row| row.0)
+        .collect()
+}
+
+async fn lock_cached_table(transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>, table: &str) {
+    sqlx::query(CACHE_WRITE_LOCK_QUERY)
+        .bind(format!("public.{table}"))
+        .execute(&mut **transaction)
+        .await
+        .expect("failed to acquire dynamic-table writer lock");
+}
+
+#[tokio::test]
+async fn test_postgres_dynamic_table_cache_refreshes_with_serialized_writers() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("failed to create test context");
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("failed to register schema");
+    ctx.postgres
+        .execute(
+            r#"
+            CREATE TABLE public.cached_members (
+                value TEXT PRIMARY KEY,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT CLOCK_TIMESTAMP()
+            )
+            "#,
+        )
+        .await
+        .expect("failed to create dynamic table");
+
+    // Start this transaction first, then make it commit second. Assigning NOW() here would
+    // leave MAX(updated_at) unchanged and make the second insert invisible to the cache.
+    let mut older_transaction = ctx
+        .postgres
+        .pool()
+        .begin()
+        .await
+        .expect("failed to begin older transaction");
+    sqlx::query_scalar::<_, String>("SELECT transaction_timestamp()::TEXT")
+        .fetch_one(&mut *older_transaction)
+        .await
+        .expect("failed to establish the older transaction timestamp");
+
+    let mut first_writer = ctx
+        .postgres
+        .pool()
+        .begin()
+        .await
+        .expect("failed to begin first writer");
+    lock_cached_table(&mut first_writer, "cached_members").await;
+    sqlx::query(
+        "INSERT INTO public.cached_members (value, updated_at) \
+         VALUES ('commits_first', clock_timestamp())",
+    )
+    .execute(&mut *first_writer)
+    .await
+    .expect("failed to insert first committed row");
+
+    let lock_available =
+        sqlx::query_scalar::<_, bool>("SELECT pg_try_advisory_xact_lock(hashtextextended($1, 0))")
+            .bind("public.cached_members")
+            .fetch_one(&mut *older_transaction)
+            .await
+            .expect("failed to check the writer lock");
+    assert!(!lock_available, "concurrent writers must be serialized");
+    first_writer
+        .commit()
+        .await
+        .expect("failed to commit first writer");
+
+    ctx.kafka
+        .produce_avro_records(&[record("commits_first")])
+        .await
+        .expect("failed to produce first record");
+
+    let pipeline = pipeline(&ctx, "cached_members", "out_of_order_output", true);
+    let pipeline_fut = ctx.run_pipeline_with_opts(
+        &pipeline,
+        cached_postgres_opts(&ctx, 2, Duration::from_secs(45)),
+    );
+    let mutation_fut = async {
+        wait_for_count(&ctx, "out_of_order_output", 1).await;
+        lock_cached_table(&mut older_transaction, "cached_members").await;
+        sqlx::query(
+            "INSERT INTO public.cached_members (value, updated_at) \
+             VALUES ('commits_last', clock_timestamp())",
+        )
+        .execute(&mut *older_transaction)
+        .await
+        .expect("failed to insert in older transaction");
+        older_transaction
+            .commit()
+            .await
+            .expect("failed to commit older transaction");
+        ctx.kafka
+            .produce_avro_records(&[record("commits_last")])
+            .await
+            .expect("failed to produce late-commit record");
+    };
+
+    let (status, ()) = tokio::join!(pipeline_fut, mutation_fut);
+    let status = status.expect("pipeline failed");
+    assert!(status.success(), "pipeline should exit successfully");
+    assert_eq!(
+        output_ids(&ctx, "out_of_order_output").await,
+        ["commits_first", "commits_last"]
+    );
+}
+
+#[tokio::test]
+async fn test_postgres_dynamic_table_cache_missing_time_column_fails_fast() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("failed to create test context");
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("failed to register schema");
+    ctx.postgres
+        .execute("CREATE TABLE public.cached_members (value TEXT PRIMARY KEY)")
+        .await
+        .expect("failed to create dynamic table");
+    ctx.kafka
+        .produce_avro_records(&[record("member")])
+        .await
+        .expect("failed to produce record");
+
+    let output = ctx
+        .run_pipeline_raw(
+            &pipeline(&ctx, "cached_members", "missing_column_output", false),
+            cached_postgres_opts(&ctx, 1, Duration::from_secs(10)),
+        )
+        .await
+        .expect("invalid cache columns must fail instead of timing out");
+
+    assert!(!output.status.success(), "invalid cache column should fail");
+    let logs = format!("{}\n{}", output.stdout, output.stderr);
+    assert!(
+        logs.contains("updated_at") && logs.contains("cache"),
+        "error should identify the invalid cache column:\n{logs}"
+    );
+}
+
+#[tokio::test]
+async fn test_postgres_dynamic_table_cache_non_orderable_time_column_fails_fast() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("failed to create test context");
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("failed to register schema");
+    ctx.postgres
+        .execute(
+            "CREATE TABLE public.cached_members (\
+             value TEXT PRIMARY KEY, updated_at BOOLEAN NOT NULL DEFAULT FALSE)",
+        )
+        .await
+        .expect("failed to create dynamic table");
+    ctx.kafka
+        .produce_avro_records(&[record("member")])
+        .await
+        .expect("failed to produce record");
+
+    let output = ctx
+        .run_pipeline_raw(
+            &pipeline(&ctx, "cached_members", "invalid_column_output", false),
+            cached_postgres_opts(&ctx, 1, Duration::from_secs(10)),
+        )
+        .await
+        .expect("invalid cache columns must fail instead of timing out");
+
+    assert!(!output.status.success(), "invalid cache column should fail");
+    let logs = format!("{}\n{}", output.stdout, output.stderr);
+    assert!(
+        logs.contains("updated_at") && logs.contains("cache"),
+        "error should identify the invalid cache column:\n{logs}"
+    );
+}
+
+#[tokio::test]
+async fn test_postgres_dynamic_table_cache_appends_to_legacy_table_after_writer_lock() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("failed to create test context");
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("failed to register schema");
+    ctx.postgres
+        .execute(
+            r#"
+            CREATE TABLE public.cached_members (
+                value TEXT PRIMARY KEY,
+                updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+            )
+            "#,
+        )
+        .await
+        .expect("failed to create legacy dynamic table");
+    ctx.postgres
+        .execute(
+            "CREATE TABLE public.lock_release_marker (\
+             released_at TIMESTAMP WITH TIME ZONE NOT NULL)",
+        )
+        .await
+        .expect("failed to create lock release marker");
+    ctx.postgres
+        .execute("INSERT INTO public.cached_members (value) VALUES ('already_deployed')")
+        .await
+        .expect("failed to seed legacy dynamic table");
+
+    let mut lock_holder = ctx
+        .postgres
+        .pool()
+        .begin()
+        .await
+        .expect("failed to begin lock-holder transaction");
+    lock_cached_table(&mut lock_holder, "cached_members").await;
+
+    ctx.kafka
+        .produce_avro_records(&[record("new_member")])
+        .await
+        .expect("failed to produce dynamic-table value");
+
+    let pipeline = append_pipeline(&ctx, "cached_members", true);
+    let pipeline_fut = ctx.run_pipeline_with_opts(
+        &pipeline,
+        cached_postgres_opts(&ctx, 1, Duration::from_secs(45)),
+    );
+    let release_lock_fut = async {
+        wait_for_query_count(
+            &ctx,
+            r#"
+            SELECT COUNT(*)
+            FROM pg_locks
+            WHERE locktype = 'advisory'
+              AND database = (
+                  SELECT oid FROM pg_database WHERE datname = current_database()
+              )
+              AND NOT granted
+            "#,
+            1,
+            "a cached writer waiting for the legacy table lock",
+        )
+        .await;
+        sqlx::query("INSERT INTO public.lock_release_marker VALUES (clock_timestamp())")
+            .execute(&mut *lock_holder)
+            .await
+            .expect("failed to record lock release time");
+        sqlx::query("SELECT pg_sleep(0.02)")
+            .execute(&mut *lock_holder)
+            .await
+            .expect("failed to separate lock and write timestamps");
+        lock_holder
+            .commit()
+            .await
+            .expect("failed to release dynamic-table writer lock");
+    };
+
+    let (status, ()) = tokio::join!(pipeline_fut, release_lock_fut);
+    let status = status.expect("pipeline failed");
+    assert!(status.success(), "pipeline should exit successfully");
+
+    let rows = ctx
+        .postgres
+        .query::<(String, bool)>(
+            r#"
+            SELECT value, updated_at > released_at
+            FROM public.cached_members
+            CROSS JOIN public.lock_release_marker
+            WHERE value = 'new_member'
+            "#,
+        )
+        .await
+        .expect("failed to verify the legacy-table write timestamp");
+    assert_eq!(rows, [("new_member".to_string(), true)]);
+
+    assert_eq!(
+        ctx.postgres
+            .query::<(String,)>("SELECT value FROM public.cached_members ORDER BY value")
+            .await
+            .expect("failed to verify legacy table values"),
+        [
+            ("already_deployed".to_string(),),
+            ("new_member".to_string(),)
+        ]
+    );
+    let schema = ctx
+        .postgres
+        .query::<(String, Option<String>)>(
+            r#"
+            SELECT is_nullable, column_default
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'cached_members'
+              AND column_name = 'updated_at'
+            "#,
+        )
+        .await
+        .expect("failed to inspect legacy table schema");
+    assert_eq!(schema.len(), 1);
+    assert_eq!(schema[0].0, "YES");
+    assert!(
+        schema[0]
+            .1
+            .as_deref()
+            .is_some_and(|default| default.eq_ignore_ascii_case("now()")),
+        "legacy default should remain unchanged: {schema:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_postgres_dynamic_table_cache_flag_preserves_uncached_legacy_table() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("failed to create test context");
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("failed to register schema");
+    ctx.postgres
+        .execute("CREATE TABLE public.legacy_members (value TEXT PRIMARY KEY)")
+        .await
+        .expect("failed to create legacy dynamic table");
+    ctx.kafka
+        .produce_avro_records(&[record("legacy_member")])
+        .await
+        .expect("failed to produce dynamic-table value");
+
+    let status = ctx
+        .run_pipeline_with_opts(
+            &append_pipeline(&ctx, "legacy_members", false),
+            cached_postgres_opts(&ctx, 1, Duration::from_secs(30)),
+        )
+        .await
+        .expect("pipeline failed");
+    assert!(status.success(), "pipeline should exit successfully");
+    assert_eq!(
+        ctx.postgres
+            .query::<(String,)>("SELECT value FROM public.legacy_members")
+            .await
+            .expect("failed to read uncached legacy table"),
+        [("legacy_member".to_string(),)]
+    );
+}
+
+#[tokio::test]
+async fn test_postgres_dynamic_table_cache_loads_and_refreshes_membership() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("failed to create test context");
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("failed to register schema");
+    ctx.postgres
+        .execute(
+            r#"
+            CREATE TABLE public.cached_members (
+                value TEXT PRIMARY KEY,
+                updated_at TIMESTAMPTZ DEFAULT NOW()
+            )
+            "#,
+        )
+        .await
+        .expect("failed to create dynamic table");
+    let mut seed_transaction = ctx
+        .postgres
+        .pool()
+        .begin()
+        .await
+        .expect("failed to begin seed transaction");
+    lock_cached_table(&mut seed_transaction, "cached_members").await;
+    sqlx::query(
+        "INSERT INTO public.cached_members (value, updated_at) \
+         VALUES ('initial', clock_timestamp())",
+    )
+    .execute(&mut *seed_transaction)
+    .await
+    .expect("failed to seed dynamic table");
+    seed_transaction
+        .commit()
+        .await
+        .expect("failed to commit seed transaction");
+    ctx.kafka
+        .produce_avro_records(&[record("initial")])
+        .await
+        .expect("failed to produce initial record");
+
+    let pipeline = pipeline(&ctx, "cached_members", "cache_refresh_output", true);
+    let pipeline_fut = ctx.run_pipeline_with_opts(
+        &pipeline,
+        cached_postgres_opts(&ctx, 3, Duration::from_secs(45)),
+    );
+    let mutation_fut = async {
+        wait_for_count(&ctx, "cache_refresh_output", 1).await;
+        let mut transaction = ctx
+            .postgres
+            .pool()
+            .begin()
+            .await
+            .expect("failed to begin update transaction");
+        lock_cached_table(&mut transaction, "cached_members").await;
+        sqlx::query(
+            "UPDATE public.cached_members \
+             SET value = 'replacement', updated_at = clock_timestamp() \
+             WHERE value = 'initial'",
+        )
+        .execute(&mut *transaction)
+        .await
+        .expect("failed to update dynamic table and its time column");
+        transaction
+            .commit()
+            .await
+            .expect("failed to commit dynamic-table update");
+        ctx.kafka
+            .produce_avro_records(&[record("replacement"), record("not_a_member")])
+            .await
+            .expect("failed to produce refreshed records");
+    };
+
+    let (status, ()) = tokio::join!(pipeline_fut, mutation_fut);
+    let status = status.expect("pipeline failed");
+    assert!(status.success(), "pipeline should exit successfully");
+    assert_eq!(
+        output_ids(&ctx, "cache_refresh_output").await,
+        ["initial", "replacement"]
+    );
+}

--- a/crates/streamling-e2e/tests/dynamic_table.rs
+++ b/crates/streamling-e2e/tests/dynamic_table.rs
@@ -536,7 +536,7 @@ async fn test_postgres_dynamic_table_cache_flag_preserves_uncached_legacy_table(
 }
 
 #[tokio::test]
-async fn test_postgres_dynamic_table_cache_loads_and_refreshes_membership() {
+async fn test_postgres_dynamic_table_cache_loads_and_refreshes_after_append() {
     init_tracing();
 
     let ctx = TestContext::new()
@@ -585,38 +585,37 @@ async fn test_postgres_dynamic_table_cache_loads_and_refreshes_membership() {
         &pipeline,
         cached_postgres_opts(&ctx, 3, Duration::from_secs(45)),
     );
-    let mutation_fut = async {
+    let append_fut = async {
         wait_for_count(&ctx, "cache_refresh_output", 1).await;
         let mut transaction = ctx
             .postgres
             .pool()
             .begin()
             .await
-            .expect("failed to begin update transaction");
+            .expect("failed to begin append transaction");
         lock_cached_table(&mut transaction, "cached_members").await;
         sqlx::query(
-            "UPDATE public.cached_members \
-             SET value = 'replacement', updated_at = clock_timestamp() \
-             WHERE value = 'initial'",
+            "INSERT INTO public.cached_members (value, updated_at) \
+             VALUES ('appended_member', clock_timestamp())",
         )
         .execute(&mut *transaction)
         .await
-        .expect("failed to update dynamic table and its time column");
+        .expect("failed to append dynamic table value and its time column");
         transaction
             .commit()
             .await
-            .expect("failed to commit dynamic-table update");
+            .expect("failed to commit dynamic-table append");
         ctx.kafka
-            .produce_avro_records(&[record("replacement"), record("not_a_member")])
+            .produce_avro_records(&[record("appended_member"), record("not_a_member")])
             .await
             .expect("failed to produce refreshed records");
     };
 
-    let (status, ()) = tokio::join!(pipeline_fut, mutation_fut);
+    let (status, ()) = tokio::join!(pipeline_fut, append_fut);
     let status = status.expect("pipeline failed");
     assert!(status.success(), "pipeline should exit successfully");
     assert_eq!(
         output_ids(&ctx, "cache_refresh_output").await,
-        ["initial", "replacement"]
+        ["appended_member", "initial"]
     );
 }


### PR DESCRIPTION
## Summary

- Add an opt-in in-memory membership cache for PostgreSQL dynamic tables.
- Enable caching only when the global `cache_enabled` flag is true and the table explicitly declares a timestamp-compatible `time_column`; legacy tables keep the existing batched lookup path.
- Populate the cache lazily through a repeatable-read PostgreSQL cursor, fetching 1,000 rows per page into `HashSet<Box<str>>` instead of building one `ARRAY_AGG` result.
- Check `MAX(time_column)` on every `dynamic_table_check` invocation. When the watermark advances, fetch only newer rows and extend the existing cache in place.
- Avoid cloning Arrow input strings on cached lookups and deduplicate values sent through the uncached lookup path.
- Emit structured logs for cache configuration, initial population, and incremental refreshes.

## Why

Repeated PostgreSQL membership queries are expensive for frequently evaluated dynamic-table filters. Keeping the membership set in process makes each cached lookup a direct hash-set probe, while cursor pagination bounds temporary load memory for large tables.

## Configuration

Caching remains disabled by default:

```yaml
dynamic_table_backend:
  postgres:
    cache_enabled: true
```

Each cached table must also opt in with a time column:

```yaml
transforms:
  membership:
    type: dynamic_table
    backend_type: Postgres
    backend_entity_name: persistent_data
    time_column: updated_at
```

The global flag can alternatively be set with `STREAMLING__DYNAMIC_TABLE_BACKEND__POSTGRES__CACHE_ENABLED=true`.

## Correctness and operational behavior

- Cached tables are append-only. Updates and deletes are not reflected in this mode.
- Every writer must take the same per-table PostgreSQL advisory transaction lock and assign `CLOCK_TIMESTAMP()` after acquiring it. Streamling's cached writer path follows this protocol.
- `time_column` must advance for every append and should be indexed so the watermark and incremental range queries stay cheap.
- Initial population occurs on the first cached lookup. Cached lookups wait while initial population or an incremental refresh is in progress; there is no fallback to the uncached query path during a load.
- Initial population and refresh logs include the table, entries, cursor pages, duration, and watermark. Refresh details are available at `debug` level.

## Validation

- `cargo test -p streamling-core dynamic_table::postgres::tests`
- `just e2e-test test_postgres_dynamic_table_cache_loads_and_refreshes_after_append`
- `just e2e-test test_postgres_dynamic_table_cache_refreshes_with_serialized_writers`
- `just e2e-test test_postgres_dynamic_table_cache_non_orderable_time_column_fails_fast`
- `just fix`
- `just lint`
- GitHub Actions `validate-and-test` and `e2e-tests`
