### PR TITLE
fix(kafka): log final row count on sink completion

### DIFF
--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -2883,6 +2883,13 @@ impl DataSink for KafkaSink {
             })?;
         }
 
+        info!(
+            "[{}] write_all completed with {} rows (topic '{}')",
+            get_reference_name_from_metric_key(&self.metric_metadata_id),
+            row_count,
+            self.topic
+        );
+
         Ok(row_count as u64)
     }
 }


### PR DESCRIPTION
The postgres and clickhouse sinks both log `write_all completed with N rows` when their write loop ends (`postgres/mod.rs:372`, `clickhouse.rs:1327`). The kafka sink logged nothing.

Without that line a pipeline's logs cannot distinguish "the source returned no rows" from "the source returned rows but the sink emitted none" — the two cases look identical. It matters most for job-mode runs, where the process exits within seconds and there is no live pipeline left to inspect afterwards.

Same message shape and the same `get_reference_name_from_metric_key` node label as the other two sinks, so the output is consistent across sink types. `row_count` already tracks exactly the rows handed to the producer, empty batches excluded.

`cargo check -p streamling-connectors` passes.