### PR TITLE
feat(clickhouse): make source page timeout and width growth tunable

### DIFF
--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -46,6 +46,7 @@ use datafusion::physical_expr::expressions::{CaseExpr, binary, col, lit};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::projection::ProjectionExec;
 use once_cell::sync::Lazy;
+use once_cell::sync::OnceCell;
 use regex::Regex;
 use reqwest::{Error, Response};
 use serde::{Deserialize, Serialize};
@@ -359,7 +360,22 @@ impl ClickHouseTableProvider {
     const DEFAULT_SORT_KEY_RANGE: i64 = 1_000_000;
     const DEFAULT_PAGE_SIZE: usize = 10_000_000;
     const MIN_SORT_KEY_RANGE: i64 = 100;
-    const SOURCE_QUERY_TIMEOUT_SECS: u64 = 60;
+    /// Hard per-page timeout for a source range query. A page that exceeds this is
+    /// cancelled and the range re-read at half the width. The soft shrink budget is
+    /// half of this, so lowering it also makes completed-but-slow pages shrink sooner.
+    /// Override with `STREAMLING__CLICKHOUSE_SOURCE__QUERY_TIMEOUT_SEC`.
+    const DEFAULT_SOURCE_QUERY_TIMEOUT_SECS: u64 = 60;
+
+    fn source_query_timeout_secs() -> u64 {
+        static TIMEOUT_SECS: OnceCell<u64> = OnceCell::new();
+        *TIMEOUT_SECS.get_or_init(|| {
+            std::env::var("STREAMLING__CLICKHOUSE_SOURCE__QUERY_TIMEOUT_SEC")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .filter(|v| *v > 0)
+                .unwrap_or(Self::DEFAULT_SOURCE_QUERY_TIMEOUT_SECS)
+        })
+    }
 
     pub fn new_source(
         reference_name: String,
@@ -1474,7 +1490,7 @@ impl ExecutionPlan for ClickHouseSourceExec {
             let max_width = (max_key - range_start).max(default_sort_key_range);
 
             let source_query_timeout =
-                Duration::from_secs(ClickHouseTableProvider::SOURCE_QUERY_TIMEOUT_SECS);
+                Duration::from_secs(ClickHouseTableProvider::source_query_timeout_secs());
             // Shrink proactively at half the hard timeout, before the query is killed.
             let soft_time_budget = source_query_timeout / 2;
 
@@ -1612,7 +1628,7 @@ impl ExecutionPlan for ClickHouseSourceExec {
                     Err(_elapsed) => {
                         Err(DataFusionError::from(streamling_core::streamling_err!(
                             "ClickHouse query timed out after {}s",
-                            ClickHouseTableProvider::SOURCE_QUERY_TIMEOUT_SECS
+                            ClickHouseTableProvider::source_query_timeout_secs()
                         )))
                     }
                 };

--- a/crates/streamling-connectors/src/table_providers/clickhouse/range_controller.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse/range_controller.rs
@@ -1,3 +1,4 @@
+use once_cell::sync::OnceCell;
 use std::time::Duration;
 
 /// Adaptive sort-key-range pagination with an owned cursor.
@@ -16,8 +17,9 @@ use std::time::Duration;
 /// Three signals drive width:
 /// - **rows** — the tripwire. A page is read with `LIMIT page_size + 1`; `page_size + 1`
 ///   rows means the range overflowed (`on_overflow`), else it was fully consumed.
-/// - **elapsed** — the time guard. A page slower than `soft_time_budget` shrinks the
-///   width even if the row count looked fine, catching the scan-bound case.
+/// - **elapsed** — the time guard. Scales width toward `soft_time_budget` on every
+///   completed page, not only slow ones: a page that used most of its budget can't
+///   be multiplied back into a timeout by row headroom alone.
 /// - **bytes** — the array guard. A page over `max_page_bytes` (`on_byte_overflow`)
 ///   would build a single Arrow column past the ~2 GiB `i32` offset limit, so it is
 ///   re-read smaller. `on_complete` also clamps growth by observed byte density, or a
@@ -41,8 +43,21 @@ pub struct RangeController {
 
 impl RangeController {
     /// Largest per-step growth multiplier. Bounds how fast width expands so a
-    /// near-empty page can't explode the range in one step.
-    const GROW_CEILING: f64 = 4.0;
+    /// near-empty page can't explode the range in one step. Lower it when a table
+    /// keeps oscillating between a completed page and a timeout. Override with
+    /// `STREAMLING__CLICKHOUSE_SOURCE__GROW_CEILING`.
+    const DEFAULT_GROW_CEILING: f64 = 4.0;
+
+    fn grow_ceiling() -> f64 {
+        static GROW_CEILING: OnceCell<f64> = OnceCell::new();
+        *GROW_CEILING.get_or_init(|| {
+            std::env::var("STREAMLING__CLICKHOUSE_SOURCE__GROW_CEILING")
+                .ok()
+                .and_then(|v| v.parse::<f64>().ok())
+                .filter(|v| *v >= 1.0 && v.is_finite())
+                .unwrap_or(Self::DEFAULT_GROW_CEILING)
+        })
+    }
 
     /// Fraction of `max_page_bytes` that byte sizing targets. A re-read covers a
     /// different (shrunk) sub-range whose byte density differs from the page that
@@ -133,13 +148,15 @@ impl RangeController {
         // GROW_CEILING. A completed page has rows <= page_size, so this is >= 1.0
         // (never shrinks on rows alone — that's the tripwire's and time guard's job).
         let rows = rows.max(1) as f64;
-        let row_mult = (self.page_size as f64 / rows).min(Self::GROW_CEILING);
+        let row_mult = (self.page_size as f64 / rows).min(Self::grow_ceiling());
         let mut candidate = self.width as f64 * row_mult;
 
-        // Time guard: a page slower than the soft budget is transfer- or scan-bound,
-        // so shrink proportionally regardless of row headroom. This stops an
-        // empty-but-slow (sparse, no projection) page from growing into a timeout.
-        if elapsed > self.soft_time_budget {
+        // Time guard: cap growth by how close the page ran to the soft budget, in both
+        // directions. Over budget it shrinks (transfer- or scan-bound); under budget it
+        // still bounds growth to budget/elapsed, so a page that already used most of its
+        // time cannot be multiplied back into a timeout by row headroom alone. A fast
+        // page leaves a multiplier well above the grow ceiling, so it is unaffected.
+        if !elapsed.is_zero() {
             let time_mult = self.soft_time_budget.as_secs_f64() / elapsed.as_secs_f64();
             candidate = candidate.min(self.width as f64 * time_mult);
         }
@@ -334,6 +351,16 @@ mod tests {
         let mut c = controller();
         c.on_complete(500, Duration::from_secs(60), 0);
         assert_eq!(c.width(), 500, "the time guard wins over row-based growth");
+    }
+
+    #[test]
+    fn near_budget_page_growth_is_damped_by_time() {
+        let mut c = controller();
+        // 100 rows against page_size 1000 wants 4x growth, but the page burned 20s of a
+        // 30s budget: growth is capped at 30/20 = 1.5x, not 4x, so the next page cannot
+        // be multiplied straight back into a timeout.
+        c.on_complete(100, Duration::from_secs(20), 0);
+        assert_eq!(c.width(), 1500);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Hybrid sources on big tables settle into a timeout loop. A page times out, the width halves, the next page completes under the soft budget with rows far below `page_size` (default 10,000,000), the row multiplier snaps width back 4x, and the range times out again. Neither the timeout nor the growth rate could be adjusted without a rebuild.

## Changes

Two env overrides, following the Kafka source's existing `OnceCell` pattern:

| Variable | Default | Effect |
|---|---|---|
| `STREAMLING__CLICKHOUSE_SOURCE__QUERY_TIMEOUT_SEC` | `60` | Hard per-page query timeout |
| `STREAMLING__CLICKHOUSE_SOURCE__GROW_CEILING` | `4.0` | Max width multiplier per completed page |

The soft shrink budget stays derived as half the hard timeout, so lowering the timeout tightens both: pages are cancelled sooner *and* completed-but-slow pages start shrinking sooner.

Also damps the oscillation itself. The time guard in `on_complete` was gated on `elapsed > soft_time_budget`, so a page finishing at 25s of a 30s budget still grew at the full 4x ceiling. It now always caps growth at `budget/elapsed`, so width converges on the budget rather than overshooting it. A fast page is unaffected — a 1s page against a 30s budget yields a 30x multiplier, well above the ceiling — which is why the existing width-adaptation tests pass unchanged.

`page_size` and `sort_key_range` were already env-settable through the `AppConfig` `Environment` source (`STREAMLING__CLICKHOUSE_SOURCE__PAGE_SIZE`, `..._SORT_KEY_RANGE`); no change needed for those.

## Testing

- `cargo test -p streamling-connectors range_controller` — 31 passed, 0 failed
- New test `near_budget_page_growth_is_damped_by_time`: 100 rows at 20s of a 30s budget grows 1.5x, not 4x
- `cargo fmt --all --check` clean
- Neither changed file produces a clippy warning

## Note on CI lint

`cargo clippy --all-targets --all-features -- -D warnings` currently fails on 3 pre-existing `clippy::result_large_err` errors in `crates/streamling-common/src/formats/avro/schema.rs`, which this branch does not touch. Verified as pre-existing: this branch has no commits against `main` other than these two files, so `streamling-common` here is identical to `main`. Needs a separate fix (boxing `apache_avro::Error`).