### PR TITLE
fix: return validation error instead of panicking on unknown plugin

### DIFF
--- a/crates/streamling-core/src/plugin.rs
+++ b/crates/streamling-core/src/plugin.rs
@@ -410,27 +410,31 @@ pub fn create_source_plugin(
     let result = create_result
         .into_rust()
         .map_err(|e| streamling_err!("Plugin creation failed: {:?}", e))?;
-    start_shutdown_watcher_once();
-    register_plugin_instance(reference_name.as_str(), plugin_channels.clone());
-    merge_metadata_tags(
-        &metric_key(&app_config.application_id, &reference_name),
-        collect_labels(result.labels),
-    );
-    let mapped_future = result
-        .execution_future
-        .map(|r| r.into_rust().map_err(|msg| msg.into_string()));
+    // Validate schema before registering so a missing/invalid output schema does
+    // not leave a half-initialized entry in the plugin instance registry.
     let output_schema = result.output_schema.into_option().ok_or_else(|| {
         streamling_user_err!(
             "source plugin '{}' did not provide an output schema",
             plugin_type
         )
     })?;
-    InitializedPlugin::new(
+    let labels = collect_labels(result.labels);
+    let mapped_future = result
+        .execution_future
+        .map(|r| r.into_rust().map_err(|msg| msg.into_string()));
+    let initialized = InitializedPlugin::new(
         plugin_type.to_string(),
         Box::pin(mapped_future),
-        plugin_channels,
+        plugin_channels.clone(),
         Some(output_schema.into()),
-    )
+    )?;
+    start_shutdown_watcher_once();
+    register_plugin_instance(reference_name.as_str(), plugin_channels);
+    merge_metadata_tags(
+        &metric_key(&app_config.application_id, &reference_name),
+        labels,
+    );
+    Ok(initialized)
 }
 
 pub fn create_transform_plugin(
@@ -465,27 +469,31 @@ pub fn create_transform_plugin(
     let result = create_result
         .into_rust()
         .map_err(|e| streamling_err!("Plugin creation failed: {:?}", e))?;
-    start_shutdown_watcher_once();
-    register_plugin_instance(reference_name.as_str(), plugin_channels.clone());
-    merge_metadata_tags(
-        &metric_key(&app_config.application_id, &reference_name),
-        collect_labels(result.labels),
-    );
-    let mapped_future = result
-        .execution_future
-        .map(|r| r.into_rust().map_err(|msg| msg.into_string()));
+    // Validate schema before registering so a missing/invalid output schema does
+    // not leave a half-initialized entry in the plugin instance registry.
     let output_schema = result.output_schema.into_option().ok_or_else(|| {
         streamling_user_err!(
             "transform plugin '{}' did not provide an output schema",
             plugin_type
         )
     })?;
-    InitializedPlugin::new(
+    let labels = collect_labels(result.labels);
+    let mapped_future = result
+        .execution_future
+        .map(|r| r.into_rust().map_err(|msg| msg.into_string()));
+    let initialized = InitializedPlugin::new(
         plugin_type.to_string(),
         Box::pin(mapped_future),
-        plugin_channels,
+        plugin_channels.clone(),
         Some(output_schema.into()),
-    )
+    )?;
+    start_shutdown_watcher_once();
+    register_plugin_instance(reference_name.as_str(), plugin_channels);
+    merge_metadata_tags(
+        &metric_key(&app_config.application_id, &reference_name),
+        labels,
+    );
+    Ok(initialized)
 }
 
 pub fn create_sink_plugin(

--- a/crates/streamling-core/src/plugin.rs
+++ b/crates/streamling-core/src/plugin.rs
@@ -413,8 +413,8 @@ pub fn create_source_plugin(
     // Validate schema before registering so a missing/invalid output schema does
     // not leave a half-initialized entry in the plugin instance registry.
     let output_schema = result.output_schema.into_option().ok_or_else(|| {
-        streamling_user_err!(
-            "source plugin '{}' did not provide an output schema",
+        streamling_err!(
+            "source plugin '{}' must provide an output schema (plugin invariant)",
             plugin_type
         )
     })?;
@@ -472,8 +472,8 @@ pub fn create_transform_plugin(
     // Validate schema before registering so a missing/invalid output schema does
     // not leave a half-initialized entry in the plugin instance registry.
     let output_schema = result.output_schema.into_option().ok_or_else(|| {
-        streamling_user_err!(
-            "transform plugin '{}' did not provide an output schema",
+        streamling_err!(
+            "transform plugin '{}' must provide an output schema (plugin invariant)",
             plugin_type
         )
     })?;

--- a/crates/streamling-core/src/plugin.rs
+++ b/crates/streamling-core/src/plugin.rs
@@ -608,8 +608,8 @@ pub fn terminate_plugins(plugins: Vec<(String, PluginChannels)>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_schema::Schema;
     use crate::error::StreamlingError;
+    use arrow_schema::Schema;
 
     /// Unused name that will not be present in the empty default plugin registry.
     const UNKNOWN_PLUGIN: &str = "definitely_not_a_real_plugin";

--- a/crates/streamling-core/src/plugin.rs
+++ b/crates/streamling-core/src/plugin.rs
@@ -604,3 +604,91 @@ pub fn terminate_plugins(plugins: Vec<(String, PluginChannels)>) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_schema::Schema;
+    use crate::error::StreamlingError;
+
+    /// Unused name that will not be present in the empty default plugin registry.
+    const UNKNOWN_PLUGIN: &str = "definitely_not_a_real_plugin";
+
+    fn assert_unknown_plugin_user_error(err: StreamlingError) {
+        assert!(
+            !err.is_internal(),
+            "missing plugin must be a user-facing error"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains(UNKNOWN_PLUGIN),
+            "error should name the plugin: {msg}"
+        );
+        assert!(
+            msg.contains("is not available"),
+            "error should say plugin is not available: {msg}"
+        );
+    }
+
+    /// Regression: unknown plugins used to `panic!("Plugin {} not found!")`.
+    /// They must now return a structured user error (never a panic).
+    #[test]
+    fn create_source_plugin_unknown_is_user_error_not_panic() {
+        let app_config = AppConfig::load().expect("embedded config must load");
+        match create_source_plugin(
+            &app_config,
+            "ref".to_string(),
+            UNKNOWN_PLUGIN.to_string(),
+            HashMap::new(),
+        ) {
+            Ok(_) => panic!("expected Err for unknown plugin"),
+            Err(err) => assert_unknown_plugin_user_error(err),
+        }
+    }
+
+    #[test]
+    fn create_transform_plugin_unknown_is_user_error_not_panic() {
+        let app_config = AppConfig::load().expect("embedded config must load");
+        let empty_schema = Arc::new(Schema::empty());
+        match create_transform_plugin(
+            &app_config,
+            "ref".to_string(),
+            UNKNOWN_PLUGIN.to_string(),
+            HashMap::new(),
+            empty_schema,
+        ) {
+            Ok(_) => panic!("expected Err for unknown plugin"),
+            Err(err) => assert_unknown_plugin_user_error(err),
+        }
+    }
+
+    #[test]
+    fn create_sink_plugin_unknown_is_user_error_not_panic() {
+        let app_config = AppConfig::load().expect("embedded config must load");
+        let empty_schema = Arc::new(Schema::empty());
+        match create_sink_plugin(
+            &app_config,
+            "ref".to_string(),
+            UNKNOWN_PLUGIN.to_string(),
+            HashMap::new(),
+            empty_schema,
+        ) {
+            Ok(_) => panic!("expected Err for unknown plugin"),
+            Err(err) => assert_unknown_plugin_user_error(err),
+        }
+    }
+
+    #[test]
+    fn create_preprocessor_plugin_unknown_is_user_error_not_panic() {
+        let app_config = AppConfig::load().expect("embedded config must load");
+        match create_preprocessor_plugin(
+            &app_config,
+            "ref".to_string(),
+            UNKNOWN_PLUGIN.to_string(),
+            HashMap::new(),
+        ) {
+            Ok(_) => panic!("expected Err for unknown plugin"),
+            Err(err) => assert_unknown_plugin_user_error(err),
+        }
+    }
+}

--- a/crates/streamling-core/src/plugin.rs
+++ b/crates/streamling-core/src/plugin.rs
@@ -580,18 +580,21 @@ pub fn create_preprocessor_plugin(
     // Preprocessors are short-lived helpers: they are not registered in
     // PLUGIN_INSTANCE_REGISTRY and do not start the process-wide shutdown watcher
     // (unlike source/transform/sink). FFI create failures are internal/platform.
+    // Construct the struct directly (no InitializedPlugin::new): preprocessors have
+    // no output schema, so the op-column check in `new` does not apply and init
+    // remains infallible after a successful FFI create.
     let result = create_result
         .into_rust()
         .map_err(|e| streamling_err!("Plugin creation failed: {:?}", e))?;
     let mapped_future = result
         .execution_future
         .map(|r| r.into_rust().map_err(|msg| msg.into_string()));
-    InitializedPlugin::new(
-        plugin_type.to_string(),
-        Box::pin(mapped_future),
-        plugin_channels,
-        None,
-    )
+    Ok(InitializedPlugin {
+        plugin_id: plugin_type.to_string(),
+        execution_future: Box::pin(mapped_future),
+        channels: plugin_channels,
+        output_schema: None,
+    })
 }
 
 pub fn terminate_plugins(plugins: Vec<(String, PluginChannels)>) -> Result<()> {

--- a/crates/streamling-core/src/plugin.rs
+++ b/crates/streamling-core/src/plugin.rs
@@ -12,7 +12,7 @@ use crate::data::COLUMN_NAME_OP;
 use crate::error::Result;
 use crate::telemetry::provider::metric_key;
 use crate::telemetry::recorder::merge_metadata_tags;
-use crate::{streamling_bail, streamling_err, streamling_user_bail};
+use crate::{streamling_bail, streamling_err, streamling_user_bail, streamling_user_err};
 use abi_stable::StableAbi;
 use abi_stable::derive_macro_reexports::{NonExhaustive, TD_Opaque};
 use abi_stable::external_types::crossbeam_channel;
@@ -386,8 +386,12 @@ pub fn create_source_plugin(
     options: HashMap<String, String>,
 ) -> Result<InitializedPlugin> {
     let plugin_type: PluginId = plugin_type.into();
-    let plugin_module =
-        find_plugin(&plugin_type).unwrap_or_else(|| panic!("Plugin {} not found!", &plugin_type));
+    let plugin_module = find_plugin(&plugin_type).ok_or_else(|| {
+        streamling_user_err!(
+            "plugin '{}' is not available; check that the plugin type is correct and that the plugin bundle is installed",
+            plugin_type
+        )
+    })?;
     let plugin_async_runtime = create_plugin_async_runtime(Handle::current());
     let plugin_state_backend_config =
         create_plugin_state_backend_config(app_config, &reference_name);
@@ -403,32 +407,30 @@ pub fn create_source_plugin(
         plugin_channels.clone(),
     );
 
-    create_result
+    let result = create_result
         .into_rust()
-        .map(|result| {
-            start_shutdown_watcher_once();
-            register_plugin_instance(reference_name.as_str(), plugin_channels.clone());
-            merge_metadata_tags(
-                &metric_key(&app_config.application_id, &reference_name),
-                collect_labels(result.labels),
-            );
-            let mapped_future = result
-                .execution_future
-                .map(|r| r.into_rust().map_err(|msg| msg.into_string()));
-            InitializedPlugin::new(
-                plugin_type.to_string(),
-                Box::pin(mapped_future),
-                plugin_channels,
-                Some(
-                    result
-                        .output_schema
-                        .expect("Source plugin must provide an output schema")
-                        .into(),
-                ),
-            )
-            .unwrap()
-        })
-        .map_err(|e| streamling_err!("Plugin creation failed: {:?}", e))
+        .map_err(|e| streamling_err!("Plugin creation failed: {:?}", e))?;
+    start_shutdown_watcher_once();
+    register_plugin_instance(reference_name.as_str(), plugin_channels.clone());
+    merge_metadata_tags(
+        &metric_key(&app_config.application_id, &reference_name),
+        collect_labels(result.labels),
+    );
+    let mapped_future = result
+        .execution_future
+        .map(|r| r.into_rust().map_err(|msg| msg.into_string()));
+    let output_schema = result.output_schema.into_option().ok_or_else(|| {
+        streamling_user_err!(
+            "source plugin '{}' did not provide an output schema",
+            plugin_type
+        )
+    })?;
+    InitializedPlugin::new(
+        plugin_type.to_string(),
+        Box::pin(mapped_future),
+        plugin_channels,
+        Some(output_schema.into()),
+    )
 }
 
 pub fn create_transform_plugin(
@@ -439,8 +441,12 @@ pub fn create_transform_plugin(
     input_schema: SchemaRef,
 ) -> Result<InitializedPlugin> {
     let plugin_type: PluginId = plugin_type.into();
-    let plugin_module =
-        find_plugin(&plugin_type).unwrap_or_else(|| panic!("Plugin {} not found!", &plugin_type));
+    let plugin_module = find_plugin(&plugin_type).ok_or_else(|| {
+        streamling_user_err!(
+            "plugin '{}' is not available; check that the plugin type is correct and that the plugin bundle is installed",
+            plugin_type
+        )
+    })?;
     let plugin_async_runtime = create_plugin_async_runtime(Handle::current());
     let plugin_state_backend_config =
         create_plugin_state_backend_config(app_config, &reference_name);
@@ -456,32 +462,30 @@ pub fn create_transform_plugin(
         plugin_channels.clone(),
     );
 
-    create_result
+    let result = create_result
         .into_rust()
-        .map(|result| {
-            start_shutdown_watcher_once();
-            register_plugin_instance(reference_name.as_str(), plugin_channels.clone());
-            merge_metadata_tags(
-                &metric_key(&app_config.application_id, &reference_name),
-                collect_labels(result.labels),
-            );
-            let mapped_future = result
-                .execution_future
-                .map(|r| r.into_rust().map_err(|msg| msg.into_string()));
-            InitializedPlugin::new(
-                plugin_type.to_string(),
-                Box::pin(mapped_future),
-                plugin_channels,
-                Some(
-                    result
-                        .output_schema
-                        .expect("Transform plugin must provide an output schema")
-                        .into(),
-                ),
-            )
-            .unwrap()
-        })
-        .map_err(|e| streamling_err!("Plugin creation failed: {:?}", e))
+        .map_err(|e| streamling_err!("Plugin creation failed: {:?}", e))?;
+    start_shutdown_watcher_once();
+    register_plugin_instance(reference_name.as_str(), plugin_channels.clone());
+    merge_metadata_tags(
+        &metric_key(&app_config.application_id, &reference_name),
+        collect_labels(result.labels),
+    );
+    let mapped_future = result
+        .execution_future
+        .map(|r| r.into_rust().map_err(|msg| msg.into_string()));
+    let output_schema = result.output_schema.into_option().ok_or_else(|| {
+        streamling_user_err!(
+            "transform plugin '{}' did not provide an output schema",
+            plugin_type
+        )
+    })?;
+    InitializedPlugin::new(
+        plugin_type.to_string(),
+        Box::pin(mapped_future),
+        plugin_channels,
+        Some(output_schema.into()),
+    )
 }
 
 pub fn create_sink_plugin(
@@ -492,8 +496,12 @@ pub fn create_sink_plugin(
     input_schema: SchemaRef,
 ) -> Result<InitializedPlugin> {
     let plugin_type: PluginId = plugin_type.into();
-    let plugin_module =
-        find_plugin(&plugin_type).unwrap_or_else(|| panic!("Plugin {} not found!", &plugin_type));
+    let plugin_module = find_plugin(&plugin_type).ok_or_else(|| {
+        streamling_user_err!(
+            "plugin '{}' is not available; check that the plugin type is correct and that the plugin bundle is installed",
+            plugin_type
+        )
+    })?;
     let plugin_async_runtime = create_plugin_async_runtime(Handle::current());
     let plugin_state_backend_config =
         create_plugin_state_backend_config(app_config, &reference_name);
@@ -509,27 +517,24 @@ pub fn create_sink_plugin(
         plugin_channels.clone(),
     );
 
-    create_result
+    let result = create_result
         .into_rust()
-        .map(|result| {
-            start_shutdown_watcher_once();
-            register_plugin_instance(reference_name.as_str(), plugin_channels.clone());
-            merge_metadata_tags(
-                &metric_key(&app_config.application_id, &reference_name),
-                collect_labels(result.labels),
-            );
-            let mapped_future = result
-                .execution_future
-                .map(|r| r.into_rust().map_err(|msg| msg.into_string()));
-            InitializedPlugin::new(
-                plugin_type.to_string(),
-                Box::pin(mapped_future),
-                plugin_channels,
-                None,
-            )
-            .unwrap()
-        })
-        .map_err(|e| streamling_err!("Plugin creation failed: {:?}", e))
+        .map_err(|e| streamling_err!("Plugin creation failed: {:?}", e))?;
+    start_shutdown_watcher_once();
+    register_plugin_instance(reference_name.as_str(), plugin_channels.clone());
+    merge_metadata_tags(
+        &metric_key(&app_config.application_id, &reference_name),
+        collect_labels(result.labels),
+    );
+    let mapped_future = result
+        .execution_future
+        .map(|r| r.into_rust().map_err(|msg| msg.into_string()));
+    InitializedPlugin::new(
+        plugin_type.to_string(),
+        Box::pin(mapped_future),
+        plugin_channels,
+        None,
+    )
 }
 
 pub fn create_preprocessor_plugin(
@@ -539,8 +544,12 @@ pub fn create_preprocessor_plugin(
     options: HashMap<String, String>,
 ) -> Result<InitializedPlugin> {
     let plugin_type: PluginId = plugin_type.into();
-    let plugin_module =
-        find_plugin(&plugin_type).unwrap_or_else(|| panic!("Plugin {} not found!", &plugin_type));
+    let plugin_module = find_plugin(&plugin_type).ok_or_else(|| {
+        streamling_user_err!(
+            "plugin '{}' is not available; check that the plugin type is correct and that the plugin bundle is installed",
+            plugin_type
+        )
+    })?;
     let plugin_async_runtime = create_plugin_async_runtime(Handle::current());
     let plugin_state_backend_config =
         create_plugin_state_backend_config(app_config, &reference_name);

--- a/crates/streamling-core/src/plugin.rs
+++ b/crates/streamling-core/src/plugin.rs
@@ -528,21 +528,25 @@ pub fn create_sink_plugin(
     let result = create_result
         .into_rust()
         .map_err(|e| streamling_err!("Plugin creation failed: {:?}", e))?;
-    start_shutdown_watcher_once();
-    register_plugin_instance(reference_name.as_str(), plugin_channels.clone());
-    merge_metadata_tags(
-        &metric_key(&app_config.application_id, &reference_name),
-        collect_labels(result.labels),
-    );
+    // Match source/transform: only register after InitializedPlugin::new succeeds
+    // so a future sink-schema invariant cannot leave a half-initialized registry entry.
+    let labels = collect_labels(result.labels);
     let mapped_future = result
         .execution_future
         .map(|r| r.into_rust().map_err(|msg| msg.into_string()));
-    InitializedPlugin::new(
+    let initialized = InitializedPlugin::new(
         plugin_type.to_string(),
         Box::pin(mapped_future),
-        plugin_channels,
+        plugin_channels.clone(),
         None,
-    )
+    )?;
+    start_shutdown_watcher_once();
+    register_plugin_instance(reference_name.as_str(), plugin_channels);
+    merge_metadata_tags(
+        &metric_key(&app_config.application_id, &reference_name),
+        labels,
+    );
+    Ok(initialized)
 }
 
 pub fn create_preprocessor_plugin(

--- a/crates/streamling-core/src/plugin.rs
+++ b/crates/streamling-core/src/plugin.rs
@@ -577,20 +577,21 @@ pub fn create_preprocessor_plugin(
         plugin_channels.clone(),
     );
 
-    create_result
+    // Preprocessors are short-lived helpers: they are not registered in
+    // PLUGIN_INSTANCE_REGISTRY and do not start the process-wide shutdown watcher
+    // (unlike source/transform/sink). FFI create failures are internal/platform.
+    let result = create_result
         .into_rust()
-        .map(|result| {
-            let mapped_future = result
-                .execution_future
-                .map(|r| r.into_rust().map_err(|msg| msg.into_string()));
-            InitializedPlugin {
-                plugin_id: plugin_type.to_string(),
-                execution_future: Box::pin(mapped_future),
-                channels: plugin_channels,
-                output_schema: None,
-            }
-        })
-        .map_err(|e| streamling_err!("Plugin creation failed: {:?}", e))
+        .map_err(|e| streamling_err!("Plugin creation failed: {:?}", e))?;
+    let mapped_future = result
+        .execution_future
+        .map(|r| r.into_rust().map_err(|msg| msg.into_string()));
+    InitializedPlugin::new(
+        plugin_type.to_string(),
+        Box::pin(mapped_future),
+        plugin_channels,
+        None,
+    )
 }
 
 pub fn terminate_plugins(plugins: Vec<(String, PluginChannels)>) -> Result<()> {

--- a/crates/streamling-e2e/tests/validation.rs
+++ b/crates/streamling-e2e/tests/validation.rs
@@ -616,23 +616,13 @@ async fn test_validate_unknown_plugin_is_error_not_panic() {
         .await
         .expect("Failed to create test context");
 
+    // Schema registration is still needed so the Kafka source can resolve its
+    // Avro schema during topology build; no records are produced because
+    // `--validate` does not consume data.
     ctx.kafka
         .register_schema(TEST_SCHEMA)
         .await
         .expect("Failed to register schema");
-
-    let records: Vec<TestRecord> = (0..3)
-        .map(|i| TestRecord {
-            block: i,
-            id: format!("id_{}", i),
-            data: format!("data{}", i),
-        })
-        .collect();
-
-    ctx.kafka
-        .produce_avro_records(&records)
-        .await
-        .expect("Failed to produce records");
 
     // `definitely_not_a_real_plugin` is not a built-in sink type, so it binds to the
     // plugin sink variant and is resolved against the (empty) plugin registry.
@@ -657,10 +647,7 @@ sinks:
     );
 
     let output = ctx
-        .run_pipeline_raw(
-            &pipeline,
-            PipelineOpts::new().record_limit(3).arg("--validate"),
-        )
+        .run_pipeline_raw(&pipeline, PipelineOpts::new().arg("--validate"))
         .await
         .expect("Failed to run pipeline");
 

--- a/crates/streamling-e2e/tests/validation.rs
+++ b/crates/streamling-e2e/tests/validation.rs
@@ -601,6 +601,98 @@ sinks:
 }
 
 // ============================================================================
+// Unknown plugin reference must be a validation error, not a panic
+// ============================================================================
+
+/// A sink referencing a plugin type that is not present in the plugin bundle
+/// used to make the validator `panic!("Plugin <name> not found!")` — exiting 101
+/// with empty stdout, which the control plane then misreported. `--validate` must
+/// instead emit structured JSON reporting the pipeline as invalid.
+#[tokio::test]
+async fn test_validate_unknown_plugin_is_error_not_panic() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("Failed to create test context");
+
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+
+    let records: Vec<TestRecord> = (0..3)
+        .map(|i| TestRecord {
+            block: i,
+            id: format!("id_{}", i),
+            data: format!("data{}", i),
+        })
+        .collect();
+
+    ctx.kafka
+        .produce_avro_records(&records)
+        .await
+        .expect("Failed to produce records");
+
+    // `definitely_not_a_real_plugin` is not a built-in sink type, so it binds to the
+    // plugin sink variant and is resolved against the (empty) plugin registry.
+    let pipeline = format!(
+        r#"
+sources:
+  test_kafka_source:
+    type: kafka
+    topic: {topic}
+    starting_offsets: earliest
+    primary_key: id
+
+transforms: {{}}
+
+sinks:
+  missing_plugin_sink:
+    type: definitely_not_a_real_plugin
+    from: test_kafka_source
+    primary_key: id
+"#,
+        topic = ctx.kafka_topic
+    );
+
+    let output = ctx
+        .run_pipeline_raw(
+            &pipeline,
+            PipelineOpts::new().record_limit(3).arg("--validate"),
+        )
+        .await
+        .expect("Failed to run pipeline");
+
+    // The key regression: stdout must be parseable JSON (the validator did not panic).
+    let validation: ValidationOutput = serde_json::from_str(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "Failed to parse validation JSON from stdout (validator likely panicked): {}\nstdout was:\n{}\nstderr was:\n{}",
+            e, output.stdout, output.stderr
+        )
+    });
+
+    assert!(
+        !validation.is_valid,
+        "Pipeline referencing an unknown plugin must be invalid, got: {:?}",
+        validation
+    );
+    assert!(
+        !validation.errors.is_empty(),
+        "Expected at least one error entry, got: {:?}",
+        validation
+    );
+
+    let all_errors = validation.errors.join("\n");
+    assert!(
+        all_errors.contains("definitely_not_a_real_plugin")
+            && all_errors.contains("is not available"),
+        "Error should name the missing plugin, got: {:?}",
+        validation.errors
+    );
+}
+
+// ============================================================================
 // STRM-5695: u256 comparison combined with boolean predicate via AND/OR
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- `--validate` fully builds the topology, so a pipeline referencing a plugin type not present in the registry hit `find_plugin(...).unwrap_or_else(|| panic!("Plugin ... not found!"))` in all four `create_*_plugin` functions.
- The panic aborted before structured validation JSON was emitted (exit 101, empty stdout), which the control plane misreported as an unparseable-output error.
- Unknown/unresolvable plugins now resolve to a user-facing validation error; nearby output-schema `.expect`/`.unwrap` are propagated as errors.

## Test plan
- [ ] `just fix && just lint`
- [ ] Unit tests for unknown-plugin Err on all four `create_*_plugin` paths
- [ ] New e2e `test_validate_unknown_plugin_is_error_not_panic` (needs `just env-setup`) asserts structured `is_valid: false` JSON instead of a crash.

One of three PRs splitting the validator panic-free work (plugin resolution / Arrow schema / telemetry recorder).

Made with [Cursor](https://cursor.com)
