### PR TITLE
fix: make script-transform schema validation panic-free and accept uint/bytes aliases

### DIFF
--- a/crates/streamling-core/src/operators/wasm_runner.rs
+++ b/crates/streamling-core/src/operators/wasm_runner.rs
@@ -98,6 +98,7 @@ impl WasmRunnerNode {
             DEFAULT_POOL_SIZE,
             DEFAULT_BATCH_SIZE,
         )
+        .expect("WasmRunnerNode::new called with an invalid schema map")
     }
 
     /// Create a new WasmRunnerNode with configurable pool size.
@@ -130,6 +131,7 @@ impl WasmRunnerNode {
             parallelism,
             DEFAULT_BATCH_SIZE,
         )
+        .expect("WasmRunnerNode::with_parallelism called with an invalid schema map")
     }
 
     /// Create a new WasmRunnerNode with full configuration options.
@@ -153,12 +155,17 @@ impl WasmRunnerNode {
         schema_map: Option<BTreeMap<String, String>>,
         parallelism: usize,
         batch_size: usize,
-    ) -> Self {
+    ) -> Result<Self> {
         // Build DF schema directly here. If a target schema is provided, use it;
         // otherwise default to the input plan's schema.
         let schema = if let Some(ref schema_map) = schema_map {
-            let arrow_schema = Self::create_arrow_schema_from_map(schema_map).unwrap();
-            let df_schema = DFSchema::try_from(arrow_schema.as_ref().clone()).unwrap();
+            let arrow_schema = Self::create_arrow_schema_from_map(schema_map)?;
+            let df_schema = DFSchema::try_from(arrow_schema.as_ref().clone()).map_err(|e| {
+                DataFusionError::from(crate::streamling_user_err!(
+                    "invalid script transform schema: {}",
+                    e
+                ))
+            })?;
             Some(Arc::new(df_schema))
         } else {
             Some(Arc::new(input.schema().as_ref().clone()))
@@ -167,7 +174,7 @@ impl WasmRunnerNode {
         // Ensure parallelism is at least 1
         let parallelism = parallelism.max(1);
 
-        Self {
+        Ok(Self {
             input,
             language,
             script,
@@ -177,7 +184,7 @@ impl WasmRunnerNode {
             schema,
             parallelism,
             batch_size,
-        }
+        })
     }
 
     pub fn get_output_schema(&self) -> Result<SchemaRef> {

--- a/crates/streamling-core/src/schema.rs
+++ b/crates/streamling-core/src/schema.rs
@@ -35,10 +35,17 @@ fn parse_data_type(type_str: &str) -> Result<DataType> {
         return Ok(decimal);
     }
 
-    let normalized = if type_str.eq_ignore_ascii_case("string") {
-        "Utf8".to_string()
-    } else {
-        type_str.to_upper_camel_case()
+    // `DataType::from_str` expects Arrow's exact spelling (e.g. `UInt64`, `Binary`),
+    // but `to_upper_camel_case` produces `Uint64`/`Bytes`, so common aliases that are
+    // advertised as supported would otherwise fail. Map those aliases explicitly first.
+    let normalized = match type_str.trim().to_ascii_lowercase().as_str() {
+        "string" | "utf8" => "Utf8".to_string(),
+        "bytes" | "binary" => "Binary".to_string(),
+        "uint8" => "UInt8".to_string(),
+        "uint16" => "UInt16".to_string(),
+        "uint32" => "UInt32".to_string(),
+        "uint64" => "UInt64".to_string(),
+        _ => type_str.to_upper_camel_case(),
     };
     DataType::from_str(&normalized).map_err(|_| {
         streamling_user_err!(
@@ -168,6 +175,50 @@ mod tests {
         assert_eq!(schema.field(1).data_type(), &DataType::Decimal256(50, 8));
         // A precision without a scale defaults the scale to 0.
         assert_eq!(schema.field(2).data_type(), &DataType::Decimal128(10, 0));
+    }
+
+    /// Regression: `uint*` and `bytes` are advertised as supported types, but
+    /// `to_upper_camel_case` produced `Uint64`/`Bytes` which Arrow's
+    /// `DataType::from_str` rejects, so the validator used to `.unwrap()`-panic on
+    /// them. They must now resolve to the correct Arrow types.
+    #[test]
+    fn parses_unsigned_and_bytes_aliases() {
+        let mut schema_map = BTreeMap::new();
+        schema_map.insert("a".to_string(), "uint8".to_string());
+        schema_map.insert("b".to_string(), "uint16".to_string());
+        schema_map.insert("c".to_string(), "uint32".to_string());
+        schema_map.insert("d".to_string(), "uint64".to_string());
+        schema_map.insert("e".to_string(), "bytes".to_string());
+        schema_map.insert("f".to_string(), "binary".to_string());
+        schema_map.insert("g".to_string(), "UInt64".to_string());
+
+        let schema = arrow_schema_from_type_map(&schema_map).expect("aliases must be supported");
+
+        assert_eq!(schema.field(0).data_type(), &DataType::UInt8);
+        assert_eq!(schema.field(1).data_type(), &DataType::UInt16);
+        assert_eq!(schema.field(2).data_type(), &DataType::UInt32);
+        assert_eq!(schema.field(3).data_type(), &DataType::UInt64);
+        assert_eq!(schema.field(4).data_type(), &DataType::Binary);
+        assert_eq!(schema.field(5).data_type(), &DataType::Binary);
+        // Arrow's own spelling still works.
+        assert_eq!(schema.field(6).data_type(), &DataType::UInt64);
+    }
+
+    /// A genuinely unknown type still yields a structured user error (never a panic).
+    #[test]
+    fn unknown_type_is_user_error_not_panic() {
+        let mut schema_map = BTreeMap::new();
+        schema_map.insert("x".to_string(), "not_a_type".to_string());
+
+        let err = arrow_schema_from_type_map(&schema_map).unwrap_err();
+        assert!(
+            !err.is_internal(),
+            "unsupported type must be a user-facing error"
+        );
+        assert!(
+            err.to_string()
+                .contains("unsupported data type 'not_a_type'")
+        );
     }
 
     /// Confirms a decimal declared in the schema actually decodes from a JSON payload.

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -1301,7 +1301,15 @@ impl Streamling {
                         schema.clone(),
                         parallelism,
                         batch_size,
-                    );
+                    )
+                    // Convert via `StreamlingError::from` (not `streamling_with_context`)
+                    // so a user-facing schema error (e.g. unsupported dtype) is recovered
+                    // from the `DataFusionError::External` wrapper and stays user-facing.
+                    // Otherwise `--validate` would misreport it as an internal failure.
+                    .map_err(|e| {
+                        streamling_core::error::StreamlingError::from(e)
+                            .context(format!("{}: failed to build script transform", ctx.format()))
+                    })?;
 
                     let logical_plan = LogicalPlan::Extension(Extension {
                         node: Arc::new(wasm_node),
@@ -2029,67 +2037,69 @@ impl Streamling {
 
         let mut dry_run_plans: Vec<(String, LogicalPlan)> = Vec::new();
 
-        sources_to_sinks
-            .into_iter()
-            .for_each(|(_, (source_plan, mut sinks))| {
-                let future_name = sinks
-                    .iter()
-                    .map(|e| e.name.as_str())
-                    .collect::<Vec<&str>>()
-                    .join(", ");
-                let sink_plan = if sinks.len() > 1 {
-                    // Fan-out: each sink gets its own RebatchExec injected by
-                    // the MultiSinkExtensionPlanner, so the raw source_plan
-                    // flows into MultiSinkLogicalNode without any upstream
-                    // wrapping. Per-sink configs live on MultiSinkEntry.
-                    let entries: Vec<MultiSinkEntry> = sinks
-                        .into_iter()
-                        .map(|e| MultiSinkEntry {
-                            name: e.name,
-                            rebatch_config: e.rebatch_config,
-                        })
-                        .collect();
-                    LogicalPlan::Extension(Extension {
-                        node: Arc::new(MultiSinkLogicalNode::new(source_plan, entries)),
+        for (_, (source_plan, mut sinks)) in sources_to_sinks.into_iter() {
+            let future_name = sinks
+                .iter()
+                .map(|e| e.name.as_str())
+                .collect::<Vec<&str>>()
+                .join(", ");
+            let sink_plan = if sinks.len() > 1 {
+                // Fan-out: each sink gets its own RebatchExec injected by
+                // the MultiSinkExtensionPlanner, so the raw source_plan
+                // flows into MultiSinkLogicalNode without any upstream
+                // wrapping. Per-sink configs live on MultiSinkEntry.
+                let entries: Vec<MultiSinkEntry> = sinks
+                    .into_iter()
+                    .map(|e| MultiSinkEntry {
+                        name: e.name,
+                        rebatch_config: e.rebatch_config,
                     })
-                } else {
-                    // Single sink: wrap once at the logical level with this
-                    // sink's config, then insert_into.
-                    let entry = sinks.remove(0);
-                    let rebatched_plan = wrap_with_rebatch(
-                        source_plan,
-                        entry.rebatch_config.batch_size.map(|s| s as usize),
-                        entry.rebatch_config.batch_flush_interval,
-                        entry.name.clone(),
-                    );
-                    LogicalPlanBuilder::insert_into(
-                        rebatched_plan,
-                        entry.name.as_str(),
-                        provider_as_source(entry.provider.clone()),
-                        InsertOp::Append,
-                    )
-                    .unwrap()
-                    .build()
-                    .unwrap()
-                };
+                    .collect();
+                LogicalPlan::Extension(Extension {
+                    node: Arc::new(MultiSinkLogicalNode::new(source_plan, entries)),
+                })
+            } else {
+                // Single sink: wrap once at the logical level with this
+                // sink's config, then insert_into.
+                let entry = sinks.remove(0);
+                let rebatched_plan = wrap_with_rebatch(
+                    source_plan,
+                    entry.rebatch_config.batch_size.map(|s| s as usize),
+                    entry.rebatch_config.batch_flush_interval,
+                    entry.name.clone(),
+                );
+                LogicalPlanBuilder::insert_into(
+                    rebatched_plan,
+                    entry.name.as_str(),
+                    provider_as_source(entry.provider.clone()),
+                    InsertOp::Append,
+                )
+                .streamling_with_context(|| {
+                    format!("failed to build insert plan for sink [{}]", entry.name)
+                })?
+                .build()
+                .streamling_with_context(|| {
+                    format!("failed to build insert plan for sink [{}]", entry.name)
+                })?
+            };
 
-                if !dry_run {
-                    let session_manager = session_manager.clone();
-                    let sink_future = async move {
-                        let result = session_manager.new_df(sink_plan).collect().await;
-                        if let Err(err) = &result {
-                            error!(
-                                "Sink future [{}] completed with error: {}",
-                                future_name, err
-                            );
-                        }
-                        result
-                    };
-                    sink_futures.push(sink_future);
-                } else {
-                    dry_run_plans.push((future_name, sink_plan));
-                }
-            });
+            if !dry_run {
+                let session_manager = session_manager.clone();
+                let sink_future = async move {
+                    let result = session_manager.new_df(sink_plan).collect().await;
+                    if let Err(err) = &result {
+                        error!(
+                            "Sink future [{}] completed with error: {}",
+                            future_name, err
+                        );
+                    }
+                    result
+                };
+                sink_futures.push(sink_future);
+            } else {
+                dry_run_plans.push((future_name, sink_plan));
+            }
+        }
 
         // During dry_run, create physical plans to catch type coercion
         // and other SQL errors that only manifest at physical planning time.

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -1307,8 +1307,10 @@ impl Streamling {
                     // from the `DataFusionError::External` wrapper and stays user-facing.
                     // Otherwise `--validate` would misreport it as an internal failure.
                     .map_err(|e| {
-                        streamling_core::error::StreamlingError::from(e)
-                            .context(format!("{}: failed to build script transform", ctx.format()))
+                        streamling_core::error::StreamlingError::from(e).context(format!(
+                            "{}: failed to build script transform",
+                            ctx.format()
+                        ))
                     })?;
 
                     let logical_plan = LogicalPlan::Extension(Extension {
@@ -2074,12 +2076,18 @@ impl Streamling {
                     provider_as_source(entry.provider.clone()),
                     InsertOp::Append,
                 )
-                .streamling_with_context(|| {
-                    format!("failed to build insert plan for sink [{}]", entry.name)
+                .map_err(|e| {
+                    streamling_core::error::StreamlingError::from(e).context(format!(
+                        "failed to build insert plan for sink [{}]",
+                        entry.name
+                    ))
                 })?
                 .build()
-                .streamling_with_context(|| {
-                    format!("failed to build insert plan for sink [{}]", entry.name)
+                .map_err(|e| {
+                    streamling_core::error::StreamlingError::from(e).context(format!(
+                        "failed to build insert plan for sink [{}]",
+                        entry.name
+                    ))
                 })?
             };
 


### PR DESCRIPTION
## Summary
- `parse_data_type` upper-camel-cased type strings, so advertised-as-supported aliases `uint8/16/32/64` and `bytes` became `Uint*`/`Bytes` — rejected by Arrow's `DataType::from_str`. Normalized to `UInt*`/`Binary`.
- `WasmRunnerNode::with_options` `.unwrap()`ed on schema conversion; it now returns `Result`, and the dry-run sink plan's `insert_into().build()` unwraps propagate via `?`.
- The script-transform caller converts through `StreamlingError::from`, so a user-facing schema error is not reclassified as internal under `--validate`.

## Test plan
- [ ] `just fix && just lint`
- [ ] Unit tests for uint/bytes aliases + unknown-type user error (`cargo test -p streamling-core --lib schema::tests`).

One of three PRs splitting the validator panic-free work (plugin resolution / Arrow schema / telemetry recorder).

Made with [Cursor](https://cursor.com)