### PR TITLE
fix: support ingesting a single file in the file source

### DIFF
--- a/crates/streamling-connectors/src/table_providers/file.rs
+++ b/crates/streamling-connectors/src/table_providers/file.rs
@@ -8,9 +8,9 @@
 //!   EOF (inferring the schema and Hive-style partition columns), and the job
 //!   terminates on its own.
 //! - **Continuous** ([`FileSourceTableProvider`]) keeps watching the path: a poll
-//!   loop lists the prefix every `poll_interval`, ingests files whose
-//!   `last_modified` exceeds a persisted [`FileWatermark`], and never
-//!   self-terminates.
+//!   loop lists the prefix (or HEADs the path when it names a single object)
+//!   every `poll_interval`, ingests files whose `last_modified` exceeds a
+//!   persisted [`FileWatermark`], and never self-terminates.
 //!
 //! Because file reads are append-only, a constant `_gs_op = 'i'` column is
 //! synthesized when the inferred schema lacks it. Files that already carry
@@ -52,6 +52,7 @@ use datafusion::physical_plan::{
     project_schema,
 };
 use futures::StreamExt;
+use object_store::ObjectStoreExt;
 use serde_derive::{Deserialize, Serialize};
 use tokio::sync::watch;
 use tokio::time::sleep;
