### PR TITLE
fix: make LiveDataInspect singleton test order-independent

### DIFF
--- a/crates/streamling-core/src/operators/inspect.rs
+++ b/crates/streamling-core/src/operators/inspect.rs
@@ -542,6 +542,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_singleton_behavior() {
+        // `INSTANCE` is a process-global `OnceLock` shared with every other test
+        // that touches `LiveDataInspect` — notably any `WrappingExec::execute`,
+        // which calls `get_instance()`. Whichever test initializes it first wins,
+        // so we cannot assume the config passed here actually takes effect.
         let instance1 = LiveDataInspect::create_instance(
             LiveDataInspectConfig {
                 records_per_topology_node: 5,
@@ -551,17 +555,26 @@ mod tests {
         );
         let instance2 = LiveDataInspect::get_instance();
 
+        // The core singleton invariant holds regardless of init order.
         assert!(
             std::ptr::eq(instance1, instance2),
             "Should return the same singleton instance"
         );
 
-        // Test that data persists across instance calls
-        let batch = create_test_batch(1, 10);
-        instance1.process("singleton_test", &batch).await;
+        // Exercise data persistence only when our config won the init race
+        // (i.e. `singleton_test` is a tracked key). Otherwise another test
+        // already fixed the singleton's tracked keys/capacity and this specific
+        // scenario is not applicable — asserting a fixed count would be an
+        // order-dependent flake.
+        if let Some(capacity) = instance1.get_capacity("singleton_test") {
+            let batch = create_test_batch(1, 10);
+            instance1.process("singleton_test", &batch).await;
 
-        // Should be able to access the same data from instance2
-        assert_eq!(instance2.get_stored_count("singleton_test"), 5);
+            // Data written through instance1 is visible through instance2 (same
+            // singleton), capped at the configured capacity.
+            let expected = capacity.min(10) as usize;
+            assert_eq!(instance2.get_stored_count("singleton_test"), expected);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`test_singleton_behavior` in `crates/streamling-core/src/operators/inspect.rs` was order-dependent and could flake depending on parallel test scheduling.

Root cause: `LiveDataInspect::INSTANCE` is a **process-global `OnceLock`**. Both `create_instance` and `get_instance` initialize it via `get_or_init`, so whichever test touches the singleton first wins the init race and fixes its tracked keys/capacity for the entire process. The test assumed the config it passed actually took effect and asserted a hard-coded stored count of `5`. That only held when this test happened to win the race under a particular ordering. Any test running `WrappingExec::execute` first (which calls `get_instance()` with a different config) breaks the assumption.

This is a pre-existing bug on `main`, independent of any feature work: `get_capacity`/`get_stored_count` and the `OnceLock` singleton all already exist on `main`, and the buggy test hunk applies cleanly there.

The fix hardens the test to be order-independent:
- The core singleton-identity assertion (`ptr::eq(instance1, instance2)`) stays unconditional.
- The storage-count scenario only runs when this test actually won the init race (detected via `get_capacity("singleton_test").is_some()`), and asserts against the configured capacity instead of a magic number. If another test already initialized the singleton, this scenario is correctly skipped rather than asserting an order-dependent value.

## Test plan

- [x] `cargo test -p streamling-core --lib -- operators::inspect::tests::test_singleton_behavior` passes
- [x] `just fix` passes
- [x] `just lint` passes (no clippy warnings)

Made with [Cursor](https://cursor.com)