### PR TITLE
fix(postgres-sink): bound statement execution client-side

### DIFF
--- a/crates/streamling-config/src/app_config.rs
+++ b/crates/streamling-config/src/app_config.rs
@@ -555,15 +555,18 @@ impl PostgresSinkConfig {
     /// the connection is dead (e.g. a middlebox silently dropped the flow), so
     /// sinks additionally bound the await client-side. Derived as 2x the
     /// server-side timeout so the server-side timeout fires first whenever the
-    /// server is reachable; when the server-side timeout is disabled (`0`),
-    /// falls back to 5 minutes.
-    pub fn client_statement_timeout(&self) -> std::time::Duration {
-        const DISABLED_FALLBACK_SECS: u64 = 300;
-        let secs = match self.statement_timeout_secs {
-            0 => DISABLED_FALLBACK_SECS,
-            s => s.saturating_mul(2),
-        };
-        std::time::Duration::from_secs(secs)
+    /// server is reachable (the 2x headroom also covers wire upload time,
+    /// which the server-side timeout does not measure).
+    ///
+    /// `statement_timeout_secs = 0` means "no timeout" and is honored here
+    /// too (`None`): a statement legitimately slower than any fixed bound
+    /// would otherwise be killed and retried forever. Users who disable the
+    /// server timeout opt out of the client bound as well.
+    pub fn client_statement_timeout(&self) -> Option<std::time::Duration> {
+        match self.statement_timeout_secs {
+            0 => None,
+            s => Some(std::time::Duration::from_secs(s.saturating_mul(2))),
+        }
     }
 }
 
@@ -1199,20 +1202,17 @@ password: ""
         };
         assert_eq!(
             config.client_statement_timeout(),
-            std::time::Duration::from_secs(120)
+            Some(std::time::Duration::from_secs(120))
         );
     }
 
     #[test]
-    fn test_client_statement_timeout_falls_back_when_server_timeout_disabled() {
+    fn test_client_statement_timeout_disabled_when_server_timeout_disabled() {
         let config = PostgresSinkConfig {
             statement_timeout_secs: 0,
             ..Default::default()
         };
-        assert_eq!(
-            config.client_statement_timeout(),
-            std::time::Duration::from_secs(300)
-        );
+        assert_eq!(config.client_statement_timeout(), None);
     }
 
     #[test]
@@ -1223,7 +1223,7 @@ password: ""
         };
         assert_eq!(
             config.client_statement_timeout(),
-            std::time::Duration::from_secs(u64::MAX)
+            Some(std::time::Duration::from_secs(u64::MAX))
         );
     }
 }

--- a/crates/streamling-config/src/app_config.rs
+++ b/crates/streamling-config/src/app_config.rs
@@ -548,6 +548,23 @@ impl PostgresSinkConfig {
             ("sslmode".to_string(), self.sslmode.to_string()),
         ])
     }
+
+    /// Client-side bound for a single statement execution.
+    ///
+    /// `statement_timeout_secs` is enforced by the server and cannot fire when
+    /// the connection is dead (e.g. a middlebox silently dropped the flow), so
+    /// sinks additionally bound the await client-side. Derived as 2x the
+    /// server-side timeout so the server-side timeout fires first whenever the
+    /// server is reachable; when the server-side timeout is disabled (`0`),
+    /// falls back to 5 minutes.
+    pub fn client_statement_timeout(&self) -> std::time::Duration {
+        const DISABLED_FALLBACK_SECS: u64 = 300;
+        let secs = match self.statement_timeout_secs {
+            0 => DISABLED_FALLBACK_SECS,
+            s => s.saturating_mul(2),
+        };
+        std::time::Duration::from_secs(secs)
+    }
 }
 
 impl Default for PostgresSinkConfig {
@@ -1172,5 +1189,41 @@ password: ""
 
         let config = result.expect("test body panicked");
         assert_eq!(config.application_id, "from_env");
+    }
+
+    #[test]
+    fn test_client_statement_timeout_is_double_the_server_timeout() {
+        let config = PostgresSinkConfig {
+            statement_timeout_secs: 60,
+            ..Default::default()
+        };
+        assert_eq!(
+            config.client_statement_timeout(),
+            std::time::Duration::from_secs(120)
+        );
+    }
+
+    #[test]
+    fn test_client_statement_timeout_falls_back_when_server_timeout_disabled() {
+        let config = PostgresSinkConfig {
+            statement_timeout_secs: 0,
+            ..Default::default()
+        };
+        assert_eq!(
+            config.client_statement_timeout(),
+            std::time::Duration::from_secs(300)
+        );
+    }
+
+    #[test]
+    fn test_client_statement_timeout_saturates_on_huge_values() {
+        let config = PostgresSinkConfig {
+            statement_timeout_secs: u64::MAX,
+            ..Default::default()
+        };
+        assert_eq!(
+            config.client_statement_timeout(),
+            std::time::Duration::from_secs(u64::MAX)
+        );
     }
 }

--- a/crates/streamling-connectors/src/table_providers/postgres/batch_processor.rs
+++ b/crates/streamling-connectors/src/table_providers/postgres/batch_processor.rs
@@ -71,6 +71,9 @@ pub struct BatchProcessorContext {
     pub current_checkpoint_epoch: Arc<Mutex<u64>>,
     pub parallelism: usize,
     pub write_batch_size: u32,
+    /// Client-side bound for a single statement execution; see
+    /// `PostgresSinkConfig::client_statement_timeout`.
+    pub client_statement_timeout: Duration,
 }
 
 /// Handle checkpoint truncation for finalized epochs
@@ -183,6 +186,7 @@ async fn execute_insert_slice(
         slice.num_rows(),
         &sink_ctx,
         epoch_for_rows,
+        context.client_statement_timeout,
     )
     .await;
 }
@@ -217,6 +221,7 @@ async fn execute_delete_slice(context: &BatchProcessorContext, slice: &RecordBat
         &context.primary_key_indices,
         slice.num_rows(),
         &sink_ctx,
+        context.client_statement_timeout,
     )
     .await;
 }
