### PR TITLE
feat: leverage partitions for the file source

### DIFF
--- a/crates/streamling-connectors/src/table_providers/file.rs
+++ b/crates/streamling-connectors/src/table_providers/file.rs
@@ -923,13 +923,24 @@ impl ExecutionPlan for FileSourceExec {
                     // TableSchema (set at construction), so the builder takes just
                     // (object_store_url, file_source) and no longer accepts the
                     // file schema or partition cols directly.
+                    //
+                    // Spread the poll's files over the session's target partitions so
+                    // they are read concurrently, then merge them back into the single
+                    // stream this loop emits from: the watermark, the checkpoint drain,
+                    // and the record limit all assume one emission point.
+                    let file_groups = FileGroup::new(new_files)
+                        .split_files(context.session_config().target_partitions());
                     let config =
                         FileScanConfigBuilder::new(object_store_url.clone(), file_source.clone())
-                            .with_file_group(FileGroup::new(new_files))
+                            .with_file_groups(file_groups)
                             .build();
 
-                    let mut stream =
-                        DataSourceExec::from_data_source(config).execute(0, context.clone())?;
+                    let scan: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(config);
+                    let mut stream = if scan.output_partitioning().partition_count() > 1 {
+                        CoalescePartitionsExec::new(scan).execute(0, context.clone())?
+                    } else {
+                        scan.execute(0, context.clone())?
+                    };
                     while let Some(batch) = stream.next().await {
                         // Drain again before every batch so markers arriving mid-read
                         // ride the next batch (within one batch interval) instead of
@@ -1379,6 +1390,97 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
 
         assert_eq!(rows, 9, "every file group's rows must reach partition 0");
+    }
+
+    /// A poll's files are split across the session's target partitions and read
+    /// concurrently, but the source still emits from one stream: every row must
+    /// arrive exactly once (the watermark's boundary set covers the files sharing
+    /// the poll's newest timestamp), and idle polls must still heartbeat.
+    #[tokio::test]
+    async fn continuous_source_reads_split_file_groups_exactly_once() {
+        use datafusion::arrow::array::Array;
+        use std::time::Duration;
+        use streamling_core::dynamic_table::DynamicTableRegistry;
+        use streamling_state::StateOperatorBackendFactory;
+        use streamling_state::in_memory::InMemoryStateOperatorBackendFactory;
+        use tokio::time::timeout;
+
+        let dir = std::env::temp_dir().join(format!("streamling_split_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // Non-numeric ids keep the inferred column Utf8, so the assertion below can
+        // name the exact rows rather than just count them.
+        for file in ["a", "b", "c"] {
+            std::fs::write(
+                dir.join(format!("{file}.csv")),
+                format!("id,name\n{file}0,alice\n{file}1,bob\n{file}2,carol"),
+            )
+            .unwrap();
+        }
+
+        let session_manager = SessionManager::new(100, 10, DynamicTableRegistry::new()).unwrap();
+        let state_backend = InMemoryStateOperatorBackendFactory::new()
+            .unwrap()
+            .create::<FileWatermark>("split_test");
+
+        let provider = FileSourceTableProvider::try_new(
+            "split_src",
+            &format!("{}/", dir.to_str().unwrap()),
+            FileSourceFormat::Csv,
+            Duration::from_millis(100),
+            &session_manager,
+            state_backend,
+            None,
+            10,
+        )
+        .await
+        .unwrap();
+
+        let plan = provider
+            .scan(&session_manager.session_state(), None, &[], None)
+            .await
+            .unwrap();
+        assert_eq!(
+            plan.output_partitioning().partition_count(),
+            1,
+            "concurrent file groups must still surface as one output partition"
+        );
+
+        let mut stream = plan
+            .execute(0, session_manager.session_context().task_ctx())
+            .unwrap();
+        let mut ids: Vec<String> = Vec::new();
+        let mut empty_batches = 0usize;
+        for _ in 0..8 {
+            let batch = timeout(Duration::from_secs(5), stream.next())
+                .await
+                .expect("stream should yield within timeout")
+                .expect("stream should not end")
+                .unwrap();
+            if batch.num_rows() == 0 {
+                empty_batches += 1;
+                continue;
+            }
+            let column = batch
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            ids.extend((0..column.len()).map(|row| column.value(row).to_string()));
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["a0", "a1", "a2", "b0", "b1", "b2", "c0", "c1", "c2"],
+            "every row from every file group must arrive exactly once"
+        );
+        assert!(
+            empty_batches >= 2,
+            "polls after ingest must emit empty heartbeat batches; got {empty_batches}"
+        );
     }
 
     /// A remote directory URL without a trailing slash is not a collection, so

--- a/crates/streamling-connectors/src/table_providers/file.rs
+++ b/crates/streamling-connectors/src/table_providers/file.rs
@@ -42,12 +42,13 @@ use datafusion::datasource::table_schema::TableSchema;
 use datafusion::datasource::{TableProvider, TableType, ViewTable, provider_as_source};
 use datafusion::error::Result as DataFusionResult;
 use datafusion::execution::TaskContext;
-use datafusion::logical_expr::{Expr, LogicalPlanBuilder, lit};
+use datafusion::logical_expr::{Expr, LogicalPlanBuilder, TableProviderFilterPushDown, lit};
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::stream::RecordBatchReceiverStreamBuilder;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
-    SendableRecordBatchStream,
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, Partitioning,
+    PlanProperties, SendableRecordBatchStream,
+    coalesce_partitions::CoalescePartitionsExec,
     execution_plan::{Boundedness, EmissionType},
     project_schema,
 };
@@ -151,6 +152,46 @@ fn register_object_store_for_url(
     Ok(())
 }
 
+/// Merges the bounded scan's parallel file groups back into a single output
+/// partition, delegating projection/filter/limit pushdown to the inner
+/// [`ListingTable`] so splitting the files costs nothing at plan time.
+#[derive(Debug)]
+struct CoalescedFileScan {
+    inner: Arc<ListingTable>,
+}
+
+#[async_trait]
+impl TableProvider for CoalescedFileScan {
+    fn schema(&self) -> SchemaRef {
+        self.inner.schema()
+    }
+
+    fn table_type(&self) -> TableType {
+        self.inner.table_type()
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        self.inner.supports_filters_pushdown(filters)
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let plan = self.inner.scan(state, projection, filters, limit).await?;
+        if plan.output_partitioning().partition_count() > 1 {
+            return Ok(Arc::new(CoalescePartitionsExec::new(plan)));
+        }
+        Ok(plan)
+    }
+}
+
 /// Builds the runtime provider for a **bounded** `file` source backed by
 /// DataFusion's [`ListingTable`]. The schema is inferred from the files at
 /// startup. Because file reads are append-only, a constant `_gs_op = 'i'` column
@@ -182,8 +223,14 @@ pub async fn build_bounded_file_source_provider(
     let object_store = state.runtime_env().object_store(table_url.object_store())?;
     let partition_cols =
         infer_partition_columns(&table_url, &file_extension, object_store.as_ref()).await;
-    let listing_options =
-        ListingOptions::new(file_format).with_table_partition_cols(partition_cols);
+    // `ListingOptions::new` defaults to one target partition, which reads every
+    // file serially on a single core. Split the files across the session's target
+    // partitions instead; `CoalescedFileScan` merges them back into one output
+    // partition. Set explicitly rather than via `with_session_config_options`,
+    // which would also turn on `collect_stat` (a footer fetch per file at startup).
+    let listing_options = ListingOptions::new(file_format)
+        .with_table_partition_cols(partition_cols)
+        .with_target_partitions(state.config().target_partitions());
     // Partition columns are detected ourselves above (`infer_partition_columns`),
     // not via DataFusion's `infer_partitions_from_path` (which treats every parent
     // directory as a partition level and errors on plain nested subfolders).
@@ -210,9 +257,11 @@ pub async fn build_bounded_file_source_provider(
             return Err(e.into());
         }
     };
-    let listing_table = Arc::new(ListingTable::try_new(config)?);
+    let provider: Arc<dyn TableProvider> = Arc::new(CoalescedFileScan {
+        inner: Arc::new(ListingTable::try_new(config)?),
+    });
 
-    let schema = listing_table.schema();
+    let schema = provider.schema();
 
     // Schema inference over a path that matches no files yields an empty schema
     // and a silent zero-row source; fail fast instead.
@@ -240,7 +289,7 @@ pub async fn build_bounded_file_source_provider(
                 op_field.is_nullable()
             );
         }
-        return Ok(listing_table);
+        return Ok(provider);
     }
 
     // Reference each column by its exact name. `col(name)` would parse the name as a
