### PR TITLE
Support per-sink Postgres connections (STRM-6516)

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,10 +692,6 @@ STREAMLING__POSTGRES_SINK_CONNECTIONS__POSTGRES_BLOCKS__HOST=blocks.example.com
 STREAMLING__POSTGRES_SINK_CONNECTIONS__POSTGRES_BLOCKS__DB=blocks
 ```
 
-The same shape exists for the Kafka and ClickHouse sinks
-(`STREAMLING__KAFKA_SINK_CONNECTIONS__<SINK_NAME>__*`,
-`STREAMLING__CLICKHOUSE_SINK_CONNECTIONS__<SINK_NAME>__*`).
-
 Behavior for 256-bit integers (U256/I256):
 
 - Columns annotated as U256/I256 in the Arrow schema (FixedSizeBinary(32) with Streamling metadata) are created in Postgres as `NUMERIC(78,0)`.

--- a/README.md
+++ b/README.md
@@ -680,6 +680,22 @@ sinks:
 | `STREAMLING__POSTGRES_SINK__DB` | `postgres` | Database name |
 | `STREAMLING__POSTGRES_SINK__SSLMODE` | `disable` | SSL mode (`disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`) |
 
+**Per-sink connections** — two `postgres` sinks in one pipeline can write to two
+different databases. Prefix a sink's connection with
+`STREAMLING__POSTGRES_SINK_CONNECTIONS__<SINK_NAME>__`, where `<SINK_NAME>` is
+the sink's key in `sinks:` with non-alphanumeric characters replaced by `_`; any
+field left unset falls back to the table above, and a sink with no entry uses it
+verbatim. For the sample above:
+
+```
+STREAMLING__POSTGRES_SINK_CONNECTIONS__POSTGRES_BLOCKS__HOST=blocks.example.com
+STREAMLING__POSTGRES_SINK_CONNECTIONS__POSTGRES_BLOCKS__DB=blocks
+```
+
+The same shape exists for the Kafka and ClickHouse sinks
+(`STREAMLING__KAFKA_SINK_CONNECTIONS__<SINK_NAME>__*`,
+`STREAMLING__CLICKHOUSE_SINK_CONNECTIONS__<SINK_NAME>__*`).
+
 Behavior for 256-bit integers (U256/I256):
 
 - Columns annotated as U256/I256 in the Arrow schema (FixedSizeBinary(32) with Streamling metadata) are created in Postgres as `NUMERIC(78,0)`.

--- a/crates/streamling-config/src/app_config.rs
+++ b/crates/streamling-config/src/app_config.rs
@@ -752,23 +752,23 @@ impl KafkaSinkConnection {
         if let Some(security_protocol) = &self.security_protocol {
             config.security_protocol = security_protocol.clone();
         }
-        if self.sasl_mechanism.is_some() {
-            config.sasl_mechanism = self.sasl_mechanism.clone();
+        if let Some(sasl_mechanism) = &self.sasl_mechanism {
+            config.sasl_mechanism = Some(sasl_mechanism.clone());
         }
-        if self.sasl_username.is_some() {
-            config.sasl_username = self.sasl_username.clone();
+        if let Some(sasl_username) = &self.sasl_username {
+            config.sasl_username = Some(sasl_username.clone());
         }
-        if self.sasl_password.is_some() {
-            config.sasl_password = self.sasl_password.clone();
+        if let Some(sasl_password) = &self.sasl_password {
+            config.sasl_password = Some(sasl_password.clone());
         }
-        if self.schema_registry_url.is_some() {
-            config.schema_registry_url = self.schema_registry_url.clone();
+        if let Some(schema_registry_url) = &self.schema_registry_url {
+            config.schema_registry_url = Some(schema_registry_url.clone());
         }
-        if self.schema_registry_username.is_some() {
-            config.schema_registry_username = self.schema_registry_username.clone();
+        if let Some(schema_registry_username) = &self.schema_registry_username {
+            config.schema_registry_username = Some(schema_registry_username.clone());
         }
-        if self.schema_registry_password.is_some() {
-            config.schema_registry_password = self.schema_registry_password.clone();
+        if let Some(schema_registry_password) = &self.schema_registry_password {
+            config.schema_registry_password = Some(schema_registry_password.clone());
         }
     }
 }

--- a/crates/streamling-config/src/app_config.rs
+++ b/crates/streamling-config/src/app_config.rs
@@ -589,6 +589,190 @@ impl Default for PostgresSinkConfig {
     }
 }
 
+/// Normalizes a topology node name to the key the config crate produces for a
+/// `STREAMLING__<SINK_TYPE>_SINK_CONNECTIONS__<NODE_NAME>__<FIELD>` env var.
+///
+/// The config crate lowercases env var names and splits them on `__`, so a node
+/// name has to survive both: non-alphanumeric characters become `_` and runs of
+/// `_` collapse into one. `my-sink`, `my_sink` and `my__sink` therefore all
+/// resolve to `my_sink`. streamling-agent applies the same normalization when it
+/// writes the env vars, and rejects a pipeline whose sink names collide once
+/// normalized, so one key never stands for two different destinations.
+pub fn normalize_sink_key(node_name: &str) -> String {
+    let mut key = String::with_capacity(node_name.len());
+    for c in node_name.chars() {
+        if c.is_alphanumeric() {
+            key.push(c.to_ascii_lowercase());
+        } else if !key.is_empty() && !key.ends_with('_') {
+            key.push('_');
+        }
+    }
+    // A leading or trailing `_` would make the config crate split the env name
+    // into an empty segment, so the key could never be looked up.
+    if key.ends_with('_') {
+        key.pop();
+    }
+    key
+}
+
+/// Connection overrides for one `postgres` / `postgres_aggregate` sink node.
+///
+/// A streamling process has a single global `postgres_sink` connection, so two
+/// postgres sinks in one pipeline used to share one destination: whichever
+/// secret the cloud agent flattened into `STREAMLING__POSTGRES_SINK__*` last
+/// won, and the other sink silently wrote to the same database (STRM-6516).
+/// Each sink's own credentials now arrive under
+/// `STREAMLING__POSTGRES_SINK_CONNECTIONS__<SINK_NAME>__*`; fields left unset
+/// fall back to the global block, and a sink with no entry at all keeps the
+/// global connection verbatim.
+#[derive(Deserialize, Clone, Default)]
+pub struct PostgresSinkConnection {
+    pub host: Option<String>,
+    pub port: Option<String>,
+    pub user: Option<String>,
+    pub pass: Option<String>,
+    pub db: Option<String>,
+    pub sslmode: Option<String>,
+}
+
+impl std::fmt::Debug for PostgresSinkConnection {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostgresSinkConnection")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("user", &self.user)
+            .field("pass", &self.pass.as_ref().map(|_| "*****"))
+            .field("db", &self.db)
+            .field("sslmode", &self.sslmode)
+            .finish()
+    }
+}
+
+impl PostgresSinkConnection {
+    fn apply_to(&self, config: &mut PostgresSinkConfig) {
+        if let Some(host) = &self.host {
+            config.host = host.clone();
+        }
+        if let Some(port) = &self.port {
+            config.port = port.clone();
+        }
+        if let Some(user) = &self.user {
+            config.user = user.clone();
+        }
+        if let Some(pass) = &self.pass {
+            config.pass = pass.clone();
+        }
+        if let Some(db) = &self.db {
+            config.db = db.clone();
+        }
+        if let Some(sslmode) = &self.sslmode {
+            config.sslmode = sslmode.clone();
+        }
+    }
+}
+
+/// Connection overrides for one `clickhouse` sink node. See
+/// [`PostgresSinkConnection`] for why these exist.
+#[derive(Deserialize, Clone, Default)]
+pub struct ClickHouseSinkConnection {
+    pub url: Option<String>,
+    pub user: Option<String>,
+    pub password: Option<String>,
+    pub database: Option<String>,
+}
+
+impl std::fmt::Debug for ClickHouseSinkConnection {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClickHouseSinkConnection")
+            .field("url", &self.url)
+            .field("user", &self.user)
+            .field("password", &self.password.as_ref().map(|_| "*****"))
+            .field("database", &self.database)
+            .finish()
+    }
+}
+
+impl ClickHouseSinkConnection {
+    fn apply_to(&self, config: &mut ClickHouseSinkConfig) {
+        if let Some(url) = &self.url {
+            config.url = url.clone();
+        }
+        if let Some(user) = &self.user {
+            config.user = user.clone();
+        }
+        if let Some(password) = &self.password {
+            config.password = password.clone();
+        }
+        if let Some(database) = &self.database {
+            config.database = database.clone();
+        }
+    }
+}
+
+/// Connection overrides for one `kafka` sink node. See
+/// [`PostgresSinkConnection`] for why these exist.
+#[derive(Deserialize, Clone, Default)]
+pub struct KafkaSinkConnection {
+    pub brokers: Option<String>,
+    pub security_protocol: Option<String>,
+    pub sasl_mechanism: Option<String>,
+    pub sasl_username: Option<String>,
+    pub sasl_password: Option<String>,
+    pub schema_registry_url: Option<String>,
+    pub schema_registry_username: Option<String>,
+    pub schema_registry_password: Option<String>,
+}
+
+impl std::fmt::Debug for KafkaSinkConnection {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KafkaSinkConnection")
+            .field("brokers", &self.brokers)
+            .field("security_protocol", &self.security_protocol)
+            .field("sasl_mechanism", &self.sasl_mechanism)
+            .field("sasl_username", &self.sasl_username)
+            .field(
+                "sasl_password",
+                &self.sasl_password.as_ref().map(|_| "*****"),
+            )
+            .field("schema_registry_url", &self.schema_registry_url)
+            .field("schema_registry_username", &self.schema_registry_username)
+            .field(
+                "schema_registry_password",
+                &self.schema_registry_password.as_ref().map(|_| "*****"),
+            )
+            .finish()
+    }
+}
+
+impl KafkaSinkConnection {
+    fn apply_to(&self, config: &mut KafkaConfig) {
+        if let Some(brokers) = &self.brokers {
+            config.brokers = brokers.clone();
+        }
+        if let Some(security_protocol) = &self.security_protocol {
+            config.security_protocol = security_protocol.clone();
+        }
+        if self.sasl_mechanism.is_some() {
+            config.sasl_mechanism = self.sasl_mechanism.clone();
+        }
+        if self.sasl_username.is_some() {
+            config.sasl_username = self.sasl_username.clone();
+        }
+        if self.sasl_password.is_some() {
+            config.sasl_password = self.sasl_password.clone();
+        }
+        if self.schema_registry_url.is_some() {
+            config.schema_registry_url = self.schema_registry_url.clone();
+        }
+        if self.schema_registry_username.is_some() {
+            config.schema_registry_username = self.schema_registry_username.clone();
+        }
+        if self.schema_registry_password.is_some() {
+            config.schema_registry_password = self.schema_registry_password.clone();
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct ExternalHttpHandlerConfig {
     pub trigger_max_count: u32,
@@ -738,6 +922,18 @@ pub struct AppConfig {
     /// Populated from `STREAMLING__HTTP_SECRET_VALUE__<NAME>` environment variables.
     #[serde(default)]
     pub http_secret_value: SecretMap,
+    /// Per-sink Postgres connections, keyed by normalized sink node name
+    /// (see [`normalize_sink_key`]). Populated from
+    /// `STREAMLING__POSTGRES_SINK_CONNECTIONS__<SINK_NAME>__*` env vars; read
+    /// via [`AppConfig::postgres_sink_for`].
+    #[serde(default)]
+    pub postgres_sink_connections: HashMap<String, PostgresSinkConnection>,
+    /// Per-sink ClickHouse connections. See [`AppConfig::clickhouse_sink_for`].
+    #[serde(default)]
+    pub clickhouse_sink_connections: HashMap<String, ClickHouseSinkConnection>,
+    /// Per-sink Kafka connections. See [`AppConfig::kafka_sink_for`].
+    #[serde(default)]
+    pub kafka_sink_connections: HashMap<String, KafkaSinkConnection>,
     #[serde(default)]
     pub test_settings: TestSettings,
     /// When true, hybrid sources terminate after all bounded phases complete
@@ -753,6 +949,48 @@ impl AppConfig {
     /// it would affect existing state.
     pub fn state_backend_namespace(&self) -> &str {
         self.application_id.as_str()
+    }
+
+    /// Connection for the `postgres` / `postgres_aggregate` sink node named
+    /// `sink_name`: the global `postgres_sink` block with that sink's own
+    /// overrides applied. Sinks without an override keep the global connection,
+    /// which is the single-destination behavior every pipeline had before
+    /// STRM-6516.
+    pub fn postgres_sink_for(&self, sink_name: &str) -> PostgresSinkConfig {
+        let mut config = self.postgres_sink.clone();
+        if let Some(connection) = self
+            .postgres_sink_connections
+            .get(&normalize_sink_key(sink_name))
+        {
+            connection.apply_to(&mut config);
+        }
+        config
+    }
+
+    /// Connection for the `clickhouse` sink node named `sink_name`.
+    /// See [`AppConfig::postgres_sink_for`].
+    pub fn clickhouse_sink_for(&self, sink_name: &str) -> ClickHouseSinkConfig {
+        let mut config = self.clickhouse_sink.clone();
+        if let Some(connection) = self
+            .clickhouse_sink_connections
+            .get(&normalize_sink_key(sink_name))
+        {
+            connection.apply_to(&mut config);
+        }
+        config
+    }
+
+    /// Connection for the `kafka` sink node named `sink_name`.
+    /// See [`AppConfig::postgres_sink_for`].
+    pub fn kafka_sink_for(&self, sink_name: &str) -> KafkaConfig {
+        let mut config = self.kafka_sink.clone();
+        if let Some(connection) = self
+            .kafka_sink_connections
+            .get(&normalize_sink_key(sink_name))
+        {
+            connection.apply_to(&mut config);
+        }
+        config
     }
 }
 
@@ -890,6 +1128,191 @@ mod tests {
             test.http_secret_value.get("my_token"),
             Some(&"Bearer abc123".to_string())
         );
+    }
+
+    /// The embedded defaults, with no external file and no env overrides — a
+    /// deterministic starting point for connection-resolution tests.
+    fn base_app_config() -> AppConfig {
+        Config::builder()
+            .add_source(File::from_str(EMBEDDED_DEFAULT_CONFIG, FileFormat::Yaml))
+            .build()
+            .expect("embedded default config must build")
+            .try_deserialize()
+            .expect("embedded default config must deserialize into AppConfig")
+    }
+
+    #[test]
+    fn normalize_sink_key_matches_config_crate_key_shape() {
+        // The config crate lowercases and splits on `__`, so every rendering of
+        // one sink name has to land on the same key.
+        assert_eq!(normalize_sink_key("postgres_prod_txs"), "postgres_prod_txs");
+        assert_eq!(normalize_sink_key("Postgres-Prod-Txs"), "postgres_prod_txs");
+        assert_eq!(
+            normalize_sink_key("postgres__prod__txs"),
+            "postgres_prod_txs"
+        );
+        assert_eq!(normalize_sink_key("pg.prod"), "pg_prod");
+        // No empty leading or trailing segment: the config crate would split the
+        // env name around it and the key would be unreachable.
+        assert_eq!(normalize_sink_key("-pg-prod-"), "pg_prod");
+    }
+
+    /// The whole point of the per-sink maps: two postgres sinks in one pipeline
+    /// resolve to two different databases instead of sharing whichever secret
+    /// the cloud agent flattened last (STRM-6516).
+    #[test]
+    fn postgres_sink_connections_resolve_per_sink() {
+        let mut config = base_app_config();
+        config.postgres_sink_connections.insert(
+            "postgres_prod_txs".to_string(),
+            PostgresSinkConnection {
+                host: Some("prod.example.com".to_string()),
+                db: Some("prod".to_string()),
+                ..Default::default()
+            },
+        );
+        config.postgres_sink_connections.insert(
+            "postgres_dev_txs".to_string(),
+            PostgresSinkConnection {
+                host: Some("dev.example.com".to_string()),
+                db: Some("dev".to_string()),
+                pass: Some("dev-pass".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let prod = config.postgres_sink_for("postgres_prod_txs");
+        let dev = config.postgres_sink_for("postgres_dev_txs");
+
+        assert_eq!(prod.host, "prod.example.com");
+        assert_eq!(prod.db, "prod");
+        assert_eq!(dev.host, "dev.example.com");
+        assert_eq!(dev.db, "dev");
+        // Unset fields fall back to the global block, set ones win.
+        assert_eq!(prod.pass, config.postgres_sink.pass);
+        assert_eq!(dev.pass, "dev-pass");
+        // Non-connection knobs are never per-sink.
+        assert_eq!(dev.batch_size, config.postgres_sink.batch_size);
+    }
+
+    /// A sink with no override keeps the global connection — the behavior of
+    /// every pipeline deployed by an agent that does not publish per-sink keys.
+    #[test]
+    fn sink_without_connection_override_falls_back_to_global() {
+        let config = base_app_config();
+
+        let resolved = config.postgres_sink_for("some_sink");
+        assert_eq!(resolved.host, config.postgres_sink.host);
+        assert_eq!(resolved.db, config.postgres_sink.db);
+
+        let clickhouse = config.clickhouse_sink_for("some_sink");
+        assert_eq!(clickhouse.url, config.clickhouse_sink.url);
+
+        let kafka = config.kafka_sink_for("some_sink");
+        assert_eq!(kafka.brokers, config.kafka_sink.brokers);
+    }
+
+    #[test]
+    fn clickhouse_and_kafka_connections_resolve_per_sink() {
+        let mut config = base_app_config();
+        config.clickhouse_sink_connections.insert(
+            "ch_two".to_string(),
+            ClickHouseSinkConnection {
+                url: Some("https://two.clickhouse.cloud:8443".to_string()),
+                database: Some("two".to_string()),
+                ..Default::default()
+            },
+        );
+        config.kafka_sink_connections.insert(
+            "kafka_two".to_string(),
+            KafkaSinkConnection {
+                brokers: Some("two.broker:9092".to_string()),
+                sasl_username: Some("two".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let ch = config.clickhouse_sink_for("ch_two");
+        assert_eq!(ch.url, "https://two.clickhouse.cloud:8443");
+        assert_eq!(ch.database, "two");
+        assert_eq!(ch.user, config.clickhouse_sink.user);
+
+        let kafka = config.kafka_sink_for("kafka_two");
+        assert_eq!(kafka.brokers, "two.broker:9092");
+        assert_eq!(kafka.sasl_username, Some("two".to_string()));
+        assert_eq!(kafka.security_protocol, config.kafka_sink.security_protocol);
+    }
+
+    /// End-to-end env path: the agent writes
+    /// `STREAMLING__POSTGRES_SINK_CONNECTIONS__<SINK>__<FIELD>`, so the config
+    /// crate must nest a map of structs two levels deep from those env vars.
+    #[test]
+    fn postgres_sink_connections_populated_from_env_vars() {
+        let _guard = env_guard();
+
+        let vars = [
+            (
+                "STREAMLING__POSTGRES_SINK_CONNECTIONS__POSTGRES_DEV_TXS__HOST",
+                "dev.example.com",
+            ),
+            (
+                "STREAMLING__POSTGRES_SINK_CONNECTIONS__POSTGRES_DEV_TXS__DB",
+                "dev",
+            ),
+            (
+                "STREAMLING__POSTGRES_SINK_CONNECTIONS__POSTGRES_PROD_TXS__HOST",
+                "prod.example.com",
+            ),
+        ];
+        let previous: Vec<_> = vars
+            .iter()
+            .map(|(name, _)| (*name, std::env::var(name).ok()))
+            .collect();
+
+        // SAFETY: we hold ENV_LOCK, serializing all env-var mutation in this test module.
+        unsafe {
+            for (name, value) in vars {
+                std::env::set_var(name, value);
+            }
+        }
+
+        let result = std::panic::catch_unwind(|| {
+            #[derive(serde_derive::Deserialize)]
+            struct TestConfig {
+                #[serde(default)]
+                postgres_sink_connections: HashMap<String, PostgresSinkConnection>,
+            }
+            Config::builder()
+                .add_source(Environment::with_prefix("streamling").separator("__"))
+                .build()
+                .unwrap()
+                .try_deserialize::<TestConfig>()
+                .unwrap()
+                .postgres_sink_connections
+        });
+
+        // SAFETY: see above.
+        unsafe {
+            for (name, value) in previous {
+                match value {
+                    Some(v) => std::env::set_var(name, v),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+
+        let connections = result.expect("test body panicked");
+        let dev = connections
+            .get("postgres_dev_txs")
+            .expect("dev sink connection must be populated from env");
+        assert_eq!(dev.host.as_deref(), Some("dev.example.com"));
+        assert_eq!(dev.db.as_deref(), Some("dev"));
+        assert_eq!(dev.user, None);
+        let prod = connections
+            .get("postgres_prod_txs")
+            .expect("prod sink connection must be populated from env");
+        assert_eq!(prod.host.as_deref(), Some("prod.example.com"));
+        assert_eq!(prod.db, None);
     }
 
     /// Verifies the full path: STREAMLING__HTTP_SECRET_HEADER__* and STREAMLING__HTTP_SECRET_VALUE__* env

--- a/crates/streamling-config/src/app_config.rs
+++ b/crates/streamling-config/src/app_config.rs
@@ -671,108 +671,6 @@ impl PostgresSinkConnection {
     }
 }
 
-/// Connection overrides for one `clickhouse` sink node. See
-/// [`PostgresSinkConnection`] for why these exist.
-#[derive(Deserialize, Clone, Default)]
-pub struct ClickHouseSinkConnection {
-    pub url: Option<String>,
-    pub user: Option<String>,
-    pub password: Option<String>,
-    pub database: Option<String>,
-}
-
-impl std::fmt::Debug for ClickHouseSinkConnection {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ClickHouseSinkConnection")
-            .field("url", &self.url)
-            .field("user", &self.user)
-            .field("password", &self.password.as_ref().map(|_| "*****"))
-            .field("database", &self.database)
-            .finish()
-    }
-}
-
-impl ClickHouseSinkConnection {
-    fn apply_to(&self, config: &mut ClickHouseSinkConfig) {
-        if let Some(url) = &self.url {
-            config.url = url.clone();
-        }
-        if let Some(user) = &self.user {
-            config.user = user.clone();
-        }
-        if let Some(password) = &self.password {
-            config.password = password.clone();
-        }
-        if let Some(database) = &self.database {
-            config.database = database.clone();
-        }
-    }
-}
-
-/// Connection overrides for one `kafka` sink node. See
-/// [`PostgresSinkConnection`] for why these exist.
-#[derive(Deserialize, Clone, Default)]
-pub struct KafkaSinkConnection {
-    pub brokers: Option<String>,
-    pub security_protocol: Option<String>,
-    pub sasl_mechanism: Option<String>,
-    pub sasl_username: Option<String>,
-    pub sasl_password: Option<String>,
-    pub schema_registry_url: Option<String>,
-    pub schema_registry_username: Option<String>,
-    pub schema_registry_password: Option<String>,
-}
-
-impl std::fmt::Debug for KafkaSinkConnection {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("KafkaSinkConnection")
-            .field("brokers", &self.brokers)
-            .field("security_protocol", &self.security_protocol)
-            .field("sasl_mechanism", &self.sasl_mechanism)
-            .field("sasl_username", &self.sasl_username)
-            .field(
-                "sasl_password",
-                &self.sasl_password.as_ref().map(|_| "*****"),
-            )
-            .field("schema_registry_url", &self.schema_registry_url)
-            .field("schema_registry_username", &self.schema_registry_username)
-            .field(
-                "schema_registry_password",
-                &self.schema_registry_password.as_ref().map(|_| "*****"),
-            )
-            .finish()
-    }
-}
-
-impl KafkaSinkConnection {
-    fn apply_to(&self, config: &mut KafkaConfig) {
-        if let Some(brokers) = &self.brokers {
-            config.brokers = brokers.clone();
-        }
-        if let Some(security_protocol) = &self.security_protocol {
-            config.security_protocol = security_protocol.clone();
-        }
-        if let Some(sasl_mechanism) = &self.sasl_mechanism {
-            config.sasl_mechanism = Some(sasl_mechanism.clone());
-        }
-        if let Some(sasl_username) = &self.sasl_username {
-            config.sasl_username = Some(sasl_username.clone());
-        }
-        if let Some(sasl_password) = &self.sasl_password {
-            config.sasl_password = Some(sasl_password.clone());
-        }
-        if let Some(schema_registry_url) = &self.schema_registry_url {
-            config.schema_registry_url = Some(schema_registry_url.clone());
-        }
-        if let Some(schema_registry_username) = &self.schema_registry_username {
-            config.schema_registry_username = Some(schema_registry_username.clone());
-        }
-        if let Some(schema_registry_password) = &self.schema_registry_password {
-            config.schema_registry_password = Some(schema_registry_password.clone());
-        }
-    }
-}
-
 #[derive(Debug, Deserialize, Clone)]
 pub struct ExternalHttpHandlerConfig {
     pub trigger_max_count: u32,
@@ -928,12 +826,6 @@ pub struct AppConfig {
     /// via [`AppConfig::postgres_sink_for`].
     #[serde(default)]
     pub postgres_sink_connections: HashMap<String, PostgresSinkConnection>,
-    /// Per-sink ClickHouse connections. See [`AppConfig::clickhouse_sink_for`].
-    #[serde(default)]
-    pub clickhouse_sink_connections: HashMap<String, ClickHouseSinkConnection>,
-    /// Per-sink Kafka connections. See [`AppConfig::kafka_sink_for`].
-    #[serde(default)]
-    pub kafka_sink_connections: HashMap<String, KafkaSinkConnection>,
     #[serde(default)]
     pub test_settings: TestSettings,
     /// When true, hybrid sources terminate after all bounded phases complete
@@ -960,32 +852,6 @@ impl AppConfig {
         let mut config = self.postgres_sink.clone();
         if let Some(connection) = self
             .postgres_sink_connections
-            .get(&normalize_sink_key(sink_name))
-        {
-            connection.apply_to(&mut config);
-        }
-        config
-    }
-
-    /// Connection for the `clickhouse` sink node named `sink_name`.
-    /// See [`AppConfig::postgres_sink_for`].
-    pub fn clickhouse_sink_for(&self, sink_name: &str) -> ClickHouseSinkConfig {
-        let mut config = self.clickhouse_sink.clone();
-        if let Some(connection) = self
-            .clickhouse_sink_connections
-            .get(&normalize_sink_key(sink_name))
-        {
-            connection.apply_to(&mut config);
-        }
-        config
-    }
-
-    /// Connection for the `kafka` sink node named `sink_name`.
-    /// See [`AppConfig::postgres_sink_for`].
-    pub fn kafka_sink_for(&self, sink_name: &str) -> KafkaConfig {
-        let mut config = self.kafka_sink.clone();
-        if let Some(connection) = self
-            .kafka_sink_connections
             .get(&normalize_sink_key(sink_name))
         {
             connection.apply_to(&mut config);
@@ -1204,43 +1070,6 @@ mod tests {
         let resolved = config.postgres_sink_for("some_sink");
         assert_eq!(resolved.host, config.postgres_sink.host);
         assert_eq!(resolved.db, config.postgres_sink.db);
-
-        let clickhouse = config.clickhouse_sink_for("some_sink");
-        assert_eq!(clickhouse.url, config.clickhouse_sink.url);
-
-        let kafka = config.kafka_sink_for("some_sink");
-        assert_eq!(kafka.brokers, config.kafka_sink.brokers);
-    }
-
-    #[test]
-    fn clickhouse_and_kafka_connections_resolve_per_sink() {
-        let mut config = base_app_config();
-        config.clickhouse_sink_connections.insert(
-            "ch_two".to_string(),
-            ClickHouseSinkConnection {
-                url: Some("https://two.clickhouse.cloud:8443".to_string()),
-                database: Some("two".to_string()),
-                ..Default::default()
-            },
-        );
-        config.kafka_sink_connections.insert(
-            "kafka_two".to_string(),
-            KafkaSinkConnection {
-                brokers: Some("two.broker:9092".to_string()),
-                sasl_username: Some("two".to_string()),
-                ..Default::default()
-            },
-        );
-
-        let ch = config.clickhouse_sink_for("ch_two");
-        assert_eq!(ch.url, "https://two.clickhouse.cloud:8443");
-        assert_eq!(ch.database, "two");
-        assert_eq!(ch.user, config.clickhouse_sink.user);
-
-        let kafka = config.kafka_sink_for("kafka_two");
-        assert_eq!(kafka.brokers, "two.broker:9092");
-        assert_eq!(kafka.sasl_username, Some("two".to_string()));
-        assert_eq!(kafka.security_protocol, config.kafka_sink.security_protocol);
     }
 
     /// End-to-end env path: the agent writes

--- a/crates/streamling-e2e/src/lib.rs
+++ b/crates/streamling-e2e/src/lib.rs
@@ -432,6 +432,14 @@ impl TestContext {
         SqsResource::new(sqs_url, &queue_name).await
     }
 
+    /// Create an additional isolated PostgreSQL database, for tests that need a
+    /// second destination on the same cluster (e.g. two postgres sinks resolving
+    /// their own per-sink connections). Dropped when the returned resource is.
+    pub async fn create_postgres_database(&self, suffix: &str) -> Result<PostgresResource> {
+        let database = format!("test_{}_{}", &self.test_id[..8], suffix);
+        PostgresResource::new(&self.config.postgres_url, &database).await
+    }
+
     /// Create an additional Kafka topic for use in tests (e.g., for sink output)
     pub async fn create_kafka_topic(&self, topic_suffix: &str) -> Result<KafkaResource> {
         let topic = format!("test_{}_{}", &self.test_id[..8], topic_suffix);

--- a/crates/streamling-e2e/tests/multi_sink.rs
+++ b/crates/streamling-e2e/tests/multi_sink.rs
@@ -506,3 +506,174 @@ sinks:
         webhook.request_count()
     );
 }
+
+// ============================================================================
+// Scenario 5: Two postgres sinks, two databases (STRM-6516)
+// ============================================================================
+
+/// Regression: two `postgres` sinks in one pipeline must write to the two
+/// databases they were each given, not both to whichever connection the
+/// deployer published last.
+///
+/// A streamling process has one global `postgres_sink` block, and
+/// streamling-agent used to flatten every sink's resolved secret into it, so the
+/// second secret it processed overwrote the first: both sinks connected to the
+/// same database and the other database received nothing (LiFi `solana-mainnet`,
+/// two sinks writing the same table name into a prod and a dev database).
+///
+/// Only `pg_second` gets per-sink keys, in the exact
+/// `STREAMLING__POSTGRES_SINK_CONNECTIONS__<SINK_NAME>__<FIELD>` form the agent
+/// writes. `pg_primary` stays on the global block and `pg_second` omits
+/// `SSLMODE`, so the run also covers the fallback path per sink and per field.
+///
+/// The two sinks write *different* table names so the misrouting is what fails,
+/// not a side effect of it: LiFi's sinks shared a table name, and pre-fix that
+/// means both sinks race to `CREATE TABLE` in the one database they both
+/// connected to. With distinct names, pre-fix leaves `multi_db_second` in the
+/// primary database and the second database empty — which is exactly what the
+/// assertions below check, in both directions.
+#[tokio::test]
+async fn test_multi_sink_two_postgres_databases() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("Failed to create test context");
+    let second = ctx
+        .create_postgres_database("second")
+        .await
+        .expect("Failed to create second PostgreSQL database");
+
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+
+    let records_to_produce: i64 = 10;
+    let records: Vec<TestRecord> = (1..=records_to_produce)
+        .map(|i| TestRecord {
+            id: i,
+            value: format!("value_{}", i),
+            timestamp: 1000 + i,
+        })
+        .collect();
+
+    ctx.kafka
+        .produce_avro_records(&records)
+        .await
+        .expect("Failed to produce records");
+
+    let pipeline = format!(
+        r#"
+sources:
+  kafka_source:
+    type: kafka
+    topic: {topic}
+    starting_offsets: earliest
+    primary_key: id
+
+transforms: {{}}
+
+sinks:
+  pg_primary:
+    type: postgres
+    from: kafka_source
+    table: multi_db_primary
+    schema: public
+    primary_key: id
+    on_conflict: update
+
+  pg_second:
+    type: postgres
+    from: kafka_source
+    table: multi_db_second
+    schema: public
+    primary_key: id
+    on_conflict: update
+"#,
+        topic = ctx.kafka_topic,
+    );
+
+    let status = ctx
+        .run_pipeline_with_opts(
+            &pipeline,
+            PipelineOpts::new()
+                .record_limit(records_to_produce as u64)
+                .timeout(std::time::Duration::from_secs(60))
+                .env(
+                    "STREAMLING__POSTGRES_SINK_CONNECTIONS__PG_SECOND__HOST",
+                    second.host.clone(),
+                )
+                .env(
+                    "STREAMLING__POSTGRES_SINK_CONNECTIONS__PG_SECOND__PORT",
+                    second.port.to_string(),
+                )
+                .env(
+                    "STREAMLING__POSTGRES_SINK_CONNECTIONS__PG_SECOND__USER",
+                    second.user.clone(),
+                )
+                .env(
+                    "STREAMLING__POSTGRES_SINK_CONNECTIONS__PG_SECOND__PASS",
+                    second.password.clone(),
+                )
+                .env(
+                    "STREAMLING__POSTGRES_SINK_CONNECTIONS__PG_SECOND__DB",
+                    second.database.clone(),
+                ),
+        )
+        .await
+        .expect("Streamling execution failed");
+
+    assert!(status.success(), "Streamling should exit successfully");
+
+    let primary_count = ctx
+        .postgres
+        .count("SELECT COUNT(*) FROM public.multi_db_primary")
+        .await
+        .expect("Failed to query the primary database");
+    assert_eq!(
+        primary_count, records_to_produce,
+        "sink on the global connection should have written {} records to database '{}'",
+        records_to_produce, ctx.pg_database
+    );
+
+    // The regression, one direction: pre-fix pg_second connected to the primary
+    // database, so its table does not exist here at all.
+    let second_count = second
+        .count("SELECT COUNT(*) FROM public.multi_db_second")
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "sink with per-sink connection keys did not write to database '{}': {}",
+                second.database, e
+            )
+        });
+    assert_eq!(
+        second_count, records_to_produce,
+        "sink with per-sink connection keys should have written {} records to database '{}'",
+        records_to_produce, second.database
+    );
+
+    let second_ids: Vec<(i64,)> = second
+        .query("SELECT id FROM public.multi_db_second ORDER BY id")
+        .await
+        .expect("Failed to query ids from the second database");
+    assert_eq!(
+        second_ids.iter().map(|row| row.0).collect::<Vec<_>>(),
+        (1..=records_to_produce).collect::<Vec<_>>(),
+        "the second database should hold every record, not a subset"
+    );
+
+    // The other direction: pg_second must not have touched the primary database.
+    let leaked: Vec<(bool,)> = ctx
+        .postgres
+        .query("SELECT to_regclass('public.multi_db_second') IS NOT NULL")
+        .await
+        .expect("Failed to probe the primary database for the second sink's table");
+    assert_eq!(
+        leaked,
+        vec![(false,)],
+        "sink 'pg_second' wrote into the primary database '{}' as well",
+        ctx.pg_database
+    );
+}

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -1642,10 +1642,19 @@ impl Streamling {
                         validate_update_where(uw, &source_schema, &reference_name)?;
                     }
 
+                    // Per-sink connection: two postgres sinks in one pipeline can
+                    // target two different databases (STRM-6516). Falls back to the
+                    // global postgres_sink block when no per-sink keys are set.
+                    let postgres_config = app_config.postgres_sink_for(&reference_name);
+                    info!(
+                        "postgres sink '{}' resolved connection {:?}",
+                        reference_name, postgres_config
+                    );
+
                     let postgres_sink_provider = Arc::new(PostgresSinkTableProvider::new(
                         metric_key(&application_id, reference_name.as_str()),
                         source_schema.clone(),
-                        app_config.postgres_sink.clone(),
+                        postgres_config.clone(),
                         table.clone(),
                         schema.clone(),
                         batch_size,
@@ -1670,18 +1679,16 @@ impl Streamling {
                     // always has a concrete batch_size/interval regardless of
                     // whether the topology supplied them.
                     let effective_batch_size =
-                        Some(batch_size.unwrap_or(app_config.postgres_sink.batch_size));
+                        Some(batch_size.unwrap_or(postgres_config.batch_size));
                     let effective_batch_flush_interval = Some(match raw_batch_flush_interval {
                         Some(d) => d,
-                        None => humantime::parse_duration(
-                            &app_config.postgres_sink.batch_flush_interval,
-                        )
-                        .streamling_with_context(|| {
-                            format!(
-                                "invalid app_config.postgres_sink.batch_flush_interval '{}'",
-                                app_config.postgres_sink.batch_flush_interval
-                            )
-                        })?,
+                        None => humantime::parse_duration(&postgres_config.batch_flush_interval)
+                            .streamling_with_context(|| {
+                                format!(
+                                    "invalid app_config.postgres_sink.batch_flush_interval '{}'",
+                                    postgres_config.batch_flush_interval
+                                )
+                            })?,
                     });
                     Self::update_source_to_sink_mapping(
                         &mut sources_to_sinks,
@@ -1747,6 +1754,13 @@ impl Streamling {
                         format!("{}: failed to create PostgresAggregator", ctx.format())
                     })?;
 
+                    // Per-sink connection, as for the plain postgres sink above.
+                    let postgres_config = app_config.postgres_sink_for(&reference_name);
+                    info!(
+                        "postgres_aggregate sink '{}' resolved connection {:?}",
+                        reference_name, postgres_config
+                    );
+
                     if dry_run {
                         // Secrets are not resolved during dry-run (see
                         // secret_name_to_resolve), so there are no DB credentials
@@ -1757,14 +1771,14 @@ impl Streamling {
                         pg_aggregator.generate_trigger_statement_sql()?;
                     } else {
                         pg_aggregator
-                            .create_trigger_and_tables(&app_config.postgres_sink)
+                            .create_trigger_and_tables(&postgres_config)
                             .await?;
                     }
 
                     let postgres_sink_provider = Arc::new(PostgresSinkTableProvider::new(
                         metric_key(&application_id, reference_name.as_str()),
                         source_schema.clone(),
-                        app_config.postgres_sink.clone(),
+                        postgres_config.clone(),
                         landing_table.clone(),
                         schema.clone(),
                         batch_size,
@@ -1789,18 +1803,16 @@ impl Streamling {
                     // always has a concrete batch_size/interval regardless of
                     // whether the topology supplied them.
                     let effective_batch_size =
-                        Some(batch_size.unwrap_or(app_config.postgres_sink.batch_size));
+                        Some(batch_size.unwrap_or(postgres_config.batch_size));
                     let effective_batch_flush_interval = Some(match raw_batch_flush_interval {
                         Some(d) => d,
-                        None => humantime::parse_duration(
-                            &app_config.postgres_sink.batch_flush_interval,
-                        )
-                        .streamling_with_context(|| {
-                            format!(
-                                "invalid app_config.postgres_sink.batch_flush_interval '{}'",
-                                app_config.postgres_sink.batch_flush_interval
-                            )
-                        })?,
+                        None => humantime::parse_duration(&postgres_config.batch_flush_interval)
+                            .streamling_with_context(|| {
+                                format!(
+                                    "invalid app_config.postgres_sink.batch_flush_interval '{}'",
+                                    postgres_config.batch_flush_interval
+                                )
+                            })?,
                     });
                     Self::update_source_to_sink_mapping(
                         &mut sources_to_sinks,
@@ -1891,10 +1903,17 @@ impl Streamling {
                         &source_schema,
                     )?;
 
+                    // Per-sink connection (STRM-6516); global kafka_sink otherwise.
+                    let kafka_config = app_config.kafka_sink_for(&reference_name);
+                    info!(
+                        "kafka sink '{}' resolved connection {:?}",
+                        reference_name, kafka_config
+                    );
+
                     let kafka_sink_provider = Arc::new(KafkaSinkTableProvider::new(
                         metric_key(&application_id, reference_name.as_str()),
                         source_schema,
-                        app_config.kafka_sink.clone(),
+                        kafka_config,
                         topic.clone(),
                         topic_partitions,
                         data_format.parse()?,
@@ -1957,10 +1976,16 @@ impl Streamling {
                         Some(raw_batch_flush_interval.unwrap_or_else(|| {
                             Duration::from_millis(app_config.record_batch_interval_ms)
                         }));
+                    // Per-sink connection (STRM-6516); global clickhouse_sink otherwise.
+                    let clickhouse_config = app_config.clickhouse_sink_for(&reference_name);
+                    info!(
+                        "clickhouse sink '{}' resolved connection {:?}",
+                        reference_name, clickhouse_config
+                    );
                     let clickhouse_sink_provider = Arc::new(ClickHouseTableProvider::new_sink(
                         metric_key(&application_id, reference_name.as_str()),
                         table.as_str(),
-                        app_config.clickhouse_sink.clone(),
+                        clickhouse_config,
                         effective_batch_size,
                         app_config.num_records_before_stop,
                         pk_metadata_opt.map(|pk| pk.to_str()).unwrap_or_default(),

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -1903,17 +1903,10 @@ impl Streamling {
                         &source_schema,
                     )?;
 
-                    // Per-sink connection (STRM-6516); global kafka_sink otherwise.
-                    let kafka_config = app_config.kafka_sink_for(&reference_name);
-                    info!(
-                        "kafka sink '{}' resolved connection {:?}",
-                        reference_name, kafka_config
-                    );
-
                     let kafka_sink_provider = Arc::new(KafkaSinkTableProvider::new(
                         metric_key(&application_id, reference_name.as_str()),
                         source_schema,
-                        kafka_config,
+                        app_config.kafka_sink.clone(),
                         topic.clone(),
                         topic_partitions,
                         data_format.parse()?,
@@ -1976,16 +1969,10 @@ impl Streamling {
                         Some(raw_batch_flush_interval.unwrap_or_else(|| {
                             Duration::from_millis(app_config.record_batch_interval_ms)
                         }));
-                    // Per-sink connection (STRM-6516); global clickhouse_sink otherwise.
-                    let clickhouse_config = app_config.clickhouse_sink_for(&reference_name);
-                    info!(
-                        "clickhouse sink '{}' resolved connection {:?}",
-                        reference_name, clickhouse_config
-                    );
                     let clickhouse_sink_provider = Arc::new(ClickHouseTableProvider::new_sink(
                         metric_key(&application_id, reference_name.as_str()),
                         table.as_str(),
-                        clickhouse_config,
+                        app_config.clickhouse_sink.clone(),
                         effective_batch_size,
                         app_config.num_records_before_stop,
                         pk_metadata_opt.map(|pk| pk.to_str()).unwrap_or_default(),

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -1685,8 +1685,8 @@ impl Streamling {
                         None => humantime::parse_duration(&postgres_config.batch_flush_interval)
                             .streamling_with_context(|| {
                                 format!(
-                                    "invalid app_config.postgres_sink.batch_flush_interval '{}'",
-                                    postgres_config.batch_flush_interval
+                                    "invalid postgres batch_flush_interval '{}' resolved for sink '{}'",
+                                    postgres_config.batch_flush_interval, reference_name
                                 )
                             })?,
                     });
@@ -1809,8 +1809,8 @@ impl Streamling {
                         None => humantime::parse_duration(&postgres_config.batch_flush_interval)
                             .streamling_with_context(|| {
                                 format!(
-                                    "invalid app_config.postgres_sink.batch_flush_interval '{}'",
-                                    postgres_config.batch_flush_interval
+                                    "invalid postgres batch_flush_interval '{}' resolved for sink '{}'",
+                                    postgres_config.batch_flush_interval, reference_name
                                 )
                             })?,
                     });


### PR DESCRIPTION
## Summary
Enable multiple `postgres` and `postgres_aggregate` sinks in a single pipeline to write to different databases by introducing per-sink connection configuration. Previously, all postgres sinks in a pipeline shared a single global connection, causing the last deployed sink's credentials to overwrite earlier ones.

## Key Changes

- **New `PostgresSinkConnection` struct**: Holds optional per-sink connection overrides (host, port, user, pass, db, sslmode) that fall back to global settings when unset. Implements custom `Debug` to mask passwords.

- **Sink key normalization**: Added `normalize_sink_key()` function that converts sink names to configuration keys by lowercasing and collapsing non-alphanumeric characters to underscores, matching the behavior of the config crate's environment variable parsing.

- **Per-sink resolution**: New `AppConfig::postgres_sink_for(sink_name)` method resolves the effective connection for a sink by applying per-sink overrides to the global `postgres_sink` block.

- **Configuration integration**: Added `postgres_sink_connections` HashMap to `AppConfig`, populated from `STREAMLING__POSTGRES_SINK_CONNECTIONS__<SINK_NAME>__*` environment variables.

- **Sink instantiation**: Updated both `postgres` and `postgres_aggregate` sink creation in `Streamling` to use `postgres_sink_for()` instead of the global config, with logging of resolved connections.

- **Comprehensive tests**: Added unit tests for key normalization, per-sink resolution, fallback behavior, and environment variable parsing. Added end-to-end test verifying two postgres sinks correctly write to separate databases.

- **Documentation**: Updated README with per-sink connection configuration examples and explanation.

## Implementation Details

- Sink names are normalized consistently across the agent and streamling to prevent collisions (e.g., `my-sink`, `my_sink`, and `my__sink` all normalize to `my_sink`).
- Unset fields in per-sink connections fall back to the global block, maintaining backward compatibility for sinks without overrides.
- Non-connection configuration (batch_size, batch_flush_interval) remains global and is never per-sink.
- The test infrastructure was extended with `create_postgres_database()` to support multi-database testing scenarios.