@@ -450,6 +455,7 @@ mod tests {
             current_checkpoint_epoch: Arc::new(Mutex::new(0)),
             parallelism: 1,
             write_batch_size: 1000,
+            client_statement_timeout: Duration::from_secs(120),
         };
 
         let empty_batch = RecordBatch::new_empty(schema);
@@ -493,6 +499,7 @@ mod tests {
             current_checkpoint_epoch: Arc::new(Mutex::new(0)),
             parallelism: 1,
             write_batch_size: 1000,
+            client_statement_timeout: Duration::from_secs(120),
         };
 
         let cloned = context.clone();

--- a/crates/streamling-connectors/src/table_providers/postgres/batch_processor.rs
+++ b/crates/streamling-connectors/src/table_providers/postgres/batch_processor.rs
@@ -73,7 +73,7 @@ pub struct BatchProcessorContext {
     pub write_batch_size: u32,
     /// Client-side bound for a single statement execution; see
     /// `PostgresSinkConfig::client_statement_timeout`.
-    pub client_statement_timeout: Duration,
+    pub client_statement_timeout: Option<Duration>,
 }
 
 /// Handle checkpoint truncation for finalized epochs
@@ -91,6 +91,7 @@ async fn handle_checkpoint_truncation(context: &BatchProcessorContext, truncate_
         &context.schema_name,
         &context.table,
         truncate_epoch,
+        context.client_statement_timeout,
     )
     .await;
 }
@@ -455,7 +456,7 @@ mod tests {
             current_checkpoint_epoch: Arc::new(Mutex::new(0)),
             parallelism: 1,
             write_batch_size: 1000,
-            client_statement_timeout: Duration::from_secs(120),
+            client_statement_timeout: Some(Duration::from_secs(120)),
         };
 
         let empty_batch = RecordBatch::new_empty(schema);
@@ -499,7 +500,7 @@ mod tests {
             current_checkpoint_epoch: Arc::new(Mutex::new(0)),
             parallelism: 1,
             write_batch_size: 1000,
-            client_statement_timeout: Duration::from_secs(120),
+            client_statement_timeout: Some(Duration::from_secs(120)),
         };
 
         let cloned = context.clone();

--- a/crates/streamling-connectors/src/table_providers/postgres/execution.rs
+++ b/crates/streamling-connectors/src/table_providers/postgres/execution.rs
@@ -1,6 +1,7 @@
 use datafusion::arrow::array::Array;
 use std::sync::Arc;
-use streamling_core::error::ResultExt;
+use std::time::Duration;
+use streamling_core::error::{Result, ResultExt, StreamlingError};
 use streamling_core::retry::retry_forever_with_backoff_async;
 
 use crate::table_providers::postgres::value_binding;
@@ -11,6 +12,42 @@ pub struct SinkContext {
     pub sink_name: String,
     pub schema_name: String,
     pub table_name: String,
+}
+
+/// Execute a query on a pooled connection with a client-side time bound.
+///
+/// The server-side `statement_timeout` cannot fire when the connection is dead
+/// (e.g. a NAT/firewall silently dropped the flow after the statement was
+/// sent): the client just awaits a response that will never arrive, and sqlx
+/// exposes no TCP keepalive to detect it. Without this bound such an await
+/// hangs the sink forever with no logs.
+///
+/// On timeout the connection is detached from the pool and dropped rather
+/// than returned: the next acquire would otherwise receive the same dead
+/// socket, and sqlx's return-to-pool cleanup can itself block on it. Dropping
+/// a detached connection closes the socket without any await, and the pool
+/// opens a fresh replacement on the next acquire.
+async fn execute_bounded(
+    pool: &sqlx::PgPool,
+    query: sqlx::query::Query<'_, sqlx::Postgres, sqlx::postgres::PgArguments>,
+    timeout: Duration,
+) -> Result<()> {
+    let mut conn = pool.acquire().await.map_err(|e| {
+        StreamlingError::retriable_with_cause("failed to acquire PostgreSQL connection", e)
+    })?;
+
+    match tokio::time::timeout(timeout, query.execute(&mut *conn)).await {
+        Ok(result) => {
+            result.streamling_context("failed to execute statement")?;
+            Ok(())
+        }
+        Err(_elapsed) => {
+            drop(conn.detach());
+            Err(StreamlingError::retriable(format!(
+                "statement did not complete within {timeout:?}; discarded the connection and will retry on a fresh one"
+            )))
+        }
+    }
 }
 
 /// Execute a batch insert query with retry logic
@@ -24,6 +61,7 @@ pub async fn execute_batch_insert(
     num_rows: usize,
     ctx: &SinkContext,
     checkpoint_epoch: Option<u64>,
+    client_statement_timeout: Duration,
 ) {
     let query = query.to_string();
     let pool = pool.clone();
@@ -55,7 +93,7 @@ pub async fn execute_batch_insert(
                         q = q.bind(epoch as i64);
                     }
                 }
-                q.execute(&pool)
+                execute_bounded(&pool, q, client_statement_timeout)
                     .await
                     .streamling_context("failed to execute INSERT query")?;
                 Ok(())
@@ -75,6 +113,7 @@ pub async fn execute_batch_delete(
     primary_key_indices: &[usize],
     num_rows: usize,
     ctx: &SinkContext,
+    client_statement_timeout: Duration,
 ) {
     let query = query.to_string();
     let pool = pool.clone();
@@ -102,7 +141,7 @@ pub async fn execute_batch_delete(
                             .streamling_context("failed to bind Arrow value to query")?;
                     }
                 }
-                q.execute(&pool)
+                execute_bounded(&pool, q, client_statement_timeout)
                     .await
                     .streamling_context("failed to execute DELETE query")?;
                 Ok(())
