### PR TITLE
feat(dynamic-table): index the time column on table creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -996,8 +996,9 @@ transforms:
 
 The cache is off by default and is used only when both settings are present. The initial lookup
 loads the full table through bounded PostgreSQL cursor pages. Each later `dynamic_table_check`
-batch reads `MAX(time_column)` and appends only rows newer than the cached maximum. Index the time
-column so these checks and range reads stay cheap.
+batch reads `MAX(time_column)` and appends only rows newer than the cached maximum. Streamling
+creates an index on the time column for tables it creates; add that index manually only for
+pre-existing tables Streamling did not create.
 
 PostgreSQL dynamic tables are append-only when the in-memory cache is enabled. Updating or deleting
 existing membership, including removals, is not supported in this mode. Keeping `time_column` current

--- a/crates/streamling-config/src/app_config.rs
+++ b/crates/streamling-config/src/app_config.rs
@@ -162,7 +162,11 @@ pub struct PostgresDynamicTableBackendConfig {
     pub sslmode: String,
     pub max_connections: Option<u32>,
     pub dt_schema_name: Option<String>,
-    /// Enables incremental in-memory caching for dynamic tables that explicitly set `time_column`.
+    /// Global default for incremental in-memory caching of dynamic tables.
+    ///
+    /// Individual `dynamic_table` transforms may override this per topology via
+    /// their `cache` field; when that field is omitted the global value applies.
+    /// Caching is only ever active when the table sets `time_column`.
     #[serde(default)]
     pub cache_enabled: bool,
 }

--- a/crates/streamling-core/src/dynamic_table.rs
+++ b/crates/streamling-core/src/dynamic_table.rs
@@ -68,6 +68,7 @@ impl DynamicTableBackendFactory {
         schema: Option<String>,
         column: Option<String>,
         time_column: Option<String>,
+        cache_enabled_override: Option<bool>,
     ) -> Result<Arc<dyn DynamicTableBackend>, DynamicTableBackendError> {
         let max_batch_size = self.config.max_batch_size.unwrap_or(1000);
         match backend_type {
@@ -96,6 +97,7 @@ impl DynamicTableBackendFactory {
                         column,
                         time_column,
                         max_batch_size,
+                        cache_enabled_override,
                     )
                     .await?;
                 Ok(Arc::new(backend))
@@ -543,6 +545,7 @@ mod tests {
                 schema: None,
                 column: None,
                 time_column: None,
+                cache: None,
                 telemetry: None,
             }),
         );
@@ -556,6 +559,7 @@ mod tests {
                 schema: None,
                 column: None,
                 time_column: None,
+                cache: None,
                 telemetry: None,
             }),
         );
@@ -569,6 +573,7 @@ mod tests {
                 schema: None,
                 column: None,
                 time_column: None,
+                cache: None,
                 telemetry: None,
             }),
         );

--- a/crates/streamling-core/src/dynamic_table/postgres.rs
+++ b/crates/streamling-core/src/dynamic_table/postgres.rs
@@ -167,6 +167,7 @@ impl PostgresDynamicTableBackendFactory {
         column: Option<String>,
         time_column: Option<String>,
         max_batch_size: usize,
+        cache_enabled_override: Option<bool>,
     ) -> Result<PostgresDynamicTableBackend, DynamicTableBackendError> {
         debug!(
             "Creating dynamic table backend: entity={}, schema={:?}, column={:?}, time_column={:?}",
@@ -221,6 +222,7 @@ impl PostgresDynamicTableBackendFactory {
             column_name,
             time_column,
             max_batch_size,
+            cache_enabled_override,
         ))
     }
 }
