### PR TITLE
feat: an option to disable sink deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,9 @@ sinks:
 
 The PostgreSQL sink allows writing data to PostgreSQL tables. It create sink table automically.
 
+When a `primary_key` is set, each batch is collapsed to the latest row per key before writing; set `deduplicate: false`
+to disable that (see `Batch Deduplication` below).
+
 Sample configuration:
 
 ```yaml
@@ -698,6 +701,8 @@ Behavior for 256-bit integers (U256/I256):
 The PostgreSQL aggregation sink enables real-time aggregations directly in PostgreSQL using database triggers. Data flows into a landing table, and a trigger function automatically maintains aggregated values in a separate aggregation table.
 
 - **Landing Table**: Stores raw records in append-only mode with a composite primary key (`primary_key` + `_gs_op`).
+- **Deduplication**: each batch is collapsed to the latest row per `primary_key` before it reaches the landing table;
+  set `deduplicate: false` to disable that (see `Batch Deduplication` below).
 - **Aggregation Table**: Stores aggregated results, updated incrementally by the trigger.
 - **Operation Handling**: For `sum`, `count`, and `avg`, delete operations negate values. `count` also correctly handles updates (contributes 0 to the count). `min` and `max` do not support deletes or updates (use only for insert-only streams).
 
@@ -833,6 +838,8 @@ implemented as a custom DataFusion Table Provider (`TableProvider`) with the fol
   - Converts Arrow `RecordBatch`es to Avro-encoded messages.
   - Adds operation type column (`_gs_op`) to track INSERT/UPDATE/DELETE operations (see `Upsert Semantics` section
     below) as a message header with the `dbz.op` key.
+- **Deduplication**: when a `primary_key` is set, each batch is collapsed to the latest row per key before it is
+  produced; set `deduplicate: false` to disable that (see `Batch Deduplication` below). Message keying is unaffected.
 
 Kafka Sink uses
 high-level [FutureProducer](https://docs.rs/rdkafka/latest/rdkafka/producer/future_producer/struct.FutureProducer.html)
@@ -870,6 +877,7 @@ The ClickHouse sink writes records to a ClickHouse table over the HTTP interface
 
 - **Upsert Semantics**: INSERT/UPDATE/DELETE operations are derived from the `_gs_op` column (see `Upsert Semantics` section below). With `append_only_mode: true` (the default), the sink targets a `ReplacingMergeTree(insert_time, is_deleted)` table and derives the `is_deleted`/`insert_time` columns automatically. With `append_only_mode: false`, it uses `INSERT` for upserts and `ALTER TABLE ... DELETE` for deletes.
 - **Compression**: INSERT request bodies can be gzip-compressed. The global default comes from `clickhouse_sink.compression`/`clickhouse_sink.compression_level` and can be overridden per sink with the `compression` and `compression_level` fields.
+- **Deduplication**: each batch is collapsed to the latest row per `primary_key` before writing. Set `deduplicate: false` for append-only tables whose rows are deltas rather than states (e.g. `SummingMergeTree`) — see `Batch Deduplication` below.
 
 Sample configuration:
 
@@ -1430,6 +1438,32 @@ This replaces the previous nested `"Execution error: Execution error:"` pattern 
 By default, DataFusion passes data in a columnar format using `RecordBatch` without any additional metadata.
 So, in order to support upsert semantics, an additional `_gs_op` column is added to the schema. Unfortunately, this
 comes with some challenges mentioned in https://github.com/goldsky-io/streamling/pull/2.
+
+### Batch Deduplication
+
+Every sink configured with a `primary_key` — Postgres, Kafka and ClickHouse — collapses each
+batch to the **latest row per key** before writing it. Only the newest state of a row matters to an upsert, so this
+saves redundant writes. Sinks with no primary key never deduplicate.
+
+That assumption breaks when rows are **deltas rather than states**. Delta rows are meant to accumulate, so several
+of them legitimately share a key and every one has to be written — a retraction and its addition, or two different
+entities rolling up to the same aggregate key. Collapsing them silently drops rows and the destination drifts. Set
+`deduplicate: false` on those sinks:
+
+```yaml
+sinks:
+  revenue_rollup:
+    type: clickhouse
+    from: revenue_deltas
+    table: product_revenue_daily
+    primary_key: revenue_date,product_id,currency
+    append_only_mode: false
+    deduplicate: false
+```
+
+The primary key still drives everything else it is used for — `ALTER TABLE ... DELETE` keying and `CREATE TABLE`
+ordering in ClickHouse, `ON CONFLICT` targeting in Postgres, message keying in Kafka. `deduplicate: false` turns off
+the batch collapse and nothing else.
 
 ## Plugin System
 

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -350,6 +350,7 @@ struct SinkParams {
     primary_keys: Vec<String>,
     parallelism: usize,
     append_only_mode: bool,
+    deduplicate: bool,
     version_column_name: Option<String>,
     schema_override: Option<std::collections::HashMap<String, String>>,
     telemetry: Option<Telemetry>,
@@ -658,6 +659,7 @@ impl ClickHouseTableProvider {
         source_name: String,
         parallelism: Option<usize>,
         append_only_mode: Option<bool>,
+        deduplicate: Option<bool>,
         version_column_name: Option<String>,
         schema_override: Option<std::collections::HashMap<String, String>>,
         compression_override: Option<ClickHouseCompression>,
@@ -693,6 +695,7 @@ impl ClickHouseTableProvider {
             primary_keys,
             parallelism,
             append_only_mode: append_only_mode.unwrap_or(true),
+            deduplicate: deduplicate.unwrap_or(true),
             version_column_name,
             schema_override,
             telemetry,
@@ -895,7 +898,9 @@ impl TableProvider for ClickHouseTableProvider {
         let wrapper_sink = Arc::new(WrappingDataSink::new(
             clickhouse_sink,
             self.metric_metadata_id.clone(),
-            Some(sink_params.primary_keys.join(",")),
+            sink_params
+                .deduplicate
+                .then(|| sink_params.primary_keys.join(",")),
             sink_params.telemetry.as_ref(),
         ));
         Ok(Arc::new(DataSinkExec::new(

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -2848,6 +2848,7 @@ pub struct KafkaSinkTableProvider {
     parallelism: Option<usize>,
     /// Producer compression codec (maps to librdkafka's compression.type)
     compression: KafkaCompression,
+    deduplicate: bool,
     telemetry: Option<Telemetry>,
 }
 
@@ -2868,6 +2869,7 @@ impl KafkaSinkTableProvider {
         message_max_bytes: Option<u32>,
         parallelism: Option<usize>,
         compression: KafkaCompression,
+        deduplicate: Option<bool>,
         telemetry: Option<Telemetry>,
     ) -> Self {
         Self {
@@ -2885,6 +2887,7 @@ impl KafkaSinkTableProvider {
             message_max_bytes,
             parallelism,
             compression,
+            deduplicate: deduplicate.unwrap_or(true),
             telemetry,
         }
     }
@@ -2936,7 +2939,7 @@ impl TableProvider for KafkaSinkTableProvider {
         let wrapper_data_sink = Arc::new(WrappingDataSink::new(
             kafka_sink,
             metric_metadata_id.clone(),
-            self.primary_key.clone(),
+            self.primary_key.clone().filter(|_| self.deduplicate),
             self.telemetry.as_ref(),
         ));
         Ok(Arc::new(DataSinkExec::new(input, wrapper_data_sink, None)))

--- a/crates/streamling-connectors/src/table_providers/postgres/mod.rs
+++ b/crates/streamling-connectors/src/table_providers/postgres/mod.rs
@@ -61,6 +61,28 @@ pub struct PostgresSinkTableProvider {
     write_batch_size: u32,
 }
 
+/// The key each batch is collapsed on before it reaches the sink, or `None`
+/// when deduplication is off.
+///
+/// This must match the destination's own key. In append-only mode the landing
+/// table's primary key — and this sink's `ON CONFLICT` target — is
+/// `(primary_key…, _gs_op)`, so an insert and a delete of the same row are two
+/// distinct rows there. Collapsing on the narrower `primary_key` alone would
+/// drop one of them, and the aggregation trigger accumulates deltas
+/// (`total = total + EXCLUDED`), so a dropped row corrupts the aggregate.
+fn dedup_key(
+    primary_key: Option<&str>,
+    append_only_mode: bool,
+    deduplicate: bool,
+) -> Option<String> {
+    let primary_key = primary_key.filter(|_| deduplicate)?;
+    Some(if append_only_mode {
+        format!("{primary_key},{COLUMN_NAME_OP}")
+    } else {
+        primary_key.to_string()
+    })
+}
+
 impl PostgresSinkTableProvider {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -159,7 +181,11 @@ impl TableProvider for PostgresSinkTableProvider {
         let wrapper_sink = Arc::new(WrappingDataSink::new(
             postgres_sink,
             self.metric_metadata_id.clone(),
-            self.primary_key.clone().filter(|_| self.deduplicate),
+            dedup_key(
+                self.primary_key.as_deref(),
+                self.append_only_mode,
+                self.deduplicate,
+            ),
             self.telemetry.as_ref(),
         ));
 
@@ -354,5 +380,40 @@ impl DataSink for PostgresSinkExec {
 impl DisplayAs for PostgresSinkExec {
     fn fmt_as(&self, _: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "PostgresSink")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dedup_key_matches_the_destination_key() {
+        // Plain sink: the table's PK is the configured key, so is the dedup key.
+        assert_eq!(dedup_key(Some("id"), false, true), Some("id".to_string()));
+        assert_eq!(
+            dedup_key(Some("account,day"), false, true),
+            Some("account,day".to_string())
+        );
+
+        // Append-only (aggregation landing table): the table's PK is
+        // (primary_key…, _gs_op), so an insert and a delete of the same row
+        // must both survive into the trigger's delta.
+        assert_eq!(
+            dedup_key(Some("id"), true, true),
+            Some("id,_gs_op".to_string())
+        );
+        assert_eq!(
+            dedup_key(Some("account,day"), true, true),
+            Some("account,day,_gs_op".to_string())
+        );
+    }
+
+    #[test]
+    fn dedup_key_is_none_when_disabled_or_keyless() {
+        assert_eq!(dedup_key(Some("id"), false, false), None);
+        assert_eq!(dedup_key(Some("id"), true, false), None);
+        assert_eq!(dedup_key(None, false, true), None);
+        assert_eq!(dedup_key(None, true, true), None);
     }
 }

--- a/crates/streamling-connectors/src/table_providers/postgres/mod.rs
+++ b/crates/streamling-connectors/src/table_providers/postgres/mod.rs
@@ -55,6 +55,7 @@ pub struct PostgresSinkTableProvider {
     update_where: Option<BTreeMap<String, String>>,
     append_only_mode: bool,
     checkpoint_truncation: bool,
+    deduplicate: bool,
     parallelism: usize,
     telemetry: Option<Telemetry>,
     write_batch_size: u32,
@@ -76,6 +77,7 @@ impl PostgresSinkTableProvider {
         update_where: Option<BTreeMap<String, String>>,
         append_only_mode: bool,
         checkpoint_truncation: bool,
+        deduplicate: Option<bool>,
         reference_name: String,
         parallelism: Option<usize>,
         telemetry: Option<Telemetry>,
@@ -98,6 +100,7 @@ impl PostgresSinkTableProvider {
             update_where,
             append_only_mode,
             checkpoint_truncation,
+            deduplicate: deduplicate.unwrap_or(true),
             parallelism,
             telemetry,
             write_batch_size,
@@ -156,7 +159,7 @@ impl TableProvider for PostgresSinkTableProvider {
         let wrapper_sink = Arc::new(WrappingDataSink::new(
             postgres_sink,
             self.metric_metadata_id.clone(),
-            self.primary_key.clone(),
+            self.primary_key.clone().filter(|_| self.deduplicate),
             self.telemetry.as_ref(),
         ));
 

--- a/crates/streamling-core/src/operators/wrapping.rs
+++ b/crates/streamling-core/src/operators/wrapping.rs
@@ -1528,4 +1528,104 @@ mod tests {
         emit_event_time_metrics(&inst, &batch, "test_source", recorder.as_ref());
         assert!(inst.read_error_logged.load(Ordering::Relaxed));
     }
+
+    /// Records every row the inner sink actually receives.
+    #[derive(Debug)]
+    struct RecordingSink {
+        schema: SchemaRef,
+        ids_written: Arc<std::sync::Mutex<Vec<i64>>>,
+    }
+
+    impl DisplayAs for RecordingSink {
+        fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "RecordingSink")
+        }
+    }
+
+    #[async_trait]
+    impl DataSink for RecordingSink {
+        fn schema(&self) -> &SchemaRef {
+            &self.schema
+        }
+
+        fn metrics(&self) -> Option<MetricsSet> {
+            None
+        }
+
+        async fn write_all(
+            &self,
+            mut data: SendableRecordBatchStream,
+            _context: &Arc<TaskContext>,
+        ) -> Result<u64> {
+            let mut rows = 0u64;
+            while let Some(batch) = data.next().await {
+                let batch = batch?;
+                let ids = batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .expect("id column");
+                let mut written = self.ids_written.lock().unwrap();
+                for i in 0..batch.num_rows() {
+                    written.push(ids.value(i));
+                }
+                rows += batch.num_rows() as u64;
+            }
+            Ok(rows)
+        }
+    }
+
+    /// Pushes one batch holding two rows that share primary key `1` through a
+    /// `WrappingDataSink` built with `primary_key`, and returns the ids that
+    /// reached the inner sink.
+    async fn ids_reaching_sink(primary_key: Option<String>) -> Vec<i64> {
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("delta", DataType::Int64, false),
+        ]));
+        // Two deltas for one key: a retraction and the addition replacing it.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1i64, 1])),
+                Arc::new(Int64Array::from(vec![-150i64, 120])),
+            ],
+        )
+        .unwrap();
+
+        let ids_written = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = WrappingDataSink::new(
+            Arc::new(RecordingSink {
+                schema: schema.clone(),
+                ids_written: ids_written.clone(),
+            }),
+            "test_sink".to_string(),
+            primary_key,
+            None,
+        );
+
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::iter(vec![Ok(batch)]),
+        ));
+        sink.write_all(stream, &Arc::new(TaskContext::default()))
+            .await
+            .unwrap();
+
+        let ids = ids_written.lock().unwrap();
+        ids.clone()
+    }
+
+    #[tokio::test]
+    async fn a_primary_key_collapses_rows_sharing_it() {
+        // Upsert semantics: only the latest state of key 1 is written.
+        assert_eq!(ids_reaching_sink(Some("id".to_string())).await, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn no_primary_key_passes_every_row_through() {
+        // What `deduplicate: false` buys the ClickHouse/Postgres/Kafka sinks:
+        // both delta rows land instead of one silently disappearing.
+        assert_eq!(ids_reaching_sink(None).await, vec![1, 1]);
+    }
 }

--- a/crates/streamling-core/src/topology.rs
+++ b/crates/streamling-core/src/topology.rs
@@ -634,6 +634,9 @@ pub struct PostgresSink {
     /// Number of parallel tasks for writing to PostgreSQL. Each task processes
     /// a slice of the accumulated batch concurrently. Defaults to 1.
     pub parallelism: Option<usize>,
+    /// When true (default), each batch is collapsed to the latest row per
+    /// `primary_key` before it is written.
+    pub deduplicate: Option<bool>,
     pub telemetry: Option<Telemetry>,
 }
 
@@ -682,6 +685,9 @@ pub struct PostgresAggregateSink {
     pub batch_flush_interval: Option<String>,
     pub batch_size: Option<u32>,
     pub primary_key: Option<String>,
+    /// When true (default), each batch is collapsed to the latest row per
+    /// `primary_key` before it is written.
+    pub deduplicate: Option<bool>,
     pub telemetry: Option<Telemetry>,
 }
 
@@ -707,6 +713,9 @@ pub struct KafkaSink {
     /// Set `gzip` or `none` for brokers that reject lz4.
     #[serde(default)]
     pub compression: KafkaCompression,
+    /// When true (default), each batch is collapsed to the latest row per
+    /// `primary_key` before it is written.
+    pub deduplicate: Option<bool>,
     pub telemetry: Option<Telemetry>,
 }
 
@@ -725,6 +734,9 @@ pub struct ClickhouseSink {
     /// When false, uses plain ReplacingMergeTree() with INSERT for upserts and
     /// ALTER TABLE DELETE for deletes.
     pub append_only_mode: Option<bool>,
+    /// When true (default), each batch is collapsed to the latest row per
+    /// `primary_key` before it is written.
+    pub deduplicate: Option<bool>,
     /// Optional schema overrides for type conversions
     /// Maps column name -> ClickHouse type (e.g., "timestamp" -> "DateTime64(3)")
     #[serde(default)]

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -1633,6 +1633,7 @@ impl Streamling {
                         update_where.clone(),
                         false, // append_only_mode (normal Postgres sink)
                         false, // checkpoint_truncation (disabled for normal sink)
+                        postgres.deduplicate,
                         reference_name.clone(),
                         postgres.parallelism,
                         sink_telemetry.clone(),
@@ -1751,6 +1752,7 @@ impl Streamling {
                         None, // update_where (not applicable for aggregation sink)
                         true, // append_only_mode (aggregation sink)
                         true, // checkpoint_truncation (enabled for aggregation sink)
+                        postgres.deduplicate,
                         reference_name.clone(),
                         None, // parallelism (default for aggregation sink)
                         sink_telemetry.clone(),
@@ -1881,6 +1883,7 @@ impl Streamling {
                         kafka_sink.message_max_bytes,
                         kafka_sink.parallelism,
                         kafka_sink.compression,
+                        kafka_sink.deduplicate,
                         sink_telemetry.clone(),
                     ));
                     session_manager
@@ -1941,6 +1944,7 @@ impl Streamling {
                         from.clone(),
                         parallelism,
                         clickhouse_sink.append_only_mode,
+                        clickhouse_sink.deduplicate,
                         clickhouse_sink.version_column_name.clone(),
                         clickhouse_sink.schema_override.clone(),
                         clickhouse_sink.compression,


### PR DESCRIPTION
Sometimes we don't want to deduplicate data at the sink level by default. E.g., to support retractions, the sinks need to receive both "previous" and "new" versions of a row (with the same primary key value). 

UPDATE: also realized there is a related issue for the append-only mode in Postgres, fixed it [here](https://github.com/goldsky-io/streamling/pull/87/changes/411915c3793abc1df08a8b279037a1dbf3d3c61f).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default write paths for sinks with primary keys; wrong `deduplicate` settings can drop delta rows or allow duplicate states, especially on aggregation landing tables.
> 
> **Overview**
> Adds an optional **`deduplicate`** flag (default **true**) on Postgres, Postgres aggregate, Kafka, and ClickHouse sinks so pipelines can turn off **per-batch collapse to the latest row per key** while keeping `primary_key` for upserts, conflict targets, deletes, and Kafka message keys.
> 
> When **`deduplicate: false`**, sinks stop passing a dedup key into **`WrappingDataSink`**, so every row in the batch is written—needed for **delta/retraction** streams where multiple rows share a key. **Postgres append-only / aggregation** landing tables still dedupe on **`(primary_key…, _gs_op)`** when dedup is on, so insert and delete deltas for the same logical row are not merged incorrectly.
> 
> README adds a **Batch Deduplication** section with a ClickHouse example. Unit tests cover **`dedup_key`** and **`WrappingDataSink`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 411915c3793abc1df08a8b279037a1dbf3d3c61f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->