@@ -116,4 +155,138 @@ pub async fn execute_batch_delete(
 // Note: Comprehensive testing of batch execution is done via integration tests
 // in `crates/streamling/tests/pipeline_postgres_sink.rs` which verify that batches
 // are correctly inserted into PostgreSQL with proper retry logic.
-// Unit testing here would require mocking sqlx::PgPool and database connections.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::postgres::PgPoolOptions;
+    use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// Minimal fake PostgreSQL server: completes the startup handshake, then
+    /// never responds to anything else while still reading (and ACKing) the
+    /// client's bytes. This models a peer that died silently mid-connection —
+    /// the client's write succeeds and its read waits forever, which is
+    /// exactly the state that used to hang the sink with no logs.
+    async fn spawn_silent_postgres() -> (SocketAddr, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let connections = Arc::new(AtomicUsize::new(0));
+        let accepted = connections.clone();
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                accepted.fetch_add(1, Ordering::SeqCst);
+
+                tokio::spawn(async move {
+                    // Read the client's StartupMessage (length-prefixed, no type byte).
+                    let mut len_buf = [0u8; 4];
+                    if socket.read_exact(&mut len_buf).await.is_err() {
+                        return;
+                    }
+                    let len = (u32::from_be_bytes(len_buf) as usize).saturating_sub(4);
+                    let mut body = vec![0u8; len];
+                    if socket.read_exact(&mut body).await.is_err() {
+                        return;
+                    }
+
+                    let mut reply: Vec<u8> = Vec::new();
+                    // AuthenticationOk
+                    reply.extend([b'R', 0, 0, 0, 8, 0, 0, 0, 0]);
+                    // ParameterStatus messages the client parses during connect
+                    for (key, value) in [
+                        ("server_version", "14.0"),
+                        ("client_encoding", "UTF8"),
+                        ("DateStyle", "ISO, MDY"),
+                    ] {
+                        let payload_len = 4 + key.len() + 1 + value.len() + 1;
+                        reply.push(b'S');
+                        reply.extend((payload_len as u32).to_be_bytes());
+                        reply.extend(key.as_bytes());
+                        reply.push(0);
+                        reply.extend(value.as_bytes());
+                        reply.push(0);
+                    }
+                    // BackendKeyData
+                    reply.extend([b'K', 0, 0, 0, 12]);
+                    reply.extend(1234u32.to_be_bytes());
+                    reply.extend(5678u32.to_be_bytes());
+                    // ReadyForQuery (idle)
+                    reply.extend([b'Z', 0, 0, 0, 5, b'I']);
+                    if socket.write_all(&reply).await.is_err() {
+                        return;
+                    }
+
+                    // Handshake complete. Play dead: keep draining client bytes
+                    // so writes succeed, but never send another byte back.
+                    let mut sink_buf = [0u8; 4096];
+                    while socket
+                        .read(&mut sink_buf)
+                        .await
+                        .map(|n| n > 0)
+                        .unwrap_or(false)
+                    {}
+                });
+            }
+        });
+
+        (addr, connections)
+    }
+
+    /// Reproduces the silent-hang bug: without the client-side bound in
+    /// `execute_bounded`, executing a statement against a peer that stopped
+    /// responding awaits forever (no error, no retry, no log). With the bound
+    /// it must fail retriable within the timeout, discard the dead connection,
+    /// and acquire a fresh one on the next attempt.
+    #[tokio::test]
+    async fn test_bounded_execute_times_out_and_discards_dead_connection() {
+        let (addr, connections) = spawn_silent_postgres().await;
+        let url = format!(
+            "postgres://user@{}:{}/db?sslmode=disable",
+            addr.ip(),
+            addr.port()
+        );
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .acquire_timeout(Duration::from_secs(5))
+            .connect_lazy(&url)
+            .expect("lazy pool");
+
+        let started = std::time::Instant::now();
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            execute_bounded(&pool, sqlx::query("SELECT 1"), Duration::from_millis(300)),
+        )
+        .await
+        .expect("execute_bounded must not hang on a silent server");
+
+        let err = result.expect_err("must time out against a silent server");
+        assert!(err.is_retriable(), "timeout must be retriable: {err:?}");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "must fail within the client-side bound, took {:?}",
+            started.elapsed()
+        );
+        assert_eq!(connections.load(Ordering::SeqCst), 1);
+
+        // The dead connection must have been discarded: a second attempt gets
+        // a fresh physical connection instead of the poisoned pooled one.
+        let result2 = tokio::time::timeout(
+            Duration::from_secs(10),
+            execute_bounded(&pool, sqlx::query("SELECT 1"), Duration::from_millis(300)),
+        )
+        .await
+        .expect("second attempt must not hang either");
+        assert!(result2.is_err());
+        assert_eq!(
+            connections.load(Ordering::SeqCst),
+            2,
+            "expected a fresh physical connection after the discard"
+        );
+    }
+}

--- a/crates/streamling-connectors/src/table_providers/postgres/execution.rs
+++ b/crates/streamling-connectors/src/table_providers/postgres/execution.rs
@@ -1,8 +1,9 @@
 use datafusion::arrow::array::Array;
 use std::sync::Arc;
 use std::time::Duration;
-use streamling_core::error::{Result, ResultExt, StreamlingError};
+use streamling_core::error::ResultExt;
 use streamling_core::retry::retry_forever_with_backoff_async;
+use streamling_core::utils::pg::execute_bounded;
 
 use crate::table_providers::postgres::value_binding;
 