@@ -260,8 +262,10 @@ impl PostgresDynamicTableBackend {
         column_name: String,
         time_column_name: Option<String>,
         max_batch_size: usize,
+        cache_enabled_override: Option<bool>,
     ) -> Self {
-        let cache_enabled = config.cache_enabled && time_column_name.is_some();
+        let cache_enabled =
+            cache_enabled_override.unwrap_or(config.cache_enabled) && time_column_name.is_some();
         debug!(
             table = %full_table_name,
             cache_enabled,
@@ -1110,6 +1114,7 @@ mod tests {
                 None,
                 Some("updated_at".to_string()),
                 1000,
+                None,
             )
             .await
             .expect("backend should be valid");
@@ -1118,7 +1123,14 @@ mod tests {
         let enabled_factory = PostgresDynamicTableBackendFactory::new(postgres_config(true))
             .expect("factory should be valid");
         let missing_time_column = enabled_factory
-            .create_backend("missing_time_column".to_string(), None, None, None, 1000)
+            .create_backend(
+                "missing_time_column".to_string(),
+                None,
+                None,
+                None,
+                1000,
+                None,
+            )
             .await
             .expect("backend should be valid");
         assert!(missing_time_column.cache.is_none());
@@ -1131,10 +1143,72 @@ mod tests {
                 None,
                 Some("updated_at".to_string()),
                 1000,
+                None,
             )
             .await
             .expect("backend should be valid");
         assert!(cached.cache.is_some());
+    }
+
+    #[tokio::test]
+    async fn cache_resolution_falls_back_to_global_unless_overridden() {
+        // Topology override wins over the global flag.
+        let global_off = PostgresDynamicTableBackendFactory::new(postgres_config(false))
+            .expect("factory should be valid");
+        let forced_on = global_off
+            .create_backend(
+                "forced_on".to_string(),
+                None,
+                None,
+                Some("updated_at".to_string()),
+                1000,
+                Some(true),
+            )
+            .await
+            .expect("backend should be valid");
+        assert!(forced_on.cache.is_some());
+
+        let global_on = PostgresDynamicTableBackendFactory::new(postgres_config(true))
+            .expect("factory should be valid");
+        let forced_off = global_on
+            .create_backend(
+                "forced_off".to_string(),
+                None,
+                None,
+                Some("updated_at".to_string()),
+                1000,
+                Some(false),
+            )
+            .await
+            .expect("backend should be valid");
+        assert!(forced_off.cache.is_none());
+
+        // No override: falls back to the global flag.
+        let defaulted_on = global_on
+            .create_backend(
+                "defaulted_on".to_string(),
+                None,
+                None,
+                Some("updated_at".to_string()),
+                1000,
+                None,
+            )
+            .await
+            .expect("backend should be valid");
+        assert!(defaulted_on.cache.is_some());
+
+        let defaulted_off = global_off
+            .create_backend(
+                "defaulted_off".to_string(),
+                None,
+                None,
+                Some("updated_at".to_string()),
+                1000,
+                None,
+            )
+            .await
+            .expect("backend should be valid");
+        assert!(defaulted_off.cache.is_none());
     }
     #[test]
     fn build_time_column_index_name_stays_under_limit() {

--- a/crates/streamling-core/src/dynamic_table/postgres.rs
+++ b/crates/streamling-core/src/dynamic_table/postgres.rs
@@ -818,7 +818,8 @@ impl PostgresDynamicTableBackend {
                         .rsplit_once('.')
                         .map(|(_, table)| table)
                         .unwrap_or(self.full_table_name.as_str());
-                    let index_name = format!("idx_{}_{}", bare_table, self.time_column_name);
+                    let index_name =
+                        build_time_column_index_name(bare_table, &self.time_column_name);
                     let create_index_sql = format!(
                         r#"CREATE INDEX IF NOT EXISTS "{}" ON {} ("{}")"#,
                         index_name, self.full_table_name, self.time_column_name
@@ -879,6 +880,32 @@ impl PostgresDynamicTableBackend {
             .await
             .cloned()
     }
+}
+
+/// Build the deterministic index name for a dynamic table's time column.
+///
+/// PostgreSQL silently truncates identifiers to `NAMEDATALEN - 1` (63) bytes,
+/// so a naive `idx_{table}_{column}` can collide after truncation — two long
+/// names can truncate to the same identifier, and `CREATE INDEX IF NOT EXISTS`
+/// would then no-op against the wrong index on subsequent startups. When the
+/// name exceeds the limit we keep a readable prefix and append a short, stable
+/// hash of the full name, keeping it unique and under 63 bytes. Identifiers are
+/// ASCII (`[A-Za-z0-9_]`), so byte slicing is always on a char boundary.
+fn build_time_column_index_name(bare_table: &str, time_column: &str) -> String {
+    const MAX_IDENT_BYTES: usize = 63;
+    let raw = format!("idx_{}_{}", bare_table, time_column);
+    if raw.len() <= MAX_IDENT_BYTES {
+        return raw;
+    }
+    let hash = {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        raw.hash(&mut hasher);
+        format!("{:08x}", hasher.finish())
+    };
+    // '_' + 8 hex hash chars.
+    let prefix_len = MAX_IDENT_BYTES - 1 - hash.len();
+    format!("{}_{}", &raw[..prefix_len], hash)
 }
 
 /// Remove duplicate values from `(index, value)` pairs, keeping only the first
@@ -1109,6 +1136,32 @@ mod tests {
             .expect("backend should be valid");
         assert!(cached.cache.is_some());
     }
+    #[test]
+    fn build_time_column_index_name_stays_under_limit() {
+        // Short names pass through unchanged.
+        let short = build_time_column_index_name("blocks", "block_timestamp");
+        assert_eq!(short, "idx_blocks_block_timestamp");
+        assert!(short.len() <= 63);
+
+        // Long names are truncated + hash-suffixed to stay under 63 bytes, and
+        // stay deterministic across calls so IF NOT EXISTS is stable at startup.
+        let long_bare_table = "a".repeat(60);
+        let long_col = "updated_at";
+        let name = build_time_column_index_name(&long_bare_table, long_col);
+        assert!(name.len() <= 63);
+        assert_eq!(
+            name,
+            build_time_column_index_name(&long_bare_table, long_col)
+        );
+
+        // Distinct long names produce distinct identifiers (no silent truncation collision).
+        let other = build_time_column_index_name(&"b".repeat(60), long_col);
+        assert_ne!(name, other);
+
+        // The readable `idx_` prefix is preserved for debuggability.
+        assert!(name.starts_with("idx_"));
+    }
+
     #[test]
     fn deduplicate_value_indices_removes_duplicates() {
         let input = vec![

--- a/crates/streamling-core/src/dynamic_table/postgres.rs
+++ b/crates/streamling-core/src/dynamic_table/postgres.rs
@@ -822,6 +822,28 @@ impl PostgresDynamicTableBackend {
                     match create_result {
                         Ok(_) => {
                             info!("Successfully created table: {}", self.full_table_name);
+                            let bare_table = self
+                                .full_table_name
+                                .rsplit_once('.')
+                                .map(|(_, table)| table)
+                                .unwrap_or(self.full_table_name.as_str());
+                            let index_name =
+                                format!("idx_{}_{}", bare_table, self.time_column_name);
+                            let create_index_sql = format!(
+                                r#"CREATE INDEX IF NOT EXISTS "{}" ON {} ("{}")"#,
+                                index_name, self.full_table_name, self.time_column_name
+                            );
+                            if let Err(e) = sqlx::query(&create_index_sql)
+                                .execute(pool_arc.as_ref())
+                                .await
+                            {
+                                let err = DynamicTableBackendError::Initialization(format!(
+                                    "Failed to create index {} on table {}: {}",
+                                    index_name, self.full_table_name, e
+                                ));
+                                error!("{}", err);
+                                return Err(err);
+                            }
                         }
                         Err(e) => {
                             let err = DynamicTableBackendError::Initialization(format!(

--- a/crates/streamling-core/src/dynamic_table/postgres.rs
+++ b/crates/streamling-core/src/dynamic_table/postgres.rs
@@ -804,56 +804,65 @@ impl PostgresDynamicTableBackend {
                         "Creating PostgreSQL dynamic table: {}",
                         self.full_table_name
                     );
-                    let create_result = sqlx::query(
-                        format!(
-                            r#"
+                    let create_table_sql = format!(
+                        r#"
                             CREATE TABLE IF NOT EXISTS {} (
                                 "{}" TEXT PRIMARY KEY,
                                 "{}" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CLOCK_TIMESTAMP()
                             );
                         "#,
-                            self.full_table_name, self.column_name, self.time_column_name
-                        )
-                        .as_str(),
-                    )
-                    .execute(pool_arc.as_ref())
-                    .await;
+                        self.full_table_name, self.column_name, self.time_column_name
+                    );
+                    let bare_table = self
+                        .full_table_name
+                        .rsplit_once('.')
+                        .map(|(_, table)| table)
+                        .unwrap_or(self.full_table_name.as_str());
+                    let index_name = format!("idx_{}_{}", bare_table, self.time_column_name);
+                    let create_index_sql = format!(
+                        r#"CREATE INDEX IF NOT EXISTS "{}" ON {} ("{}")"#,
+                        index_name, self.full_table_name, self.time_column_name
+                    );
 
-                    match create_result {
-                        Ok(_) => {
-                            info!("Successfully created table: {}", self.full_table_name);
-                            let bare_table = self
-                                .full_table_name
-                                .rsplit_once('.')
-                                .map(|(_, table)| table)
-                                .unwrap_or(self.full_table_name.as_str());
-                            let index_name =
-                                format!("idx_{}_{}", bare_table, self.time_column_name);
-                            let create_index_sql = format!(
-                                r#"CREATE INDEX IF NOT EXISTS "{}" ON {} ("{}")"#,
-                                index_name, self.full_table_name, self.time_column_name
-                            );
-                            if let Err(e) = sqlx::query(&create_index_sql)
-                                .execute(pool_arc.as_ref())
-                                .await
-                            {
-                                let err = DynamicTableBackendError::Initialization(format!(
-                                    "Failed to create index {} on table {}: {}",
-                                    index_name, self.full_table_name, e
-                                ));
-                                error!("{}", err);
-                                return Err(err);
-                            }
-                        }
-                        Err(e) => {
+                    let mut transaction = pool_arc.begin().await.map_err(|e| {
+                        let err = DynamicTableBackendError::Initialization(format!(
+                            "Failed to begin transaction for table {}: {}",
+                            self.full_table_name, e
+                        ));
+                        error!("{}", err);
+                        err
+                    })?;
+                    sqlx::query(&create_table_sql)
+                        .execute(&mut *transaction)
+                        .await
+                        .map_err(|e| {
                             let err = DynamicTableBackendError::Initialization(format!(
                                 "Failed to create table {}: {}",
                                 self.full_table_name, e
                             ));
                             error!("{}", err);
-                            return Err(err);
-                        }
-                    }
+                            err
+                        })?;
+                    sqlx::query(&create_index_sql)
+                        .execute(&mut *transaction)
+                        .await
+                        .map_err(|e| {
+                            let err = DynamicTableBackendError::Initialization(format!(
+                                "Failed to create index {} on table {}: {}",
+                                index_name, self.full_table_name, e
+                            ));
+                            error!("{}", err);
+                            err
+                        })?;
+                    transaction.commit().await.map_err(|e| {
+                        let err = DynamicTableBackendError::Initialization(format!(
+                            "Failed to commit transaction for table {}: {}",
+                            self.full_table_name, e
+                        ));
+                        error!("{}", err);
+                        err
+                    })?;
+                    info!("Successfully created table: {}", self.full_table_name);
                 } else {
                     debug!(
                         "Table {} already exists, skipping creation",

--- a/crates/streamling-core/src/topology.rs
+++ b/crates/streamling-core/src/topology.rs
@@ -488,6 +488,11 @@ pub struct DynamicTableTransform {
     pub schema: Option<String>,
     pub column: Option<String>,
     pub time_column: Option<String>,
+    /// Opt-in caching for this dynamic table. When omitted, falls back to the
+    /// global `dynamic_table_backend.postgres.cache_enabled` config. Caching is
+    /// only ever active when `time_column` is set.
+    #[serde(default)]
+    pub cache: Option<bool>,
     pub telemetry: Option<Telemetry>,
 }
 
@@ -1085,6 +1090,56 @@ data_format: avro
 {extra}
 "#
         )
+    }
+
+    #[test]
+    fn dynamic_table_cache_defaults_to_none_and_parses_explicit() {
+        // When `cache` is omitted the field is None (falls back to global).
+        let yaml = r#"
+sources:
+  src: { type: kafka, topic: t, primary_key: id }
+transforms:
+  dt_omitted:
+    type: dynamic_table
+    backend_type: Postgres
+    backend_entity_name: tbl
+    time_column: updated_at
+sinks: {}
+"#;
+        let topology = PipelineTopology::load_from_string(yaml).unwrap();
+        match topology.transforms.get("dt_omitted").unwrap() {
+            Transform::dynamic_table(dt) => assert_eq!(dt.cache, None),
+            _ => panic!("expected dynamic_table transform"),
+        }
+
+        // An explicit topology-level value is preserved.
+        let yaml = r#"
+sources:
+  src: { type: kafka, topic: t, primary_key: id }
+transforms:
+  dt_on:
+    type: dynamic_table
+    backend_type: Postgres
+    backend_entity_name: tbl
+    time_column: updated_at
+    cache: true
+  dt_off:
+    type: dynamic_table
+    backend_type: Postgres
+    backend_entity_name: tbl2
+    time_column: updated_at
+    cache: false
+sinks: {}
+"#;
+        let topology = PipelineTopology::load_from_string(yaml).unwrap();
+        match topology.transforms.get("dt_on").unwrap() {
+            Transform::dynamic_table(dt) => assert_eq!(dt.cache, Some(true)),
+            _ => panic!("expected dynamic_table transform"),
+        }
+        match topology.transforms.get("dt_off").unwrap() {
+            Transform::dynamic_table(dt) => assert_eq!(dt.cache, Some(false)),
+            _ => panic!("expected dynamic_table transform"),
+        }
     }
 
     #[test]

--- a/crates/streamling-e2e/tests/dynamic_table.rs
+++ b/crates/streamling-e2e/tests/dynamic_table.rs
@@ -641,6 +641,50 @@ async fn test_postgres_dynamic_table_cache_loads_and_refreshes_after_append() {
     );
 }
 
+#[tokio::test]
+async fn test_postgres_dynamic_table_creates_time_column_index() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("failed to create test context");
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("failed to register schema");
+    ctx.kafka
+        .produce_avro_records(&[record("indexed_member")])
+        .await
+        .expect("failed to produce dynamic-table value");
+
+    let status = ctx
+        .run_pipeline_with_opts(
+            &append_pipeline(&ctx, "indexed_members", true),
+            cached_postgres_opts(&ctx, 1, Duration::from_secs(30)),
+        )
+        .await
+        .expect("pipeline failed");
+    assert!(status.success(), "pipeline should exit successfully");
+
+    let index_count = ctx
+        .postgres
+        .query::<(i64,)>(
+            r#"
+            SELECT COUNT(*)::bigint FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND tablename = 'indexed_members'
+              AND indexdef LIKE '%updated_at%'
+            "#,
+        )
+        .await
+        .expect("failed to query pg_indexes");
+    assert_eq!(
+        index_count,
+        [(1,)],
+        "fresh Streamling-created table should index the time column"
+    );
+}
+
 /// Verify that deduplication in the uncached `contains()` path produces identical
 /// results for duplicate values. This exercises the exact code path the dedup
 /// changes: with MAX_BATCH_SIZE=3 and 6 total values (3 unique), without dedup

--- a/crates/streamling/src/lib.rs
+++ b/crates/streamling/src/lib.rs
@@ -1072,6 +1072,7 @@ impl Streamling {
                             schema,
                             column,
                             time_column,
+                            dt.cache,
                         )
                         .await
                         .map_err(|e| {

--- a/crates/streamling/src/topology_sort.rs
+++ b/crates/streamling/src/topology_sort.rs
@@ -625,6 +625,7 @@ mod tests {
             schema: None,
             column: None,
             time_column: None,
+            cache: None,
             telemetry: None,
         });
         transforms.insert("dynamic_table1".to_string(), dynamic_table1);
@@ -636,6 +637,7 @@ mod tests {
             schema: None,
             column: None,
             time_column: None,
+            cache: None,
             telemetry: None,
         });
         transforms.insert("dynamic_table2".to_string(), dynamic_table2);
@@ -663,6 +665,7 @@ mod tests {
                 schema: None,
                 column: None,
                 time_column: None,
+                cache: None,
                 telemetry: None,
             });
         transforms.insert("independent_dynamic".to_string(), independent_dynamic);
@@ -712,6 +715,7 @@ mod tests {
             schema: None,
             column: None,
             time_column: None,
+            cache: None,
             telemetry: None,
         });
         transforms.insert("filtered_market".to_string(), filtered_market);
@@ -1184,6 +1188,7 @@ mod tests {
             schema: None,
             column: None,
             time_column: None,
+            cache: None,
             telemetry: None,
         });
         transforms.insert("hot_wallets".to_string(), dt);


### PR DESCRIPTION
## Problem

`PostgresDynamicTableBackend` creates dynamic tables like this:

```sql
CREATE TABLE IF NOT EXISTS <table> (
    "<value_column>" TEXT PRIMARY KEY,
    "<time_column>"  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CLOCK_TIMESTAMP()
);
```

The value column gets an implicit btree from the PRIMARY KEY. **The time column gets nothing.**

That column is on the hot path whenever `cache_enabled` is set:

- `latest_update()` runs `SELECT MAX("<time_column>")` on **every** `contains()` call, including empty and all-null batches
- `load_cache()` runs `WHERE "<time_column>" > $1` on every incremental refresh

Unindexed, both are sequential scans. On a multi-million-row table that means a seq scan per record batch — the cache degrades worst on exactly the tables it exists to help. `validate_cache_time_column()` doesn't catch it either: it runs `... WHERE "<time_col>" >= CURRENT_TIMESTAMP AND FALSE`, which proves the column exists and is orderable but never scans, so enabling the cache on an unindexed table succeeds silently.

Today the README just tells you to add the index by hand.

## Change

Create the index as part of table creation:

```sql
CREATE INDEX IF NOT EXISTS "idx_<table>_<time_column>" ON <table> ("<time_column>")
```

Naming follows the existing precedent in `utils/pg.rs:445`.

Two deliberate scoping decisions:

- **Only on the creation path.** This sits inside the existing `if !table_exists` branch. Building an index on a live multi-million-row table during startup takes a `SHARE` lock and blocks writes, so tables Streamling did not create are left untouched — those still need the manual index, and the README now says so.
- **Not gated on `cache_enabled`.** The table is empty at creation so the index is free, and the flag can be switched on later.

## Verification

`cargo fmt --check`, `cargo check -p streamling-core`, `cargo check -p streamling-e2e --tests`, and `cargo clippy -p streamling-core -p streamling-e2e --all-targets -- -D warnings -A clippy::result_large_err` (matching the CI invocation) all pass.

The emitted DDL was run against `postgres:15-alpine` directly. It is valid, idempotent on a second run, and produces the intended plan on 50k rows:

```
 Result
   InitPlan 1 (returns $0)
     ->  Limit
           ->  Index Only Scan Backward using idx_indexed_members_updated_at on indexed_members
                 Index Cond: (updated_at IS NOT NULL)
```

Previously a `Seq Scan`.

`test_postgres_dynamic_table_creates_time_column_index` in `crates/streamling-e2e/tests/dynamic_table.rs` asserts the index exists on a freshly created cached table. It compiles, but I did not execute it locally — the e2e harness needs a k3s cluster and a release `streamling` binary, so the e2e job is the gate on it.