### PR TITLE
fix(metrics): key plugin transform metrics by the composite metric key

### DIFF
--- a/crates/streamling-core/src/plugin/operator.rs
+++ b/crates/streamling-core/src/plugin/operator.rs
@@ -77,6 +77,12 @@ impl PluginNode {
         internal_buffer_size: u32,
         metric_metadata_id: String,
     ) -> Self {
+        // Registry is keyed by metric_key(app_id, id) = "{app_id}::{id}".
+        // A bare reference name misses the lookup and every plugin metric is dropped.
+        debug_assert!(
+            metric_metadata_id.contains("::"),
+            "metric_metadata_id must be a metric_key(app_id, reference_name) composite; a bare reference name misses the metrics registry and every plugin metric is silently dropped"
+        );
         let id = format!("plugin_channel_{}", Uuid::new_v4());
 
         PLUGIN_CHANNELS

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -1429,7 +1429,7 @@ impl Streamling {
                             output_schema,
                             Arc::new(initialized_plugin.channels.clone()),
                             app_config.internal_buffer_size,
-                            reference_name.clone(),
+                            metric_key(&application_id, reference_name.as_str()),
                         )),
                     });
 
@@ -3228,6 +3228,30 @@ sinks: {}
         assert_eq!(
             meta.additional_tags.get("topic"),
             Some(&"v2.evm.blocks".to_string())
+        );
+    }
+
+    #[test]
+    fn test_plugin_transform_metric_metadata_keyed_by_composite_key() {
+        let yaml = r#"
+sources:
+  blocks:
+    type: kafka
+    topic: v2.evm.blocks
+transforms:
+  token_metadata:
+    type: test_transform_plugin
+    from: blocks
+sinks: {}
+"#;
+        let map = build_metadata_from_yaml(yaml);
+        assert!(
+            map.contains_key(&metric_key("test_app", "token_metadata")),
+            "plugin transform metadata must be keyed by metric_key(app_id, reference_name)"
+        );
+        assert!(
+            !map.contains_key("token_metadata"),
+            "bare reference name is not a registry key; consumers must look up by the composite key"
         );
     }
 


### PR DESCRIPTION
Every custom metric emitted by a **plugin transform** is silently discarded at runtime. Found while smoke-testing a new plugin transform in turbo, which logged one of these per metric per batch:

```
record_gauge_w_tags: metadata_id 'token_metadata' not found in registry,
skipping metric 'evm_token_metadata.cache_entries'
```

## Cause

`metric_metadata_tags_registry` is keyed by `metric_key(app_id, id)` = `"{app_id}::{id}"` (`telemetry/provider.rs`), and `build_pipeline_metric_metadata` registers sources, transforms and sinks under exactly that key. But the `PluginNode::new` call site passed the **bare** `reference_name` as `metric_metadata_id`:

```rust
node: Arc::new(PluginNode::new(
    transform_input,
    output_schema,
    Arc::new(initialized_plugin.channels.clone()),
    app_config.internal_buffer_size,
    reference_name.clone(),   // <-- bare name, never matches the registry
)),
```

So the lookup in the drain task (`process_plugin_metrics` → `record_*_w_tags`) always missed and the metric was dropped. Every neighbouring construction in the same function already passed `metric_key(&application_id, ...)` — including the `WrappingNode::new_with_non_null_cols` five lines below. This one call site did not.

`PluginNode::new` has exactly one call site and it is the plugin-transform path, so **all** plugin transforms were affected, not one plugin.

## Why it stayed hidden

- `output_rows` is unaffected: it routes through `record_output_rows_count`, so row-count and billing series looked healthy.
- The failure mode is a `warn!` and a dropped sample, never an error — dashboards just showed no series for these metrics.
- Checkpoint timings tagged with the same id (`checkpoint_marker_arrival`, `checkpoint_sink_flush`) were being dropped for plugin transforms too.

## Fix

Pass `metric_key(&application_id, reference_name.as_str())`, matching every sibling call site.

Also adds a `debug_assert!` in `PluginNode::new` that the id contains `::`. The parameter is a bare `String`, so nothing stops a reference name being passed in its place — this is the guard that would have caught the original bug, since the registry side was always correct.

A newtype constructible only via `metric_key` would enforce this at compile time across all ~25 call sites. That is a larger refactor touching several node/provider structs and the recorder signatures, so it is deliberately **not** done here — happy to follow up if you'd prefer that shape.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --locked --all-targets --all-features -- -D warnings -A clippy::result_large_err` — clean
- `cargo nextest run --workspace --locked -P ci --exclude streamling-e2e` — **1133 passed, 1 skipped**. Notably the new `debug_assert!` does not fire anywhere in the suite, confirming no other path constructs a `PluginNode` with a bare id.
- New test `test_plugin_transform_metric_metadata_keyed_by_composite_key` pins the registry contract the fix depends on: a plugin transform is registered under `metric_key(app_id, name)` and *not* under the bare name.

## Blast radius

Metrics-only. `metric_metadata_id` reaches nothing but the metrics drain, a `debug!` label, and `PartialOrd`; it never touches state, offsets, checkpoints or savepoints. `PluginNode`'s `PartialOrd` already includes `plugin_channel_id`, a fresh `Uuid::new_v4()` per construction, so plan identity is already unstable across restarts and nothing durable can key on it. `metric_metadata_id_to_reference_name` does `split("::").last()`, so any consumer deriving a reference name from the id gets the same value before and after this change. No savepoint or progress impact.
