### PR TITLE
fix: guard empty metric metadata in recorder to avoid validate panic

### DIFF
--- a/crates/streamling-core/src/telemetry/recorder.rs
+++ b/crates/streamling-core/src/telemetry/recorder.rs
@@ -574,6 +574,13 @@ impl MetricsRecorder {
 pub fn initialize_metrics_recorder(
     metric_metadata_registry: HashMap<String, PipelineMetricMetadata>,
 ) {
+    // Nothing to record without metadata (e.g. `--validate`/dry-run of a minimal topology).
+    // Returning early avoids panicking on an empty registry during first initialization.
+    if metric_metadata_registry.is_empty() {
+        debug!("Skipping metrics recorder initialization: no metric metadata available");
+        return;
+    }
+
     let mut instance = METRICS_RECORDER_INSTANCE.lock().unwrap();
     if instance.is_none() {
         let meter = get_meter();
@@ -1183,6 +1190,21 @@ mod tests {
             seed_metadata("app::other");
             merge_metadata_tags("app::missing", vec![("chain".into(), "eth".into())]);
             assert!(additional_tags("app::other").is_empty());
+        }
+
+        /// Regression: `--validate`/dry-run of a minimal topology produced an empty
+        /// metric metadata registry, and the first initialization used to
+        /// `.expect()`-panic on `values().next()`. It must now be a no-op instead.
+        #[test]
+        fn empty_registry_does_not_panic() {
+            let _guard = TEST_LOCK.lock().unwrap();
+            reset_instance();
+            initialize_metrics_recorder(HashMap::new());
+            let instance = METRICS_RECORDER_INSTANCE.lock().unwrap();
+            assert!(
+                instance.is_none(),
+                "empty registry must not initialize the recorder"
+            );
         }
 
         #[test]


### PR DESCRIPTION
## Summary
- `initialize_metrics_recorder` used `.values().next().expect(...)` on first initialization. During `--validate`/dry-run of a minimal topology the metric metadata registry can be empty, so the validator panicked (the most frequent crash signature) instead of emitting structured output.
- Returns early when the registry is empty (nothing to record in that case).

## Test plan
- [x] `just fix && just lint`
- [ ] `cargo test -p streamling-core --lib telemetry::recorder::tests::merge_metadata_tags_tests::empty_registry_does_not_panic`

One of three PRs splitting the validator panic-free work (plugin resolution / Arrow schema / telemetry recorder).

Made with [Cursor](https://cursor.com)