@@ -12,49 +13,6 @@ pub struct SinkContext {
     pub sink_name: String,
     pub schema_name: String,
     pub table_name: String,
-}
-
-/// Execute a query on a pooled connection with a client-side time bound.
-///
-/// The server-side `statement_timeout` cannot fire when the connection is dead
-/// (e.g. a NAT/firewall silently dropped the flow after the statement was
-/// sent): the client just awaits a response that will never arrive, and sqlx
-/// exposes no TCP keepalive to detect it. Without this bound such an await
-/// hangs the sink forever with no logs.
-///
-/// On timeout the connection is detached from the pool and dropped rather
-/// than returned: the next acquire would otherwise receive the same dead
-/// socket, and sqlx's return-to-pool cleanup can itself block on it. Dropping
-/// a detached connection closes the socket without any await, and the pool
-/// opens a fresh replacement on the next acquire.
-///
-/// Delivery semantics: like every retried error in this sink (e.g. a
-/// connection drop after the server committed but before the response
-/// arrived), a timeout can re-execute a statement that already committed —
-/// at-least-once. Upsert/delete statements absorb this; sinks configured
-/// without a primary key issue plain INSERTs and can observe duplicates,
-/// which is the sink's pre-existing contract, not a property of this bound.
-async fn execute_bounded(
-    pool: &sqlx::PgPool,
-    query: sqlx::query::Query<'_, sqlx::Postgres, sqlx::postgres::PgArguments>,
-    timeout: Duration,
-) -> Result<()> {
-    let mut conn = pool.acquire().await.map_err(|e| {
-        StreamlingError::retriable_with_cause("failed to acquire PostgreSQL connection", e)
-    })?;
-
-    match tokio::time::timeout(timeout, query.execute(&mut *conn)).await {
-        Ok(result) => {
-            result.streamling_context("failed to execute statement")?;
-            Ok(())
-        }
-        Err(_elapsed) => {
-            drop(conn.detach());
-            Err(StreamlingError::retriable(format!(
-                "statement did not complete within {timeout:?}; discarded the connection and will retry on a fresh one"
-            )))
-        }
-    }
 }
 
 /// Execute a batch insert query with retry logic