@@ -792,7 +793,16 @@ impl ExecutionPlan for FileSourceExec {
                 let boundary: HashSet<String> = watermark.boundary_paths.iter().cloned().collect();
                 let mut new_files: Vec<PartitionedFile> = Vec::new();
                 let mut max_seen = watermark.last_modified_ms;
-                let mut listing = object_store.list(Some(table_url.prefix()));
+                // A non-collection URL names one exact object, which a prefix
+                // listing never returns (object_store prefixes match whole
+                // path segments), so HEAD it instead — the resulting
+                // ObjectMeta flows through the same watermark and extension
+                // checks below, so an unchanged object is only ingested once.
+                let mut listing = if table_url.is_collection() {
+                    object_store.list(Some(table_url.prefix()))
+                } else {
+                    futures::stream::iter([object_store.head(table_url.prefix()).await]).boxed()
+                };
                 while let Some(meta) = listing.next().await {
                     let meta = meta?;
                     let last_modified_ms = meta.last_modified.timestamp_millis();
@@ -1257,6 +1267,77 @@ mod tests {
         assert!(
             empty_batches >= 2,
             "idle polls must emit empty heartbeat batches; got {empty_batches}"
+        );
+    }
+
+    /// A path naming one exact object (no trailing slash) must be ingested by
+    /// the continuous source. The poll loop's prefix listing never returns a
+    /// key equal to the prefix (object_store prefixes match whole path
+    /// segments), so this exercises the HEAD branch — without it the source
+    /// heartbeats forever with zero rows.
+    #[tokio::test]
+    async fn continuous_source_ingests_single_file_path() {
+        use std::time::Duration;
+        use streamling_core::dynamic_table::DynamicTableRegistry;
+        use streamling_state::StateOperatorBackendFactory;
+        use streamling_state::in_memory::InMemoryStateOperatorBackendFactory;
+        use tokio::time::timeout;
+
+        let dir =
+            std::env::temp_dir().join(format!("streamling_single_file_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("1.csv");
+        std::fs::write(&file, "id,name\n1,alice\n2,bob\n3,carol").unwrap();
+
+        let session_manager = SessionManager::new(100, 10, DynamicTableRegistry::new()).unwrap();
+        let state_backend = InMemoryStateOperatorBackendFactory::new()
+            .unwrap()
+            .create::<FileWatermark>("single_file_test");
+
+        let provider = FileSourceTableProvider::try_new(
+            "single_file_src",
+            file.to_str().unwrap(),
+            FileSourceFormat::Csv,
+            Duration::from_millis(100),
+            &session_manager,
+            state_backend,
+            None,
+            10,
+        )
+        .await
+        .unwrap();
+
+        let plan = provider
+            .scan(&session_manager.session_state(), None, &[], None)
+            .await
+            .unwrap();
+        let mut stream = plan
+            .execute(0, session_manager.session_context().task_ctx())
+            .unwrap();
+
+        // First poll HEADs and reads the file (3 rows); the watermark then
+        // filters the unchanged object, so later polls are idle heartbeats.
+        let mut data_rows = 0usize;
+        let mut empty_batches = 0usize;
+        for _ in 0..5 {
+            let batch = timeout(Duration::from_secs(5), stream.next())
+                .await
+                .expect("stream should yield within timeout")
+                .expect("stream should not end")
+                .unwrap();
+            if batch.num_rows() == 0 {
+                empty_batches += 1;
+            } else {
+                data_rows += batch.num_rows();
+            }
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(data_rows, 3, "the object's 3 rows are read exactly once");
+        assert!(
+            empty_batches >= 2,
+            "polls after ingest must emit empty heartbeat batches; got {empty_batches}"
         );
     }
 

--- a/crates/streamling-connectors/src/table_providers/file.rs
+++ b/crates/streamling-connectors/src/table_providers/file.rs
@@ -52,7 +52,8 @@ use datafusion::physical_plan::{
     project_schema,
 };
 use futures::StreamExt;
-use object_store::ObjectStoreExt;
+use futures::stream::BoxStream;
+use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt};
 use serde_derive::{Deserialize, Serialize};
 use tokio::sync::watch;
 use tokio::time::sleep;
@@ -279,6 +280,29 @@ pub struct FileWatermark {
 
 fn watermark_state_key(reference_name: &str) -> StateKey {
     StateKey::from(format!("{reference_name}:watermark"))
+}
+
+/// The candidate objects for one poll.
+///
+/// A non-collection URL names one exact object, which a prefix listing never
+/// returns (object_store matches prefixes on whole path segments), so it is
+/// HEADed instead. A `NotFound` falls back to a prefix listing, mirroring
+/// DataFusion's `ListingTableUrl::list_prefixed_files`: a remote directory URL
+/// without a trailing slash is also non-collection, and schema inference
+/// resolves it through that same fallback, so a source configured that way would
+/// otherwise start and then tear down on its first poll. Other errors ride the
+/// stream, keeping one error path in the caller.
+async fn list_poll_candidates(
+    object_store: &dyn ObjectStore,
+    table_url: &ListingTableUrl,
+) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+    if table_url.is_collection() {
+        return object_store.list(Some(table_url.prefix()));
+    }
+    match object_store.head(table_url.prefix()).await {
+        Err(object_store::Error::NotFound { .. }) => object_store.list(Some(table_url.prefix())),
+        result => futures::stream::iter([result]).boxed(),
+    }
 }
 
 /// Whether a listed object should be ingested: it must carry the format's
@@ -793,16 +817,9 @@ impl ExecutionPlan for FileSourceExec {
                 let boundary: HashSet<String> = watermark.boundary_paths.iter().cloned().collect();
                 let mut new_files: Vec<PartitionedFile> = Vec::new();
                 let mut max_seen = watermark.last_modified_ms;
-                // A non-collection URL names one exact object, which a prefix
-                // listing never returns (object_store prefixes match whole
-                // path segments), so HEAD it instead — the resulting
-                // ObjectMeta flows through the same watermark and extension
-                // checks below, so an unchanged object is only ingested once.
-                let mut listing = if table_url.is_collection() {
-                    object_store.list(Some(table_url.prefix()))
-                } else {
-                    futures::stream::iter([object_store.head(table_url.prefix()).await]).boxed()
-                };
+                // A HEADed single object flows through the same watermark and
+                // extension checks as a listed one, so it is ingested only once.
+                let mut listing = list_poll_candidates(object_store.as_ref(), &table_url).await;
                 while let Some(meta) = listing.next().await {
                     let meta = meta?;
                     let last_modified_ms = meta.last_modified.timestamp_millis();
@@ -1268,6 +1285,34 @@ mod tests {
             empty_batches >= 2,
             "idle polls must emit empty heartbeat batches; got {empty_batches}"
         );
+    }
+
+    /// A remote directory URL without a trailing slash is not a collection, so
+    /// the poll HEADs it and gets NotFound. Schema inference resolves such a URL
+    /// by falling back to a prefix listing, so the poll loop must agree —
+    /// otherwise the source starts and dies on its first poll.
+    #[tokio::test]
+    async fn poll_candidates_fall_back_to_listing_when_head_misses() {
+        use futures::TryStreamExt;
+        use object_store::memory::InMemory;
+        use object_store::path::Path;
+
+        let store = InMemory::new();
+        store
+            .put(&Path::from("data/1.csv"), "id\n1".into())
+            .await
+            .unwrap();
+
+        let table_url = ListingTableUrl::parse("memory:///data").unwrap();
+        assert!(!table_url.is_collection(), "no trailing slash");
+
+        let found: Vec<ObjectMeta> = list_poll_candidates(&store, &table_url)
+            .await
+            .try_collect()
+            .await
+            .unwrap();
+        let locations: Vec<&str> = found.iter().map(|meta| meta.location.as_ref()).collect();
+        assert_eq!(locations, vec!["data/1.csv"]);
     }
 
     /// A path naming one exact object (no trailing slash) must be ingested by


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes object discovery in the continuous file source poll loop; behavior is aligned with DataFusion listing but affects what files are seen on each poll.
> 
> **Overview**
> Fixes the **continuous file source** so paths that are not prefix “collections” are discovered the same way schema inference already works.
> 
> The poll loop no longer relies only on `object_store.list` on the URL prefix. It now uses **`list_poll_candidates`**: collection URLs still list; non-collection URLs **HEAD** the exact object (so a single file path is ingested once), and **`NotFound` on HEAD falls back to prefix listing** (e.g. `memory:///data` without a trailing slash). Existing watermark, extension, and boundary-path logic is unchanged for objects returned from that stream.
> 
> Adds tests for the HEAD→list fallback and for end-to-end ingest of a single local file path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffe11b94a83e6233ca7d2038c3f030eb78e9acf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->