### PR TITLE
fix: preserve checkpoint markers through multi-sink transform chains

### DIFF
--- a/crates/streamling-core/src/operators/broadcast.rs
+++ b/crates/streamling-core/src/operators/broadcast.rs
@@ -5,11 +5,15 @@
 pub(crate) mod broadcast_stream;
 
 use crate::operators::broadcast::broadcast_stream::BroadcastStream;
+use crate::operators::filter::StreamingFilterExec;
+use crate::operators::projection::StreamingProjectionExec;
 use crate::operators::rebatch::RebatchConfig;
+use crate::operators::unnest::StreamingUnnestExec;
 use crate::session::{DEFAULT_CATALOG_NAME, SessionManager, get_streamling_config};
 use crate::utils::batch_accumulator::AsyncBatchAccumulator;
 use arrow_schema::SchemaRef;
 use async_trait::async_trait;
+use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode, TreeNodeRecursion};
 use datafusion::common::{DFSchemaRef, Statistics, internal_err};
 use datafusion::error::Result;
 use datafusion::execution::{SendableRecordBatchStream, SessionState, TaskContext};
@@ -18,7 +22,10 @@ use datafusion::logical_expr::{
     Expr, LogicalPlan, UserDefinedLogicalNode, UserDefinedLogicalNodeCore,
 };
 use datafusion::physical_expr::{Distribution, EquivalenceProperties, Partitioning};
+use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::unnest::UnnestExec;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, execute_input_stream,
     execution_plan::{Boundedness, EmissionType},
@@ -190,6 +197,49 @@ impl UserDefinedLogicalNodeCore for MultiSinkLogicalNode {
     }
 }
 
+/// Rewrite stock DataFusion operators in a sink's transform chain (the nodes
+/// `insert_into` adds between the shared broadcast input and the `DataSink`,
+/// e.g. a ClickHouse sink's `ProjectionExec`) into their metadata-preserving
+/// `Streaming*` counterparts.
+///
+/// The main plan tree gets this rewrite from the
+/// `Streaming*RewritePhysicalOptimizerRule`s, but the per-sink plans built
+/// here are stored in `MultiSinkExec::sinks`, which is not exposed through
+/// `children()`, so the physical optimizer never traverses them. Left as-is,
+/// a stock `ProjectionExec` rebuilds every batch with its plan-time schema,
+/// dropping the checkpoint-marker metadata — the sink then keeps writing but
+/// never acks an epoch, and checkpointing stalls forever on "missing sinks".
+///
+/// Traversal stops at `shared_input`: that subtree belongs to the main plan
+/// tree (optimized separately) and is replaced by the broadcast stream at
+/// execute time anyway. Not descending into it also keeps the
+/// `Arc::ptr_eq(dse.input(), &input_physical)` transform detection intact for
+/// sinks whose `insert_into` adds no nodes.
+fn rewrite_sink_transform_chain(
+    plan: Arc<dyn ExecutionPlan>,
+    shared_input: &Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    plan.transform_down(|node| {
+        if Arc::ptr_eq(&node, shared_input) {
+            return Ok(Transformed::new(node, false, TreeNodeRecursion::Jump));
+        }
+        if let Some(projection) = node.downcast_ref::<ProjectionExec>() {
+            let streaming = StreamingProjectionExec::from_original(projection.clone())?;
+            return Ok(Transformed::yes(Arc::new(streaming)));
+        }
+        if let Some(filter) = node.downcast_ref::<FilterExec>() {
+            let streaming = StreamingFilterExec::from_original(filter.clone())?;
+            return Ok(Transformed::yes(Arc::new(streaming)));
+        }
+        if let Some(unnest) = node.downcast_ref::<UnnestExec>() {
+            let streaming = StreamingUnnestExec::from_original(unnest.clone())?;
+            return Ok(Transformed::yes(Arc::new(streaming)));
+        }
+        Ok(Transformed::no(node))
+    })
+    .data()
+}
+
 pub struct MultiSinkExtensionPlanner {}
 
 #[async_trait]