@@ -252,13 +301,9 @@ pub async fn build_bounded_file_source_provider(
         .map(|f| Expr::Column(Column::new_unqualified(f.name())))
         .collect();
     projection.push(lit(ScalarValue::Utf8(Some(RowKind::Insert.to_str()))).alias(COLUMN_NAME_OP));
-    let plan = LogicalPlanBuilder::scan(
-        reference_name,
-        provider_as_source(listing_table as Arc<dyn TableProvider>),
-        None,
-    )?
-    .project(projection)?
-    .build()?;
+    let plan = LogicalPlanBuilder::scan(reference_name, provider_as_source(provider), None)?
+        .project(projection)?
+        .build()?;
 
     Ok(Arc::new(ViewTable::new(plan, None)))
 }
@@ -1285,6 +1330,55 @@ mod tests {
             empty_batches >= 2,
             "idle polls must emit empty heartbeat batches; got {empty_batches}"
         );
+    }
+
+    /// The bounded source splits its files across the session's target partitions
+    /// but must expose exactly one output partition: `DataSinkExec` reads only
+    /// input partition 0, and streamling's optimizer never inserts a coalesce, so
+    /// a multi-partition source feeding a sink directly would drop rows.
+    #[tokio::test]
+    async fn bounded_source_coalesces_file_groups_into_one_partition() {
+        use streamling_core::dynamic_table::DynamicTableRegistry;
+
+        let dir = std::env::temp_dir().join(format!("streamling_bounded_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        for file in 0..3 {
+            std::fs::write(
+                dir.join(format!("{file}.csv")),
+                format!("id,name\n{file}0,alice\n{file}1,bob\n{file}2,carol"),
+            )
+            .unwrap();
+        }
+
+        let session_manager = SessionManager::new(100, 10, DynamicTableRegistry::new()).unwrap();
+        let provider = build_bounded_file_source_provider(
+            "bounded_src",
+            &format!("{}/", dir.to_str().unwrap()),
+            FileSourceFormat::Csv,
+            &session_manager,
+        )
+        .await
+        .unwrap();
+
+        let state = session_manager.session_state();
+        let plan = provider.scan(&state, None, &[], None).await.unwrap();
+        assert_eq!(
+            plan.output_partitioning().partition_count(),
+            1,
+            "the bounded source must expose a single output partition"
+        );
+
+        let mut stream = plan
+            .execute(0, session_manager.session_context().task_ctx())
+            .unwrap();
+        let mut rows = 0usize;
+        while let Some(batch) = stream.next().await {
+            rows += batch.unwrap().num_rows();
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(rows, 9, "every file group's rows must reach partition 0");
     }
 
     /// A remote directory URL without a trailing slash is not a collection, so


### PR DESCRIPTION
Properly leverage DataFusion partitions for the bounded and unbounded file source. The bounded source uses `with_target_partitions` on the ListingTable, the unbounded source creates file groups using `FileGroup::new(new_files).split_files`. Both then use the coalesce operator to combine multiple input partitions into one output partition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core file-source physical plans and row delivery assumptions; incorrect coalescing could drop or duplicate rows, though new tests cover partition count and exactly-once reads.
> 
> **Overview**
> **Parallelizes file reads** for bounded and continuous file sources by spreading work across the session’s `target_partitions`, while **keeping a single output partition** so sinks that only consume partition 0 do not drop rows.
> 
> For **bounded** sources, `ListingOptions` now sets `with_target_partitions` explicitly (avoiding `with_session_config_options`, which would enable per-file stat collection). A new **`CoalescedFileScan`** `TableProvider` wraps `ListingTable` and inserts **`CoalescePartitionsExec`** when the inner scan has more than one partition, forwarding filter/projection/limit pushdown to the inner table.
> 
> For **continuous** polling, each poll’s `new_files` are split via **`FileGroup::split_files`**, the scan runs concurrently, then **`CoalescePartitionsExec`** merges partitions before the existing single-stream emission loop (watermarks, checkpoints, record limits).
> 
> Adds integration tests asserting **one output partition** and **exactly-once row delivery** across multiple CSV files for both modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29f643279d555e32507bee9ca0f96b54fec11741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->