### PR TITLE
fix: flush delta meter provider on shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4871,6 +4871,8 @@ dependencies = [
  "rand 0.9.2",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/crates/streamling-core/Cargo.toml
+++ b/crates/streamling-core/Cargo.toml
@@ -88,3 +88,4 @@ paste.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
+opentelemetry_sdk = { workspace = true, features = ["testing"] }

--- a/crates/streamling-core/src/telemetry/mod.rs
+++ b/crates/streamling-core/src/telemetry/mod.rs
@@ -4,7 +4,10 @@ pub mod recorder;
 pub mod types;
 
 pub use event_time_reader::{EventTimeReadError, EventTimeReader};
-pub use provider::{get_delta_meter, init_telemetry_provider, shutdown_test_meter_providers};
+pub use provider::{
+    get_delta_meter, init_telemetry_provider, shutdown_delta_meter_provider,
+    shutdown_test_meter_providers,
+};
 pub use types::{
     PipelineMetricMetadata, TopologyNodeType, get_global_metric_tags, set_global_metric_tags,
 };

--- a/crates/streamling-core/src/telemetry/provider.rs
+++ b/crates/streamling-core/src/telemetry/provider.rs
@@ -201,8 +201,12 @@ pub fn init_telemetry_provider(
 pub fn shutdown_delta_meter_provider() {
     if let Some(provider) = DELTA_METER_PROVIDER.get() {
         info!("Shutting down delta telemetry meter provider");
-        let _ = provider.force_flush();
-        let _ = provider.shutdown();
+        if let Err(e) = provider.force_flush() {
+            error!("Failed to flush delta meter provider; billing counts since the last export tick may be lost: {e}");
+        }
+        if let Err(e) = provider.shutdown() {
+            error!("Failed to shut down delta meter provider: {e}");
+        }
     }
 }
 
@@ -393,4 +397,41 @@ pub fn get_delta_meter() -> opentelemetry::metrics::Meter {
     // This should rarely happen in practice
     trace!("Delta provider not found, falling back to global meter");
     global::meter("execution_metrics_delta")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry_sdk::metrics::InMemoryMetricExporterBuilder;
+
+    /// Regression test for short-lived jobs losing billing counts: delta
+    /// measurements recorded after the last PeriodicReader tick must still be
+    /// exported when shutdown_delta_meter_provider() runs on process exit.
+    #[test]
+    fn shutdown_delta_meter_provider_flushes_pending_counts() {
+        let exporter = InMemoryMetricExporterBuilder::new()
+            .with_temporality(Temporality::Delta)
+            .build();
+        // Interval far longer than the test: nothing exports unless shutdown flushes.
+        let reader = PeriodicReader::builder(exporter.clone())
+            .with_interval(Duration::from_secs(3600))
+            .build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        DELTA_METER_PROVIDER
+            .set(provider)
+            .expect("DELTA_METER_PROVIDER already set; no other test may initialize it");
+
+        get_delta_meter()
+            .u64_counter("streamling_output_rows_delta")
+            .build()
+            .add(42, &[]);
+
+        shutdown_delta_meter_provider();
+
+        let exported = exporter.get_finished_metrics().unwrap();
+        assert!(
+            !exported.is_empty(),
+            "delta counts recorded before exit were not exported on shutdown"
+        );
+    }
 }

--- a/crates/streamling-core/src/telemetry/provider.rs
+++ b/crates/streamling-core/src/telemetry/provider.rs
@@ -202,7 +202,9 @@ pub fn shutdown_delta_meter_provider() {
     if let Some(provider) = DELTA_METER_PROVIDER.get() {
         info!("Shutting down delta telemetry meter provider");
         if let Err(e) = provider.force_flush() {
-            error!("Failed to flush delta meter provider; billing counts since the last export tick may be lost: {e}");
+            error!(
+                "Failed to flush delta meter provider; billing counts since the last export tick may be lost: {e}"
+            );
         }
         if let Err(e) = provider.shutdown() {
             error!("Failed to shut down delta meter provider: {e}");

--- a/crates/streamling-core/src/telemetry/provider.rs
+++ b/crates/streamling-core/src/telemetry/provider.rs
@@ -193,6 +193,19 @@ pub fn init_telemetry_provider(
     }
 }
 
+/// Flush and shut down the delta meter provider. Must be called on process
+/// exit: the delta provider is not the global provider, so it is not covered
+/// by the cumulative provider's shutdown — without this, jobs that finish
+/// before the PeriodicReader's first tick lose their output_rows_delta
+/// (billing) counts entirely.
+pub fn shutdown_delta_meter_provider() {
+    if let Some(provider) = DELTA_METER_PROVIDER.get() {
+        info!("Shutting down delta telemetry meter provider");
+        let _ = provider.force_flush();
+        let _ = provider.shutdown();
+    }
+}
+
 pub fn shutdown_test_meter_providers() {
     info!("Shutting down telemetry meter providers");
     if let Some(provider) = SHARED_TEST_METER.get() {

--- a/crates/streamling/src/main.rs
+++ b/crates/streamling/src/main.rs
@@ -198,8 +198,10 @@ async fn run_pipeline(
     if let Some(provider) = telemetry_provider {
         let _ = provider.force_flush();
         let _ = provider.shutdown();
-        streamling_core::telemetry::shutdown_delta_meter_provider();
     }
+    // Independent of the cumulative provider above: flushes billing counts
+    // even if a future code path initializes only the delta provider.
+    streamling_core::telemetry::shutdown_delta_meter_provider();
 
     result
 }

--- a/crates/streamling/src/main.rs
+++ b/crates/streamling/src/main.rs
@@ -198,6 +198,7 @@ async fn run_pipeline(
     if let Some(provider) = telemetry_provider {
         let _ = provider.force_flush();
         let _ = provider.shutdown();
+        streamling_core::telemetry::shutdown_delta_meter_provider();
     }
 
     result


### PR DESCRIPTION
## Summary

Bug fix for the delta reporter flush: flush and shut down the delta meter provider on pipeline shutdown so short-lived jobs export pending delta metrics.

## Test plan

- [x] Unit regression test for delta meter provider flush on shutdown
- [x] `just fix && just lint`