@@ -227,6 +277,9 @@ impl ExtensionPlanner for MultiSinkExtensionPlanner {
                     let sink_plan = table
                         .insert_into(session_state, input_physical.clone(), InsertOp::Append)
                         .await?;
+                    // Checkpoint markers must survive the sink's transform
+                    // chain; the physical optimizer can't reach it here.
+                    let sink_plan = rewrite_sink_transform_chain(sink_plan, &input_physical)?;
 
                     let has_transforms = sink_plan
                         .downcast_ref::<DataSinkExec>()
@@ -502,5 +555,101 @@ impl ExecutionPlan for MultiSinkExec {
 
     fn partition_statistics(&self, _partition: Option<usize>) -> Result<Arc<Statistics>> {
         Ok(Arc::new(Statistics::new_unknown(&self.schema())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Int64Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use datafusion::catalog::TableProvider;
+    use datafusion::datasource::MemTable;
+    use datafusion::physical_expr::expressions::Column;
+    use datafusion::prelude::SessionContext;
+
+    fn scan_plan() -> Arc<dyn ExecutionPlan> {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int64Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let mem_table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        futures::executor::block_on(mem_table.scan(&state, None, &[], None)).unwrap()
+    }
+
+    fn identity_projection(input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+        let col: Arc<dyn datafusion::physical_expr::PhysicalExpr> = Arc::new(Column::new("id", 0));
+        Arc::new(ProjectionExec::try_new(vec![(col, "id".to_string())], input).unwrap())
+    }
+
+    /// A `ProjectionExec` added by a sink's `insert_into` must be rewritten to
+    /// the metadata-preserving `StreamingProjectionExec`, while the shared
+    /// broadcast input below it stays untouched (same `Arc`).
+    #[test]
+    fn rewrite_replaces_sink_projection_and_keeps_shared_input() {
+        let shared = scan_plan();
+        let plan = identity_projection(shared.clone());
+
+        let rewritten = rewrite_sink_transform_chain(plan, &shared).unwrap();
+
+        assert!(
+            rewritten
+                .downcast_ref::<StreamingProjectionExec>()
+                .is_some(),
+            "expected StreamingProjectionExec at the root, got {}",
+            rewritten.name()
+        );
+        let children = rewritten.children();
+        assert_eq!(children.len(), 1);
+        assert!(
+            Arc::ptr_eq(children[0], &shared),
+            "shared input must be forwarded untouched"
+        );
+    }
+
+    /// A sink plan that adds no nodes (e.g. a webhook sink) must come back as
+    /// the very same plan, preserving the `Arc::ptr_eq` transform detection.
+    #[test]
+    fn rewrite_is_identity_when_sink_adds_no_nodes() {
+        let shared = scan_plan();
+
+        let rewritten = rewrite_sink_transform_chain(shared.clone(), &shared).unwrap();
+
+        assert!(
+            Arc::ptr_eq(&rewritten, &shared),
+            "plan without sink-side transforms must be returned as-is"
+        );
+    }
+
+    /// Operators inside the shared input subtree belong to the main plan tree
+    /// (the physical optimizer handles them there); the rewrite must not
+    /// descend into it.
+    #[test]
+    fn rewrite_does_not_descend_into_shared_input() {
+        let shared = identity_projection(scan_plan());
+        let plan = identity_projection(shared.clone());
+
+        let rewritten = rewrite_sink_transform_chain(plan, &shared).unwrap();
+
+        assert!(
+            rewritten
+                .downcast_ref::<StreamingProjectionExec>()
+                .is_some(),
+            "sink-side projection must still be rewritten"
+        );
+        let children = rewritten.children();
+        assert!(
+            Arc::ptr_eq(children[0], &shared),
+            "shared input subtree must not be rebuilt"
+        );
+        assert!(
+            children[0].downcast_ref::<ProjectionExec>().is_some(),
+            "nodes inside the shared input must keep their original type"
+        );
     }
 }

--- a/crates/streamling-e2e/tests/multi_sink.rs
+++ b/crates/streamling-e2e/tests/multi_sink.rs
@@ -338,3 +338,171 @@ sinks:
         "Pipeline should fail when one branch errors"
     );
 }
+
+// ============================================================================
+// Scenario 4: Checkpoints must finalize when a transform-adding sink (ClickHouse)
+// shares a source with another sink (webhook) through the multi-sink broadcast
+// ============================================================================
+
+/// Regression: checkpoint markers ride on per-batch schema metadata, and the
+/// per-sink plans inside `MultiSinkExec` live outside the tree the physical
+/// optimizer traverses. A ClickHouse sink's `insert_into` adds a stock
+/// `ProjectionExec`; un-rewritten, it rebuilds every batch with its plan-time
+/// schema and silently drops the markers — the sink keeps writing but never
+/// acks an epoch, and the coordinator stalls forever on "missing sinks".
+///
+/// The webhook branch adds no transform nodes, so it acks fine — masking the
+/// stall from delivery-only assertions. This test pins the fix by asserting
+/// checkpoint *finalization*, not just delivery:
+///   1. At least one epoch finalizes ("Epoch finalized" — requires ALL sinks,
+///      including the ClickHouse branch behind the projection, to ack).
+///   2. No stall symptoms ("missing sinks" / "still waiting for finalization").
+///   3. Both sinks still receive every record.
+///
+/// Records are produced in two waves with the second wave delayed past several
+/// 1s checkpoint intervals, so the run provably spans at least one full
+/// epoch cycle before the record limit stops the pipeline.
+#[tokio::test]
+async fn test_multi_sink_checkpoint_finalizes_with_clickhouse_and_webhook() {
+    init_tracing();
+
+    use streamling_e2e::resources::WebhookResource;
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+
+    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
+
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+
+    let webhook = WebhookResource::new()
+        .await
+        .expect("Failed to start webhook server");
+
+    let total_records: i64 = 100;
+    let first_wave: Vec<TestRecord> = (1..=total_records / 2)
+        .map(|i| TestRecord {
+            id: i,
+            value: format!("value_{}", i),
+            timestamp: 1000 + i,
+        })
+        .collect();
+    let second_wave: Vec<TestRecord> = (total_records / 2 + 1..=total_records)
+        .map(|i| TestRecord {
+            id: i,
+            value: format!("value_{}", i),
+            timestamp: 1000 + i,
+        })
+        .collect();
+
+    ctx.kafka
+        .produce_avro_records(&first_wave)
+        .await
+        .expect("Failed to produce first wave");
+
+    // Kafka source → ClickHouse sink + webhook sink sharing the same source
+    // node, which engages the multi-sink broadcast. The ClickHouse branch is
+    // the transform-adding one (its insert_into interposes a projection).
+    let pipeline = format!(
+        r#"
+sources:
+  kafka_source:
+    type: kafka
+    topic: {topic}
+    starting_offsets: earliest
+    primary_key: id
+
+transforms: {{}}
+
+sinks:
+  ch_sink:
+    type: clickhouse
+    from: kafka_source
+    table: multi_sink_checkpoint_ch
+    primary_key: id
+    schema_override:
+      _gs_op: "String"
+
+  webhook_sink:
+    type: webhook
+    from: kafka_source
+    url: {webhook_url}
+    one_row_per_request: true
+    payload_version: 0
+"#,
+        topic = ctx.kafka_topic,
+        webhook_url = webhook.webhook_url(),
+    );
+
+    // The pipeline cannot hit the record limit before the delayed second wave
+    // arrives, so it stays up across several checkpoint intervals with data
+    // flowing on both sides of the markers.
+    let run_pipeline = ctx.run_pipeline_raw(
+        &pipeline,
+        PipelineOpts::new()
+            .record_limit(total_records as u64)
+            .env("STREAMLING__CHECKPOINT_INTERVAL_SEC", "1")
+            .env("RUST_LOG", "info")
+            .timeout(std::time::Duration::from_secs(120)),
+    );
+    let produce_second_wave = async {
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        ctx.kafka
+            .produce_avro_records(&second_wave)
+            .await
+            .expect("Failed to produce second wave");
+    };
+    let (output, _) = tokio::join!(run_pipeline, produce_second_wave);
+    let output = output.expect("Pipeline execution failed");
+
+    assert!(
+        output.status.success(),
+        "Pipeline should exit successfully; stderr:\n{}",
+        output.stderr
+    );
+
+    // Positive proof the ClickHouse branch acked: an epoch only finalizes once
+    // every sink (including the one behind the sink-side projection) acks it.
+    assert!(
+        output.stderr.contains("Epoch finalized"),
+        "No checkpoint epoch finalized — a marker was dropped before a sink ack.\nstderr:\n{}",
+        output.stderr
+    );
+
+    // And no stall symptoms while the pipeline ran.
+    assert!(
+        !output.stderr.contains("missing sinks"),
+        "Checkpoint coordinator reported missing sink acks.\nstderr:\n{}",
+        output.stderr
+    );
+    assert!(
+        !output.stderr.contains("still waiting for finalization"),
+        "Checkpoint epoch stalled waiting for a sink ack.\nstderr:\n{}",
+        output.stderr
+    );
+
+    // Delivery still works on both branches.
+    let ch_count: u64 = clickhouse
+        .count("SELECT COUNT(*) FROM multi_sink_checkpoint_ch")
+        .await
+        .expect("Failed to query ClickHouse count");
+    assert_eq!(
+        ch_count, total_records as u64,
+        "ClickHouse should have {} records",
+        total_records
+    );
+
+    let received_all = webhook
+        .wait_for_requests(total_records as usize, std::time::Duration::from_secs(10))
+        .await;
+    assert!(
+        received_all,
+        "Expected {} webhook requests, got {}",
+        total_records,
+        webhook.request_count()
+    );
+}


### PR DESCRIPTION
## Problem

Checkpoint markers travel as per-batch schema metadata. Streamling normally protects them by rewriting stock DataFusion operators (`ProjectionExec`/`FilterExec`/`UnnestExec`) into metadata-preserving `Streaming*` variants via physical-optimizer rules — but those rules traverse the plan tree through `children()`, and the per-sink plans built by the MultiSink extension planner live in `MultiSinkExec::sinks`, which `children()` does not expose. They are never rewritten.

A sink whose `insert_into` adds a stock operator — ClickHouse always interposes a `ProjectionExec`; Postgres does when the schema has u256/i256 or nested columns — then rebuilds every batch with its plan-time schema, silently dropping the markers. The sink keeps writing data but never acks a checkpoint epoch, and the coordinator stalls forever:

```
Checkpoint producer still waiting for finalization (...): epoch=1,
state=InProgress { acked_sinks: {"webhook_sink"}, ... } — missing sinks: ["clickhouse_sink"]
```

This hits any topology where such a sink shares a source/transform with another sink (which is what engages the multi-sink broadcast). The sibling sink (e.g. webhook — no added nodes) acks fine, which is why delivery-focused tests never caught it.

## Fix

`rewrite_sink_transform_chain()` rewrites each sink plan's transform chain into the `Streaming*` operators at planning time, mirroring what the optimizer rules do for the main tree. Traversal stops at the shared broadcast input (`TreeNodeRecursion::Jump`): that subtree is optimized in the main plan tree and is replaced by the broadcast stream at execute time, and not descending into it keeps the `Arc::ptr_eq` transform detection intact for sinks that add no nodes.

`StreamingProjectionExec::with_new_children` returns the streaming variant, so the rewrite also survives the runtime child-swap in `MultiSinkExec::execute`.

## Tests

- 3 unit tests for the rewrite: sink-side projection rewritten with the shared input forwarded untouched; identity (same `Arc`) when the sink adds no nodes; no descent into the shared input subtree.
- New e2e `test_multi_sink_checkpoint_finalizes_with_clickhouse_and_webhook`: ClickHouse + webhook sharing one Kafka source, 1s checkpoint interval, records produced in two waves so the run provably spans a full epoch cycle. Asserts a **positive** "Epoch finalized" (which requires the sink behind the projection to ack), no stall warnings, and delivery on both branches. The positive assertion matters: the stall warning only appears after 10s of waiting, so short runs would otherwise pass vacuously.
- Verified the e2e test **fails without the fix** (missing "Epoch finalized") and passes with it; full `multi_sink` (4/4) and checkpoint-related (7/7) e2e suites pass, `streamling-core` unit tests 392/392.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multi-sink physical planning and checkpoint ack paths for transform-heavy sinks; behavior is narrowly scoped with targeted unit and e2e coverage.
> 
> **Overview**
> Fixes **checkpoint stalls** when multiple sinks share a source and one sink’s `insert_into` adds stock DataFusion operators (e.g. ClickHouse’s `ProjectionExec`) that were never rewritten by the physical optimizer.
> 
> Per-sink plans live under `MultiSinkExec::sinks`, outside `children()`, so checkpoint marker metadata on batch schemas was dropped in those transforms—the sink kept writing but never acked epochs while siblings (e.g. webhook) could ack, leaving the coordinator on “missing sinks”.
> 
> Adds **`rewrite_sink_transform_chain`** at multi-sink planning time to swap `ProjectionExec` / `FilterExec` / `UnnestExec` for metadata-preserving `Streaming*` variants, stopping at the shared broadcast input so transform detection and main-tree optimization stay unchanged. **Unit tests** cover rewrite, identity, and no descent into the shared subtree. **E2e** `test_multi_sink_checkpoint_finalizes_with_clickhouse_and_webhook` asserts epoch finalization (not just delivery) for ClickHouse + webhook with 1s checkpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e99921fa302899312e1f2dded20e231bd65477e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->