### PR TITLE
fix: support LargeUtf8 in avro writer

### DIFF
--- a/crates/streamling-common/src/formats/avro/writer.rs
+++ b/crates/streamling-common/src/formats/avro/writer.rs
@@ -249,6 +249,10 @@ fn serialize_column<T: SerializeTarget>(
             write_arrow_value!(ArrayRef::as_string::<i32>, Value::String, |v: &str| v
                 .into())
         }
+        DataType::LargeUtf8 => {
+            write_arrow_value!(ArrayRef::as_string::<i64>, Value::String, |v: &str| v
+                .into())
+        }
         DataType::Utf8View => {
             write_arrow_value!(ArrayRef::as_string_view, Value::String, |v: &str| v.into())
         }
@@ -1117,6 +1121,70 @@ mod tests {
                 Record(vec![(
                     "payload".to_string(),
                     Union(1, Box::new(Bytes(b"world".to_vec())))
+                )]),
+            ]
+        );
+    }
+
+    /// Regression test for the `unimplemented!("unsupported data type:
+    /// LargeUtf8")` panic. EVM datasets declare unbounded string columns
+    /// (log `data`, transaction calldata `input`) as `LargeUtf8` to avoid
+    /// i32 string-offset overflow; serializing them to a Kafka avro sink
+    /// must emit plain avro strings, exactly like `Utf8`.
+    #[test]
+    fn test_large_utf8_serialization() {
+        use apache_avro::types::Value::*;
+        use datafusion::arrow::array::LargeStringArray;
+
+        let arrow_schema = Arc::new(Schema::new(vec![Field::new(
+            "data",
+            DataType::LargeUtf8,
+            false,
+        )]));
+
+        let array = LargeStringArray::from(vec!["0xdeadbeef", ""]);
+
+        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(array)]).unwrap();
+        let avro_schema = to_avro("LogData", &arrow_schema.fields);
+        let result = serialize(&avro_schema, &batch);
+
+        assert_eq!(
+            result,
+            vec![
+                Record(vec![("data".to_string(), String("0xdeadbeef".to_string()))]),
+                Record(vec![("data".to_string(), String("".to_string()))]),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_large_utf8_nullable_serialization() {
+        use apache_avro::types::Value::*;
+        use datafusion::arrow::array::LargeStringArray;
+
+        let arrow_schema = Arc::new(Schema::new(vec![Field::new(
+            "input",
+            DataType::LargeUtf8,
+            true,
+        )]));
+
+        let array = LargeStringArray::from(vec![Some("0x00"), None, Some("0xffff")]);
+
+        let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(array)]).unwrap();
+        let avro_schema = to_avro("TxInput", &arrow_schema.fields);
+        let result = serialize(&avro_schema, &batch);
+
+        assert_eq!(
+            result,
+            vec![
+                Record(vec![(
+                    "input".to_string(),
+                    Union(1, Box::new(String("0x00".to_string())))
+                )]),
+                Record(vec![("input".to_string(), Union(0, Box::new(Null)))]),
+                Record(vec![(
+                    "input".to_string(),
+                    Union(1, Box::new(String("0xffff".to_string())))
                 )]),
             ]
         );


### PR DESCRIPTION
The avro value serializer had no `LargeUtf8` arm, so any `LargeUtf8` column reaching a Kafka avro sink panicked:

```
panic: not implemented: unsupported data type: LargeUtf8 at crates/streamling-common/src/formats/avro/writer.rs:453
```

The schema mapper already handled `LargeUtf8` (→ avro `string`); only the per-value path was missing. This is the same missing-arm class #9 fixed for `FixedSizeBinary`/`LargeBinary`, completed for the large string type: one arm mirroring `Utf8` with `as_string::<i64>`.

Current workaround is a per-pipeline `CAST(… AS VARCHAR)` in SQL transform, which this makes unnecessary.

Tests: `test_large_utf8_serialization` + `test_large_utf8_nullable_serialization`, written first and observed panicking on the old arm (CONV-001).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow serializer change with tests; behavior mirrors existing Utf8 handling and does not touch auth, persistence, or schema generation.
> 
> **Overview**
> Fixes a **panic** when Arrow **`LargeUtf8`** columns reach the Kafka Avro sink: `serialize_column` now handles **`LargeUtf8`** the same way as **`Utf8`**, using `as_string::<i64>` and emitting Avro **`string`** values (schema mapping already treated **`LargeUtf8`** as string).
> 
> This unblocks pipelines that use **`LargeUtf8`** for unbounded EVM fields (e.g. log `data`, tx `input`) without SQL **`CAST(... AS VARCHAR)`** workarounds.
> 
> Adds regression tests for required and nullable **`LargeUtf8`** serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e556976a547cf8792c478ab2d262f0836e806121. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->