@@ -68,7 +26,7 @@ pub async fn execute_batch_insert(
     num_rows: usize,
     ctx: &SinkContext,
     checkpoint_epoch: Option<u64>,
-    client_statement_timeout: Duration,
+    client_statement_timeout: Option<Duration>,
 ) {
     let query = query.to_string();
     let pool = pool.clone();
@@ -120,7 +78,7 @@ pub async fn execute_batch_delete(
     primary_key_indices: &[usize],
     num_rows: usize,
     ctx: &SinkContext,
-    client_statement_timeout: Duration,
+    client_statement_timeout: Option<Duration>,
 ) {
     let query = query.to_string();
     let pool = pool.clone();
@@ -161,139 +119,7 @@ pub async fn execute_batch_delete(
 
 // Note: Comprehensive testing of batch execution is done via integration tests
 // in `crates/streamling/tests/pipeline_postgres_sink.rs` which verify that batches
-// are correctly inserted into PostgreSQL with proper retry logic.
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use sqlx::postgres::PgPoolOptions;
-    use std::net::SocketAddr;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::TcpListener;
-
-    /// Minimal fake PostgreSQL server: completes the startup handshake, then
-    /// never responds to anything else while still reading (and ACKing) the
-    /// client's bytes. This models a peer that died silently mid-connection —
-    /// the client's write succeeds and its read waits forever, which is
-    /// exactly the state that used to hang the sink with no logs.
-    async fn spawn_silent_postgres() -> (SocketAddr, Arc<AtomicUsize>) {
-        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
-        let addr = listener.local_addr().expect("local_addr");
-        let connections = Arc::new(AtomicUsize::new(0));
-        let accepted = connections.clone();
-
-        tokio::spawn(async move {
-            loop {
-                let Ok((mut socket, _)) = listener.accept().await else {
-                    break;
-                };
-                accepted.fetch_add(1, Ordering::SeqCst);
-
-                tokio::spawn(async move {
-                    // Read the client's StartupMessage (length-prefixed, no type byte).
-                    let mut len_buf = [0u8; 4];
-                    if socket.read_exact(&mut len_buf).await.is_err() {
-                        return;
-                    }
-                    let len = (u32::from_be_bytes(len_buf) as usize).saturating_sub(4);
-                    let mut body = vec![0u8; len];
-                    if socket.read_exact(&mut body).await.is_err() {
-                        return;
-                    }
-
-                    let mut reply: Vec<u8> = Vec::new();
-                    // AuthenticationOk
-                    reply.extend([b'R', 0, 0, 0, 8, 0, 0, 0, 0]);
-                    // ParameterStatus messages the client parses during connect
-                    for (key, value) in [
-                        ("server_version", "14.0"),
-                        ("client_encoding", "UTF8"),
-                        ("DateStyle", "ISO, MDY"),
-                    ] {
-                        let payload_len = 4 + key.len() + 1 + value.len() + 1;
-                        reply.push(b'S');
-                        reply.extend((payload_len as u32).to_be_bytes());
-                        reply.extend(key.as_bytes());
-                        reply.push(0);
-                        reply.extend(value.as_bytes());
-                        reply.push(0);
-                    }
-                    // BackendKeyData
-                    reply.extend([b'K', 0, 0, 0, 12]);
-                    reply.extend(1234u32.to_be_bytes());
-                    reply.extend(5678u32.to_be_bytes());
-                    // ReadyForQuery (idle)
-                    reply.extend([b'Z', 0, 0, 0, 5, b'I']);
-                    if socket.write_all(&reply).await.is_err() {
-                        return;
-                    }
-
-                    // Handshake complete. Play dead: keep draining client bytes
-                    // so writes succeed, but never send another byte back.
-                    let mut sink_buf = [0u8; 4096];
-                    while socket
-                        .read(&mut sink_buf)
-                        .await
-                        .map(|n| n > 0)
-                        .unwrap_or(false)
-                    {}
-                });
-            }
-        });
-
-        (addr, connections)
-    }
-
-    /// Reproduces the silent-hang bug: without the client-side bound in
-    /// `execute_bounded`, executing a statement against a peer that stopped
-    /// responding awaits forever (no error, no retry, no log). With the bound
-    /// it must fail retriable within the timeout, discard the dead connection,
-    /// and acquire a fresh one on the next attempt.
-    #[tokio::test]
-    async fn test_bounded_execute_times_out_and_discards_dead_connection() {
-        let (addr, connections) = spawn_silent_postgres().await;
-        let url = format!(
-            "postgres://user@{}:{}/db?sslmode=disable",
-            addr.ip(),
-            addr.port()
-        );
-        let pool = PgPoolOptions::new()
-            .max_connections(2)
-            .acquire_timeout(Duration::from_secs(5))
-            .connect_lazy(&url)
-            .expect("lazy pool");
-
-        let started = std::time::Instant::now();
-        let result = tokio::time::timeout(
-            Duration::from_secs(10),
-            execute_bounded(&pool, sqlx::query("SELECT 1"), Duration::from_millis(300)),
-        )
-        .await
-        .expect("execute_bounded must not hang on a silent server");
-
-        let err = result.expect_err("must time out against a silent server");
-        assert!(err.is_retriable(), "timeout must be retriable: {err:?}");
-        assert!(
-            started.elapsed() < Duration::from_secs(5),
-            "must fail within the client-side bound, took {:?}",
-            started.elapsed()
-        );
-        assert_eq!(connections.load(Ordering::SeqCst), 1);
-
-        // The dead connection must have been discarded: a second attempt gets
-        // a fresh physical connection instead of the poisoned pooled one.
-        let result2 = tokio::time::timeout(
-            Duration::from_secs(10),
-            execute_bounded(&pool, sqlx::query("SELECT 1"), Duration::from_millis(300)),
-        )
-        .await
-        .expect("second attempt must not hang either");
-        assert!(result2.is_err());
-        assert_eq!(
-            connections.load(Ordering::SeqCst),
-            2,
-            "expected a fresh physical connection after the discard"
-        );
-    }
-}
+// are correctly inserted into PostgreSQL with proper retry logic. The client-side
+// statement bound itself is unit-tested next to its implementation in
+// `streamling_core::utils::pg` (fake silent-server reproduction) and covered
+// end-to-end by `streamling-e2e/tests/postgres_sink_recovery.rs`.

--- a/crates/streamling-connectors/src/table_providers/postgres/execution.rs
+++ b/crates/streamling-connectors/src/table_providers/postgres/execution.rs
@@ -27,6 +27,13 @@ pub struct SinkContext {
 /// socket, and sqlx's return-to-pool cleanup can itself block on it. Dropping
 /// a detached connection closes the socket without any await, and the pool
 /// opens a fresh replacement on the next acquire.
+///
+/// Delivery semantics: like every retried error in this sink (e.g. a
+/// connection drop after the server committed but before the response
+/// arrived), a timeout can re-execute a statement that already committed —
+/// at-least-once. Upsert/delete statements absorb this; sinks configured
+/// without a primary key issue plain INSERTs and can observe duplicates,
+/// which is the sink's pre-existing contract, not a property of this bound.
 async fn execute_bounded(
     pool: &sqlx::PgPool,
     query: sqlx::query::Query<'_, sqlx::Postgres, sqlx::postgres::PgArguments>,

--- a/crates/streamling-connectors/src/table_providers/postgres/mod.rs
+++ b/crates/streamling-connectors/src/table_providers/postgres/mod.rs
@@ -323,6 +323,7 @@ impl DataSink for PostgresSinkExec {
             current_checkpoint_epoch: Arc::new(Mutex::new(0)),
             parallelism: self.parallelism,
             write_batch_size: self.write_batch_size,
+            client_statement_timeout: self.config.client_statement_timeout(),
         };
 
         // Process each batch directly — accumulation is handled by RebatchExec

--- a/crates/streamling-core/src/utils/pg.rs
+++ b/crates/streamling-core/src/utils/pg.rs
@@ -1,5 +1,5 @@
 use crate::data::COLUMN_NAME_OP;
-use crate::error::{Result, StreamlingError};
+use crate::error::{Result, ResultExt, StreamlingError};
 use crate::types::{i256::I256Type, u256::U256Type};
 use crate::utils::parse_primary_key_columns;
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
@@ -99,6 +99,60 @@ impl PostgresConnection {
     /// Get a reference to the pool
     pub fn pool(&self) -> &PgPool {
         &self.pool
+    }
+}
+
+/// Execute a query on a pooled connection with an optional client-side time
+/// bound, returning the number of rows affected.
+///
+/// The server-side `statement_timeout` cannot fire when the connection is dead
+/// (e.g. a NAT/firewall silently dropped the flow after the statement was
+/// sent): the client just awaits a response that will never arrive, and sqlx
+/// exposes no TCP keepalive to detect it. Without this bound such an await
+/// hangs the caller forever with no logs. `None` (from
+/// `statement_timeout_secs = 0`) disables the bound — matching the server-side
+/// "no timeout" contract.
+///
+/// On timeout the connection is detached from the pool and dropped rather
+/// than returned: the next acquire would otherwise receive the same dead
+/// socket, and sqlx's return-to-pool cleanup can itself block on it. Dropping
+/// a detached connection closes the socket without any await, and the pool
+/// opens a fresh replacement on the next acquire.
+///
+/// Delivery semantics: like every retried error on these paths (e.g. a
+/// connection drop after the server committed but before the response
+/// arrived), a timeout can lead to re-executing a statement that already
+/// committed — at-least-once. Upsert/delete statements absorb this; callers
+/// issuing plain INSERTs (no conflict target) can observe duplicates, which is
+/// their pre-existing retry contract, not a property of this bound.
+pub async fn execute_bounded(
+    pool: &PgPool,
+    query: sqlx::query::Query<'_, sqlx::Postgres, sqlx::postgres::PgArguments>,
+    timeout: Option<Duration>,
+) -> Result<u64> {
+    let Some(timeout) = timeout else {
+        let result = query
+            .execute(pool)
+            .await
+            .streamling_context("failed to execute statement")?;
+        return Ok(result.rows_affected());
+    };
+
+    let mut conn = pool.acquire().await.map_err(|e| {
+        StreamlingError::retriable_with_cause("failed to acquire PostgreSQL connection", e)
+    })?;
+
+    match tokio::time::timeout(timeout, query.execute(&mut *conn)).await {
+        Ok(result) => {
+            let result = result.streamling_context("failed to execute statement")?;
+            Ok(result.rows_affected())
+        }
+        Err(_elapsed) => {
+            drop(conn.detach());
+            Err(StreamlingError::retriable(format!(
+                "statement did not complete within {timeout:?}; discarded the connection and will retry on a fresh one"
+            )))
+        }
     }
 }
 
@@ -416,11 +470,16 @@ pub async fn create_schema_and_table_if_needed(
 
 /// Truncate finalized checkpoint data from the table
 /// This is a best-effort operation - errors are logged but don't fail the pipeline
+///
+/// The DELETE runs inline in the sink's batch loop, so it carries the same
+/// client-side bound as data statements (`execute_bounded`) — an unbounded
+/// await here would wedge the sink exactly like a hung INSERT.
 pub async fn truncate_finalized_checkpoint_data(
     pool: &PgPool,
     schema: &str,
     table: &str,
     finalized_epoch: u64,
+    statement_timeout: Option<Duration>,
 ) -> Result<()> {
     let delete_sql = format!(
         r#"DELETE FROM "{}"."{}" WHERE "_gs_checkpoint_epoch" <= $1"#,
@@ -432,13 +491,9 @@ pub async fn truncate_finalized_checkpoint_data(
         schema, table, finalized_epoch
     );
 
-    match sqlx::query(&delete_sql)
-        .bind(finalized_epoch as i64)
-        .execute(pool)
-        .await
-    {
-        Ok(result) => {
-            let rows_deleted = result.rows_affected();
+    let query = sqlx::query(&delete_sql).bind(finalized_epoch as i64);
+    match execute_bounded(pool, query, statement_timeout).await {
+        Ok(rows_deleted) => {
             info!(
                 "Truncated {} rows from {}.{} for epoch {}",
                 rows_deleted, schema, table, finalized_epoch
@@ -662,5 +717,143 @@ mod tests {
             false,
         );
         assert_eq!(arrow_field_to_postgres_type(&field), "TEXT");
+    }
+
+    use sqlx::postgres::PgPoolOptions;
+    use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// Minimal fake PostgreSQL server: completes the startup handshake, then
+    /// never responds to anything else while still reading (and ACKing) the
+    /// client's bytes. This models a peer that died silently mid-connection —
+    /// the client's write succeeds and its read waits forever, which is
+    /// exactly the state that used to hang the sink with no logs.
+    async fn spawn_silent_postgres() -> (SocketAddr, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let connections = Arc::new(AtomicUsize::new(0));
+        let accepted = connections.clone();
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                accepted.fetch_add(1, Ordering::SeqCst);
+
+                tokio::spawn(async move {
+                    // Read the client's StartupMessage (length-prefixed, no type byte).
+                    let mut len_buf = [0u8; 4];
+                    if socket.read_exact(&mut len_buf).await.is_err() {
+                        return;
+                    }
+                    let len = (u32::from_be_bytes(len_buf) as usize).saturating_sub(4);
+                    let mut body = vec![0u8; len];
+                    if socket.read_exact(&mut body).await.is_err() {
+                        return;
+                    }
+
+                    let mut reply: Vec<u8> = Vec::new();
+                    // AuthenticationOk
+                    reply.extend([b'R', 0, 0, 0, 8, 0, 0, 0, 0]);
+                    // ParameterStatus messages the client parses during connect
+                    for (key, value) in [
+                        ("server_version", "14.0"),
+                        ("client_encoding", "UTF8"),
+                        ("DateStyle", "ISO, MDY"),
+                    ] {
+                        let payload_len = 4 + key.len() + 1 + value.len() + 1;
+                        reply.push(b'S');
+                        reply.extend((payload_len as u32).to_be_bytes());
+                        reply.extend(key.as_bytes());
+                        reply.push(0);
+                        reply.extend(value.as_bytes());
+                        reply.push(0);
+                    }
+                    // BackendKeyData
+                    reply.extend([b'K', 0, 0, 0, 12]);
+                    reply.extend(1234u32.to_be_bytes());
+                    reply.extend(5678u32.to_be_bytes());
+                    // ReadyForQuery (idle)
+                    reply.extend([b'Z', 0, 0, 0, 5, b'I']);
+                    if socket.write_all(&reply).await.is_err() {
+                        return;
+                    }
+
+                    // Handshake complete. Play dead: keep draining client bytes
+                    // so writes succeed, but never send another byte back.
+                    let mut sink_buf = [0u8; 4096];
+                    while socket
+                        .read(&mut sink_buf)
+                        .await
+                        .map(|n| n > 0)
+                        .unwrap_or(false)
+                    {}
+                });
+            }
+        });
+
+        (addr, connections)
+    }
+
+    /// Reproduces the silent-hang bug: without the client-side bound in
+    /// `execute_bounded`, executing a statement against a peer that stopped
+    /// responding awaits forever (no error, no retry, no log). With the bound
+    /// it must fail retriable within the timeout, discard the dead connection
+    /// (releasing its pool permit), and get a fresh physical connection on
+    /// every subsequent attempt — the third attempt exists to catch a
+    /// permit-leak regression (a plain drop instead of detach strands the
+    /// permit in a background return-to-pool ping and exhausts a 2-connection
+    /// pool by attempt 3).
+    #[tokio::test]
+    async fn test_bounded_execute_times_out_and_discards_dead_connection() {
+        let bound = Duration::from_millis(300);
+        let (addr, connections) = spawn_silent_postgres().await;
+        let url = format!(
+            "postgres://user@{}:{}/db?sslmode=disable",
+            addr.ip(),
+            addr.port()
+        );
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .acquire_timeout(Duration::from_secs(5))
+            .connect_lazy(&url)
+            .expect("lazy pool");
+
+        for attempt in 1..=3u32 {
+            let started = std::time::Instant::now();
+            let result = tokio::time::timeout(
+                Duration::from_secs(10),
+                execute_bounded(&pool, sqlx::query("SELECT 1"), Some(bound)),
+            )
+            .await
+            .unwrap_or_else(|_| panic!("attempt {attempt} must not hang on a silent server"));
+
+            let err = result.expect_err("must time out against a silent server");
+            assert!(err.is_retriable(), "timeout must be retriable: {err:?}");
+            // Distinguish a genuine statement timeout from an acquire failure:
+            // the bound must actually elapse and produce the timeout message.
+            assert!(
+                format!("{err:?}").contains("did not complete within"),
+                "attempt {attempt} must fail via the statement bound, got: {err:?}"
+            );
+            assert!(
+                started.elapsed() >= bound,
+                "attempt {attempt} failed before the bound elapsed: {:?}",
+                started.elapsed()
+            );
+            assert!(
+                started.elapsed() < Duration::from_secs(5),
+                "attempt {attempt} took too long: {:?}",
+                started.elapsed()
+            );
+            assert_eq!(
+                connections.load(Ordering::SeqCst),
+                attempt as usize,
+                "each attempt must open a fresh physical connection (permit released by detach)"
+            );
+        }
     }
 }

--- a/crates/streamling-e2e/tests/postgres_sink_recovery.rs
+++ b/crates/streamling-e2e/tests/postgres_sink_recovery.rs
@@ -1,0 +1,283 @@
+//! PostgreSQL sink recovery tests.
+//!
+//! Verifies that the sink survives a database connection that dies *silently*
+//! (no RST/FIN — the peer just stops responding, as happens when a NAT or
+//! firewall drops an established flow). Without a client-side statement bound
+//! this wedges the sink forever with clean logs; with it, the sink must log,
+//! discard the dead connection, and recover on a fresh one.
+
+use serde::Serialize;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use streamling_e2e::{init_tracing, PipelineOpts, TestContext};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+#[derive(Debug, Clone, Serialize)]
+struct TestRecord {
+    id: i64,
+    value: String,
+    timestamp: i64,
+}
+
+const TEST_SCHEMA: &str = r#"{
+    "type": "record",
+    "name": "TestRecord",
+    "fields": [
+        {"name": "id", "type": "long"},
+        {"name": "value", "type": "string"},
+        {"name": "timestamp", "type": "long"}
+    ]
+}"#;
+
+/// TCP proxy that can simulate a middlebox silently killing connections.
+///
+/// Two failure injections, both leaving the client with a socket that accepts
+/// writes but never delivers a response (the "silently dead" state):
+/// - `kill_established()` poisons every currently-open link; new connections
+///   pass through normally (models a NAT flushing its flow table).
+/// - `arm_insert_trap()` poisons the first link that carries an INSERT
+///   statement after arming — this catches a *fresh* connection mid-statement,
+///   which is the exact state a server-side `statement_timeout` can never
+///   cancel.
+struct FlakyProxy {
+    port: u16,
+    /// Bumped by kill_established(); links remember the value at birth.
+    generation: Arc<AtomicU64>,
+    /// 1 = armed, 2 = fired. One-shot.
+    insert_trap: Arc<AtomicU64>,
+}
+
+impl FlakyProxy {
+    async fn start(upstream: String) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("proxy bind");
+        let port = listener.local_addr().expect("proxy addr").port();
+        let generation = Arc::new(AtomicU64::new(0));
+        let insert_trap = Arc::new(AtomicU64::new(0));
+
+        let generation_accept = generation.clone();
+        let insert_trap_accept = insert_trap.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((client, _)) = listener.accept().await else {
+                    break;
+                };
+                let upstream = upstream.clone();
+                let generation = generation_accept.clone();
+                let insert_trap = insert_trap_accept.clone();
+                tokio::spawn(async move {
+                    let born = generation.load(Ordering::SeqCst);
+                    let Ok(server) = TcpStream::connect(&upstream).await else {
+                        return;
+                    };
+                    let (mut client_read, mut client_write) = client.into_split();
+                    let (mut server_read, mut server_write) = server.into_split();
+
+                    // Per-link poison flag shared by both directions.
+                    let poisoned = Arc::new(AtomicU64::new(0));
+
+                    let c2s = {
+                        let generation = generation.clone();
+                        let insert_trap = insert_trap.clone();
+                        let poisoned = poisoned.clone();
+                        async move {
+                            let mut buf = [0u8; 8192];
+                            loop {
+                                let n = match client_read.read(&mut buf).await {
+                                    Ok(0) | Err(_) => break,
+                                    Ok(n) => n,
+                                };
+                                if insert_trap.load(Ordering::SeqCst) == 1
+                                    && buf[..n].windows(11).any(|w| w == b"INSERT INTO")
+                                    && insert_trap
+                                        .compare_exchange(1, 2, Ordering::SeqCst, Ordering::SeqCst)
+                                        .is_ok()
+                                {
+                                    poisoned.store(1, Ordering::SeqCst);
+                                }
+                                let dead = poisoned.load(Ordering::SeqCst) == 1
+                                    || generation.load(Ordering::SeqCst) != born;
+                                // A dead link keeps reading (the client's writes
+                                // succeed and get ACKed) but forwards nothing.
+                                if !dead && server_write.write_all(&buf[..n]).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                    };
+                    let s2c = {
+                        let generation = generation.clone();
+                        let poisoned = poisoned.clone();
+                        async move {
+                            let mut buf = [0u8; 8192];
+                            loop {
+                                let n = match server_read.read(&mut buf).await {
+                                    Ok(0) | Err(_) => break,
+                                    Ok(n) => n,
+                                };
+                                let dead = poisoned.load(Ordering::SeqCst) == 1
+                                    || generation.load(Ordering::SeqCst) != born;
+                                if !dead && client_write.write_all(&buf[..n]).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                    };
+                    tokio::join!(c2s, s2c);
+                });
+            }
+        });
+
+        Self {
+            port,
+            generation,
+            insert_trap,
+        }
+    }
+
+    /// Silently kill every currently-established link. New connections pass.
+    fn kill_established(&self) {
+        self.generation.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Arm a one-shot trap: the next link that carries an INSERT statement
+    /// goes silent from that statement on.
+    fn arm_insert_trap(&self) {
+        self.insert_trap.store(1, Ordering::SeqCst);
+    }
+
+    fn trap_fired(&self) -> bool {
+        self.insert_trap.load(Ordering::SeqCst) == 2
+    }
+}
+
+/// The sink must recover when its connection dies silently: first a poisoned
+/// idle connection (caught at acquire), then a fresh connection that goes
+/// silent mid-INSERT (caught by the client-side statement bound). Before the
+/// client-side bound existed, the second case hung the pipeline forever with
+/// no logs.
+#[tokio::test]
+async fn test_postgres_sink_recovers_from_silently_dead_connection() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("Failed to create test context");
+
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+
+    let proxy = FlakyProxy::start(format!("{}:{}", ctx.postgres.host, ctx.postgres.port)).await;
+
+    let first_batch: Vec<TestRecord> = (1..=5)
+        .map(|i| TestRecord {
+            id: i,
+            value: format!("value_{}", i),
+            timestamp: 1000 + i,
+        })
+        .collect();
+    ctx.kafka
+        .produce_avro_records(&first_batch)
+        .await
+        .expect("Failed to produce first batch");
+
+    let pipeline = format!(
+        r#"
+sources:
+  kafka_source:
+    type: kafka
+    topic: {topic}
+    starting_offsets: earliest
+    primary_key: id
+
+transforms: {{}}
+
+sinks:
+  pg_sink:
+    type: postgres
+    from: kafka_source
+    table: test_recovery
+    schema: public
+    primary_key: id
+    on_conflict: update
+    batch_size: 1
+"#,
+        topic = ctx.kafka_topic,
+    );
+
+    let opts = PipelineOpts::new()
+        .record_limit(10)
+        .timeout(Duration::from_secs(90))
+        // Route the sink through the proxy; the test asserts via a direct pool.
+        .env("STREAMLING__POSTGRES_SINK__HOST", "127.0.0.1")
+        .env("STREAMLING__POSTGRES_SINK__PORT", proxy.port.to_string())
+        // 1s server-side timeout => 2s client-side bound; keeps the test fast.
+        .env("STREAMLING__POSTGRES_SINK__STATEMENT_TIMEOUT_SECS", "1")
+        // Poisoned idle connections fail the pre-acquire ping at this deadline.
+        .env("STREAMLING__POSTGRES_SINK__POOL_ACQUIRE_TIMEOUT_SECS", "2")
+        .env("STREAMLING__RECORD_BATCH_SIZE", "1");
+
+    let run = ctx.run_pipeline_raw(&pipeline, opts);
+    tokio::pin!(run);
+
+    let mut wedged = false;
+    let output = loop {
+        tokio::select! {
+            out = &mut run => break out.expect("pipeline run failed"),
+            _ = tokio::time::sleep(Duration::from_millis(250)) => {
+                if !wedged {
+                    let count = ctx
+                        .postgres
+                        .count("SELECT COUNT(*) FROM public.test_recovery")
+                        .await
+                        .unwrap_or(0);
+                    if count >= 5 {
+                        // Phase 2: kill the connections the sink is holding and
+                        // make the next fresh connection go silent mid-INSERT.
+                        proxy.kill_established();
+                        proxy.arm_insert_trap();
+                        let second_batch: Vec<TestRecord> = (6..=10)
+                            .map(|i| TestRecord {
+                                id: i,
+                                value: format!("value_{}", i),
+                                timestamp: 1000 + i,
+                            })
+                            .collect();
+                        ctx.kafka
+                            .produce_avro_records(&second_batch)
+                            .await
+                            .expect("Failed to produce second batch");
+                        wedged = true;
+                    }
+                }
+            }
+        }
+    };
+
+    assert!(wedged, "test never reached the failure-injection phase");
+    assert!(proxy.trap_fired(), "the mid-INSERT trap never fired");
+    assert!(
+        output.status.success(),
+        "pipeline must recover and exit cleanly; stderr:\n{}",
+        output.stderr
+    );
+
+    let count = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.test_recovery")
+        .await
+        .expect("Failed to query count");
+    assert_eq!(
+        count, 10,
+        "all records must land despite the dead connection"
+    );
+
+    assert!(
+        output.stderr.contains("did not complete within"),
+        "expected the client-side statement timeout to be logged; stderr:\n{}",
+        output.stderr
+    );
+}


### PR DESCRIPTION
## Problem

A postgres sink statement can hang **forever with no log output** when its connection dies silently (peer stops responding without RST/FIN — NAT flow expiry, some failovers). Nothing bounds the wait client-side: `statement_timeout` is server-side (can't fire when the server is unreachable), sqlx 0.8 has no TCP keepalive, and `retry_forever_with_backoff_async` never runs an iteration because the `execute` future never resolves — no error, no retry, no log. Since the sink writes before acking checkpoints, it also stops finalizing checkpoints while still looking healthy.

## Fix

New `execute_bounded` in `streamling_core::utils::pg`, used by every sink hot-loop statement — `execute_batch_insert`, `execute_batch_delete`, and the checkpoint-truncation `DELETE` (which ran inline with no bound or retry — the same latent hang):

1. `pool.acquire()` (bounded by `acquire_timeout`), then `tokio::time::timeout(bound, execute)`.
2. On timeout, `detach()` + drop the connection — frees the pool slot and closes the socket without awaiting, rather than sqlx's return-to-pool path which can itself block on the dead socket.
3. The timeout is a retriable error, so the existing retry loop logs it and re-runs the idempotent statement on a fresh connection.

Bound = `2 × statement_timeout_secs` (default 60 → 120s): the server-side timeout fires first at 1× whenever the server is reachable, so the client bound only trips on a dead connection. `statement_timeout_secs = 0` disables both (`Option`-typed), so a deliberately-unbounded deployment can't be forced into a kill/retry loop. No new config field.

## Correctness

- Each slice is one multi-row `INSERT … ON CONFLICT` / `DELETE` — atomic server-side, socket close aborts the implicit tx (no partial commit), re-execution is idempotent.
- Healthy path unchanged (`execute(&pool)` already acquired a connection internally).
- Worst case (a statement legitimately slower than 2×): a logged retry of an idempotent statement — strictly better than today's silent hang; `0` opts out.

## Tests

- **Unit** (`utils::pg`): fake postgres finishes the handshake then goes silent while still ACKing bytes. Asserts a retriable timeout within the bound + a fresh connection per retry; mutation-checked both ways (removing the bound → hangs; replacing `detach()` with a plain drop → pool exhausts by attempt 3).
- **E2E** (`postgres_sink_recovery.rs`): kafka→postgres through a proxy that kills a connection mid-INSERT; asserts full recovery, all rows present, timeout logged. Stable across repeated runs.
- Full postgres e2e suite green; `just fix && just lint` clean.


