### PR TITLE
feat(kafka): support starting a source from a timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,29 @@ sources:
     topic: app.events
 ```
 
+**Starting position.** `starting_offsets` controls where a partition starts when the state backend holds no offset for
+it. Partitions that do have a persisted offset always resume from it, so this only applies on a first run (or to a
+partition added later).
+
+```yaml
+sources:
+  raw_events:
+    type: kafka
+    topic: app.events
+    starting_offsets: 2025-08-01T12:00:00Z
+```
+
+| Value | Behaviour |
+| --- | --- |
+| `earliest` (default) | Start at the oldest retained message |
+| `latest` | Start at the end of the partition — only messages produced from now on |
+| A datetime, e.g. `2025-08-01T12:00:00Z` | Start at the first message timestamped at or after that instant. `2025-08-01 12:00:00` and `2025-08-01` also work; a value without an offset is read as UTC |
+| Epoch milliseconds, e.g. `1754049600000` | Same as above. Must be milliseconds — a seconds-sized value is rejected rather than silently rewinding to 1970 |
+
+With a timestamp, the source asks the brokers for each partition's first offset at or after that instant before it
+starts consuming. A partition with no message that late starts at its end, so it picks up whatever arrives next.
+Partitions assigned later by a rebalance fall back to `earliest` (the timestamp is only resolved at startup).
+
 **JSON format.** Set `data_format: json` (the default is `avro`) and declare the input schema as a `column → type` map.
 Each Kafka message payload is treated as a single UTF-8 JSON object (one row); Schema Registry is not used.
 
@@ -1243,7 +1266,7 @@ The state backend plays a crucial role in Kafka source reliability:
   - On startup, Kafka source:
     - Queries state backend for stored offsets
     - Seeks to stored positions if found
-    - Starts from configured position (earliest/latest) for new partitions
+    - Starts from the configured `starting_offsets` position (earliest/latest/timestamp) for new partitions
 
 ## Error Handling
 

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -21,6 +21,7 @@ use crate::table_providers::kafka::schema_registry::{
     retry_registry_call,
 };
 use apache_avro::Schema as AvroSchema;
+use arrow::compute::kernels::cast_utils::string_to_timestamp_nanos;
 use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
 use datafusion::arrow::array::{RecordBatch, StringArray};
@@ -284,6 +285,86 @@ impl FromStr for KafkaFormat {
             "avro" => Ok(KafkaFormat::Avro),
             "json" => Ok(KafkaFormat::Json),
             _ => Err(streamling_user_err!("unsupported Kafka format: {}", s)),
+        }
+    }
+}
+
+/// Where a Kafka source starts reading a partition when it has no persisted offset.
+///
+/// Parsed from the source's `starting_offsets` (`start_at` on a hybrid source):
+/// - `earliest` (the default) or `latest`, plus librdkafka's aliases for both
+/// - an epoch-millisecond timestamp, e.g. `1754049600000`
+/// - a datetime, e.g. `2025-08-01T12:00:00Z`, `2025-08-01 12:00:00` or `2025-08-01`
+///   (a value without an offset is read as UTC)
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum KafkaStartPosition {
+    #[default]
+    Earliest,
+    Latest,
+    /// Start at the first message whose Kafka timestamp is >= this epoch-millisecond
+    /// value. Partitions with no such message start at the end of the partition.
+    Timestamp(i64),
+}
+
+/// Smallest epoch-millisecond value accepted for a timestamp start position
+/// (1973-03-03). A number below it is almost always epoch *seconds* by mistake,
+/// which would silently rewind the source to the start of the topic.
+const MIN_START_TIMESTAMP_MS: i64 = 100_000_000_000;
+
+impl KafkaStartPosition {
+    /// The `auto.offset.reset` policy to configure on the consumer.
+    ///
+    /// Startup always seeks explicitly, so this only covers partitions we never
+    /// seek — e.g. ones handed to us by a rebalance after startup. A timestamp
+    /// position falls back to `earliest` so a late-assigned partition replays
+    /// from the beginning rather than skipping the backlog.
+    fn auto_offset_reset(&self) -> &'static str {
+        match self {
+            Self::Latest => "latest",
+            Self::Earliest | Self::Timestamp(_) => "earliest",
+        }
+    }
+}
+
+impl FromStr for KafkaStartPosition {
+    type Err = StreamlingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let value = s.trim();
+        match value.to_lowercase().as_str() {
+            // The three spellings librdkafka accepts for each end of the topic,
+            // since this value used to be passed straight to `auto.offset.reset`.
+            "earliest" | "smallest" | "beginning" => return Ok(Self::Earliest),
+            "latest" | "largest" | "end" => return Ok(Self::Latest),
+            _ => {}
+        }
+
+        if let Ok(epoch_ms) = value.parse::<i64>() {
+            if epoch_ms < MIN_START_TIMESTAMP_MS {
+                streamling_user_bail!(
+                    "starting_offsets '{}' is too small to be an epoch-millisecond timestamp \
+                     (expected at least {}): pass the timestamp in milliseconds, or use \
+                     'earliest' to start at the beginning of the topic",
+                    value,
+                    MIN_START_TIMESTAMP_MS
+                );
+            }
+            return Ok(Self::Timestamp(epoch_ms));
+        }
+
+        match string_to_timestamp_nanos(value) {
+            Ok(nanos) if nanos >= 0 => Ok(Self::Timestamp(nanos / 1_000_000)),
+            Ok(_) => streamling_user_bail!(
+                "starting_offsets '{}' is before the Unix epoch; use 'earliest' to start at the \
+                 beginning of the topic",
+                value
+            ),
+            Err(_) => streamling_user_bail!(
+                "unsupported starting_offsets '{}': expected 'earliest', 'latest', a datetime \
+                 (e.g. '2025-08-01T12:00:00Z'), or an epoch-millisecond timestamp \
+                 (e.g. 1754049600000)",
+                value
+            ),
         }
     }
 }
@@ -592,7 +673,7 @@ struct KafkaSourceExec {
     should_enrich_op_column: bool,
     kafka_config: KafkaConfig,
     topic: String,
-    start_at: Option<String>,
+    start_at: KafkaStartPosition,
     filter: Option<String>,
     cached_properties: Arc<PlanProperties>,
     record_batch_interval_ms: u64,
@@ -640,7 +721,7 @@ impl KafkaSourceExec {
         payload_schema: SchemaRef,
         config: KafkaConfig,
         topic: String,
-        start_at: Option<String>,
+        start_at: KafkaStartPosition,
         filter: Option<String>,
         decoding: KafkaSourceDecoding,
         should_enrich_op_column: bool,
@@ -703,7 +784,7 @@ impl KafkaSourceExec {
 
     fn create_consumer(
         config: &KafkaConfig,
-        starting_offsets: &Option<String>,
+        start_at: KafkaStartPosition,
         reference_name: &str,
         is_lag_consumer: bool,
     ) -> StreamConsumer {
@@ -727,10 +808,7 @@ impl KafkaSourceExec {
             .set("group.id", group_id)
             .set("enable.auto.commit", "false")
             // .set("debug", "all") // enable for debugging
-            .set(
-                "auto.offset.reset",
-                starting_offsets.as_deref().unwrap_or("earliest"),
-            );
+            .set("auto.offset.reset", start_at.auto_offset_reset());
 
         let kafka_config_optimizer = KafkaConfigOptimizer::new(config);
         kafka_config_optimizer
@@ -853,6 +931,129 @@ impl KafkaSourceExec {
         }
 
         state_topic_partition_list
+    }
+
+    /// Build the partition list to seek to when the state backend holds no
+    /// offsets for this source, i.e. the configured start position applied to
+    /// every assigned partition.
+    fn resolve_start_offsets(
+        consumer: &StreamConsumer,
+        topic: &str,
+        start_at: KafkaStartPosition,
+    ) -> streamling_core::error::Result<KafkaTopicPartitionList> {
+        let mut assignment = consumer.assignment().streamling_with_context(|| {
+            format!("failed to get consumer assignment (topic: {})", topic)
+        })?;
+
+        let target_offset = match start_at {
+            KafkaStartPosition::Earliest => Offset::Beginning,
+            KafkaStartPosition::Latest => Offset::End,
+            KafkaStartPosition::Timestamp(timestamp_ms) => {
+                return Self::resolve_offsets_for_timestamp(
+                    consumer,
+                    topic,
+                    &assignment,
+                    timestamp_ms,
+                );
+            }
+        };
+
+        assignment
+            .set_all_offsets(target_offset)
+            .streamling_with_context(|| {
+                format!(
+                    "failed to set offsets to {:?} (topic: {})",
+                    target_offset, topic
+                )
+            })?;
+
+        Ok(assignment)
+    }
+
+    /// Ask the brokers which offset each partition's first message at or after
+    /// `timestamp_ms` sits at.
+    ///
+    /// librdkafka reads the target timestamp out of each element's offset field
+    /// and replaces it with the resolved offset, or with `Offset::End` when the
+    /// partition holds no message that late (an empty partition, or a timestamp
+    /// past the last message) — so those partitions start streaming from
+    /// whatever arrives next.
+    fn resolve_offsets_for_timestamp(
+        consumer: &StreamConsumer,
+        topic: &str,
+        assignment: &KafkaTopicPartitionList,
+        timestamp_ms: i64,
+    ) -> streamling_core::error::Result<KafkaTopicPartitionList> {
+        let mut query = assignment.clone();
+        query
+            .set_all_offsets(Offset::Offset(timestamp_ms))
+            .streamling_with_context(|| {
+                format!(
+                    "failed to set lookup timestamp {} (topic: {})",
+                    timestamp_ms, topic
+                )
+            })?;
+
+        let resolved = consumer
+            .offsets_for_times(
+                query,
+                Timeout::After(Duration::from_secs(CONSUMER_SEEK_TIMEOUT_SEC)),
+            )
+            .streamling_with_context(|| {
+                format!(
+                    "failed to look up offsets for timestamp {} (topic: {})",
+                    timestamp_ms, topic
+                )
+            })?;
+
+        let mut to_seek = KafkaTopicPartitionList::new();
+        for topic_partition in resolved.elements() {
+            if let Err(e) = topic_partition.error() {
+                return Err(streamling_err!(
+                    "failed to look up offset for timestamp {} (topic: {}, partition: {}): {}",
+                    timestamp_ms,
+                    topic_partition.topic(),
+                    topic_partition.partition(),
+                    e
+                ));
+            }
+
+            // `Invalid` isn't a documented outcome of the lookup and can't be
+            // seeked to, so treat it the same as "nothing at or after the
+            // timestamp" instead of failing the source.
+            let offset = match topic_partition.offset() {
+                Offset::Invalid => {
+                    warn!(
+                        "No offset resolved for timestamp {} (topic: {}, partition: {}), starting at the end of the partition",
+                        timestamp_ms,
+                        topic_partition.topic(),
+                        topic_partition.partition()
+                    );
+                    Offset::End
+                }
+                offset => offset,
+            };
+
+            debug!(
+                "Timestamp {} resolved to topic: {}, partition: {}, offset: {:?}",
+                timestamp_ms,
+                topic_partition.topic(),
+                topic_partition.partition(),
+                offset
+            );
+
+            to_seek
+                .add_partition_offset(topic_partition.topic(), topic_partition.partition(), offset)
+                .streamling_with_context(|| {
+                    format!(
+                        "failed to record resolved offset (topic: {}, partition: {})",
+                        topic_partition.topic(),
+                        topic_partition.partition()
+                    )
+                })?;
+        }
+
+        Ok(to_seek)
     }
 }
 
@@ -1151,7 +1352,7 @@ impl ExecutionPlan for KafkaSourceExec {
 
         let consumer = SafeKafkaConsumer::new(Self::create_consumer(
             &self.kafka_config,
-            &self.start_at,
+            self.start_at,
             &self.reference_name,
             false,
         ));
@@ -1249,7 +1450,7 @@ impl ExecutionPlan for KafkaSourceExec {
                 .full_schema_projected
                 .field_with_name(COLUMN_NAME_OP)
                 .is_ok();
-        let start_at = self.start_at.clone();
+        let start_at = self.start_at;
         let mut shutdown_rx = self.shutdown_rx.clone();
         let num_records_before_stop = self.num_records_before_stop;
         let metric_metadata_id = self.metric_metadata_id.clone();
@@ -1260,7 +1461,7 @@ impl ExecutionPlan for KafkaSourceExec {
         // (the documented deadlock the main consumer is already protected from).
         let lag_consumer = SafeKafkaConsumer::new(Self::create_consumer(
             &self.kafka_config,
-            &self.start_at,
+            self.start_at,
             &self.reference_name,
             true,
         ));
@@ -1333,29 +1534,14 @@ impl ExecutionPlan for KafkaSourceExec {
                 committed_offsets = Some(kafka_topic_partition_list_to_seek);
             } else {
                 // No offsets found in the state backend, so we need to seek to the configured
-                // starting position (earliest/latest) for all assigned partitions
-                let target_offset = match start_at.as_deref() {
-                    Some("latest") => Offset::End,
-                    _ => Offset::Beginning, // "earliest" or default
-                };
+                // starting position (earliest/latest/timestamp) for all assigned partitions
+                debug!("No state found, seeking all partitions to start_at={:?}", start_at);
 
-                debug!(
-                    "No state found, seeking all partitions to {:?}",
-                    target_offset
-                );
-
-                // Get the current assignment and set all partitions to the target offset
-                let mut assignment = consumer
-                    .assignment()
-                    .streamling_with_context(|| format!("failed to get consumer assignment (topic: {})", topic))?;
-
-                assignment
-                    .set_all_offsets(target_offset)
-                    .streamling_with_context(|| format!("failed to set offsets to {:?} (topic: {})", target_offset, topic))?;
+                let assignment = Self::resolve_start_offsets(&consumer, &topic, start_at)?;
 
                 let seek_result = consumer
                     .seek_partitions(assignment, Timeout::After(Duration::from_secs(CONSUMER_SEEK_TIMEOUT_SEC)))
-                    .streamling_with_context(|| format!("failed to seek partitions to {:?} (topic: {})", target_offset, topic))?;
+                    .streamling_with_context(|| format!("failed to seek partitions to start_at={:?} (topic: {})", start_at, topic))?;
 
                 let mut seek_count = 0usize;
                 for topic_partition in seek_result.elements() {
@@ -1375,7 +1561,7 @@ impl ExecutionPlan for KafkaSourceExec {
                 }
                 debug!(
                     "Seeked {} partitions of topic '{}' to start_at={:?}",
-                    seek_count, topic, target_offset
+                    seek_count, topic, start_at
                 );
             }
 
@@ -1756,7 +1942,7 @@ pub struct KafkaSourceTableProvider {
     metric_metadata_id: String,
     config: KafkaConfig,
     topic: String,
-    start_at: Option<String>, // TODO: use enum
+    start_at: KafkaStartPosition,
     filter: Option<String>,
     full_schema: SchemaRef,
     payload_schema: SchemaRef,
@@ -1833,6 +2019,13 @@ impl KafkaSourceTableProvider {
         format: KafkaFormat,
         json_schema: Option<BTreeMap<String, String>>,
     ) -> Result<Self> {
+        // Parse the start position up front so a bad value fails validation
+        // instead of surfacing as a librdkafka config error at execute time.
+        let start_at = match start_at.as_deref() {
+            Some(value) => value.parse::<KafkaStartPosition>()?,
+            None => KafkaStartPosition::default(),
+        };
+
         let (payload_schema, decoding, extracted_primary_key) = match format {
             KafkaFormat::Avro => {
                 if json_schema.is_some() {
@@ -2029,7 +2222,7 @@ impl KafkaSourceTableProvider {
         payload_schema: SchemaRef,
         config: KafkaConfig,
         topic: String,
-        start_at: Option<String>,
+        start_at: KafkaStartPosition,
         filter: Option<String>,
         decoding: KafkaSourceDecoding,
         should_enrich_op_column: bool,
@@ -2236,7 +2429,7 @@ impl TableProvider for KafkaSourceTableProvider {
             self.payload_schema.clone(),
             self.config.clone(),
             self.topic.clone(),
-            self.start_at.clone(),
+            self.start_at,
             self.filter.clone(),
             self.decoding.clone(),
             self.should_enrich_op_column,
@@ -3026,6 +3219,91 @@ impl TableProvider for KafkaSinkTableProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn parse_start_at(value: &str) -> KafkaStartPosition {
+        value
+            .parse::<KafkaStartPosition>()
+            .unwrap_or_else(|e| panic!("'{}' should parse: {}", value, e))
+    }
+
+    #[test]
+    fn start_position_parses_topic_boundaries() {
+        for value in ["earliest", "smallest", "beginning", " EARLIEST "] {
+            assert_eq!(parse_start_at(value), KafkaStartPosition::Earliest);
+        }
+        for value in ["latest", "largest", "end", "Latest"] {
+            assert_eq!(parse_start_at(value), KafkaStartPosition::Latest);
+        }
+        assert_eq!(KafkaStartPosition::default(), KafkaStartPosition::Earliest);
+    }
+
+    #[test]
+    fn start_position_parses_epoch_millis() {
+        assert_eq!(
+            parse_start_at("1754049600000"),
+            KafkaStartPosition::Timestamp(1_754_049_600_000)
+        );
+    }
+
+    #[test]
+    fn start_position_parses_datetimes_as_utc() {
+        // Same instant expressed three ways: RFC 3339, a space separator with no
+        // zone (read as UTC), and an explicit offset.
+        assert_eq!(
+            parse_start_at("2025-08-01T12:00:00Z"),
+            KafkaStartPosition::Timestamp(1_754_049_600_000)
+        );
+        assert_eq!(
+            parse_start_at("2025-08-01 12:00:00"),
+            KafkaStartPosition::Timestamp(1_754_049_600_000)
+        );
+        assert_eq!(
+            parse_start_at("2025-08-01T14:00:00+02:00"),
+            KafkaStartPosition::Timestamp(1_754_049_600_000)
+        );
+    }
+
+    /// A timestamp passed in seconds would otherwise resolve to 1970 and rewind
+    /// the source to the start of the topic, which is the opposite of what a
+    /// user asking for "start here" wants.
+    #[test]
+    fn start_position_rejects_epoch_seconds() {
+        let err = "1754049600"
+            .parse::<KafkaStartPosition>()
+            .expect_err("epoch seconds must be rejected");
+        assert!(
+            err.to_string().contains("milliseconds"),
+            "error should point at milliseconds, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn start_position_rejects_unparseable_values() {
+        for value in ["", "yesterday", "error", "2025-13-45"] {
+            let err = match value.parse::<KafkaStartPosition>() {
+                Ok(parsed) => panic!("'{}' must be rejected, parsed as {:?}", value, parsed),
+                Err(e) => e.to_string(),
+            };
+            assert!(
+                err.contains("starting_offsets"),
+                "error should name the setting, got: {}",
+                err
+            );
+        }
+    }
+
+    /// A timestamp start still needs a reset policy for partitions assigned
+    /// after startup (a rebalance), and replaying is safer than skipping.
+    #[test]
+    fn timestamp_start_falls_back_to_earliest_reset() {
+        assert_eq!(
+            KafkaStartPosition::Timestamp(1_754_049_600_000).auto_offset_reset(),
+            "earliest"
+        );
+        assert_eq!(KafkaStartPosition::Earliest.auto_offset_reset(), "earliest");
+        assert_eq!(KafkaStartPosition::Latest.auto_offset_reset(), "latest");
+    }
 
     /// A topology-level source `filter:` is defined against the source's full
     /// payload schema. When the engine pushes a scan projection that prunes a

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -994,22 +994,31 @@ impl KafkaSourceExec {
                 )
             })?;
 
+        // Retriable: this is a ListOffsets round-trip to the brokers, so a blip
+        // here is transient and a restart resolves it — unlike a bad config
+        // value, which is already rejected when the source is constructed. Same
+        // reasoning as the assignment timeout in `wait_for_assignment`.
         let resolved = consumer
             .offsets_for_times(
                 query,
                 Timeout::After(Duration::from_secs(CONSUMER_SEEK_TIMEOUT_SEC)),
             )
-            .streamling_with_context(|| {
-                format!(
-                    "failed to look up offsets for timestamp {} (topic: {})",
-                    timestamp_ms, topic
+            .map_err(|e| {
+                streamling_retriable_err!(
+                    "failed to look up offsets for timestamp {} (topic: {}): {}",
+                    timestamp_ms,
+                    topic,
+                    e
                 )
             })?;
 
         let mut to_seek = KafkaTopicPartitionList::new();
         for topic_partition in resolved.elements() {
+            // Per-partition lookup failures are broker-side error codes (an
+            // unavailable leader, a partition still settling after a rebalance),
+            // so they are retriable for the same reason as the call itself.
             if let Err(e) = topic_partition.error() {
-                return Err(streamling_err!(
+                return Err(streamling_retriable_err!(
                     "failed to look up offset for timestamp {} (topic: {}, partition: {}): {}",
                     timestamp_ms,
                     topic_partition.topic(),

--- a/crates/streamling-core/src/topology.rs
+++ b/crates/streamling-core/src/topology.rs
@@ -101,6 +101,8 @@ pub struct HybridUnboundedSource {
     pub source_type: String,
     pub topic: String,
     pub filter: Option<String>,
+    /// Mirrors `KafkaSource::starting_offsets` for the hybrid path: `earliest`/`latest`,
+    /// an epoch-millisecond timestamp, or a datetime.
     pub start_at: Option<String>,
     /// Mirrors `KafkaSource::validate_writer_schema_ordering` for the hybrid path.
     /// Defaults to true when omitted.
@@ -153,6 +155,15 @@ impl HybridOffsetTable {
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct KafkaSource {
     pub topic: String,
+    /// Where to start reading a partition that has no persisted offset. Ignored for
+    /// partitions the state backend already holds an offset for — those always resume.
+    ///
+    /// Accepts `earliest` (the default) or `latest`, an epoch-millisecond timestamp
+    /// (e.g. `1754049600000`), or a datetime (e.g. `2025-08-01T12:00:00Z`,
+    /// `2025-08-01 12:00:00`, `2025-08-01` — a value without an offset is read as UTC).
+    ///
+    /// With a timestamp, each partition starts at its first message timestamped at or
+    /// after that instant; a partition with no such message starts at its end.
     pub starting_offsets: Option<String>,
     pub include_metadata: Option<bool>,
     pub filter: Option<String>,

--- a/crates/streamling-e2e/tests/kafka_source.rs
+++ b/crates/streamling-e2e/tests/kafka_source.rs
@@ -251,3 +251,93 @@ sinks:
     ids.sort();
     assert_eq!(ids, vec![1, 2, 3]);
 }
+
+/// `starting_offsets` given as a timestamp must skip everything produced before
+/// that instant: the source resolves the timestamp to a concrete offset per
+/// partition before it starts consuming, instead of replaying the topic.
+#[tokio::test]
+async fn kafka_json_source_starts_from_timestamp() {
+    init_tracing();
+
+    let ctx = TestContext::new()
+        .await
+        .expect("Failed to create test context");
+
+    let record = |id: i64, name: &str| JsonRecord {
+        id,
+        name: name.to_string(),
+        amount: id as f64,
+        active: true,
+    };
+
+    // Two batches separated by a gap wide enough that the cutoff below lands
+    // strictly between their producer-assigned timestamps.
+    let before: Vec<JsonRecord> = vec![record(1, "before-one"), record(2, "before-two")];
+    ctx.kafka
+        .produce_json_records(&before)
+        .await
+        .expect("Failed to produce the pre-cutoff records");
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    let cutoff_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock is after the Unix epoch")
+        .as_millis() as u64;
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let after: Vec<JsonRecord> = vec![record(3, "after-one"), record(4, "after-two")];
+    ctx.kafka
+        .produce_json_records(&after)
+        .await
+        .expect("Failed to produce the post-cutoff records");
+
+    let pipeline = format!(
+        r#"
+sources:
+  kafka_source:
+    type: kafka
+    topic: {topic}
+    starting_offsets: "{cutoff_ms}"
+    primary_key: id
+    data_format: json
+    schema:
+      id: int64
+      name: string
+      amount: float64
+      active: boolean
+
+transforms: {{}}
+
+sinks:
+  print_sink:
+    type: print
+    from: kafka_source
+    sample_every: 1
+"#,
+        topic = ctx.kafka_topic,
+        cutoff_ms = cutoff_ms,
+    );
+
+    let output = ctx
+        .run_pipeline_with_capture(
+            &pipeline,
+            PipelineOpts::new()
+                .record_limit(after.len() as u64)
+                .env("STREAMLING__RECORD_BATCH_SIZE", "1")
+                .timeout(std::time::Duration::from_secs(60)),
+        )
+        .await
+        .expect("Pipeline execution failed");
+
+    let mut ids: Vec<i64> = output
+        .column_values("id")
+        .iter()
+        .filter_map(|v| v.as_i64())
+        .collect();
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![3, 4],
+        "only records produced at or after the cutoff timestamp should be read"
+    );
+}


### PR DESCRIPTION
## Why

`starting_offsets` accepted only `earliest` and `latest`. Recovering a pipeline from a known point in time — after a bad deploy, a schema incident, a backfill boundary — meant replaying the entire topic or skipping the backlog outright. Neither is what you want when you know the instant you care about.

## What

`starting_offsets` now also accepts an instant:

```yaml
sources:
  raw_events:
    type: kafka
    topic: app.events
    starting_offsets: 2025-08-01T12:00:00Z   # or "1754049600000"
```

| Value | Behaviour |
| --- | --- |
| `earliest` (default) | Oldest retained message |
| `latest` | End of the partition |
| A datetime | First message timestamped at or after that instant. `2025-08-01 12:00:00` and `2025-08-01` also work; no offset means UTC |
| Epoch milliseconds | Same. Must be milliseconds |

Each partition is resolved through `offsets_for_times` before consuming starts. A partition holding no message that late starts at its end, so it picks up whatever arrives next.

The same value works as `start_at` on a hybrid source's Kafka phase.

## Notable decisions

- **Parsed once, up front.** The string becomes a `KafkaStartPosition` enum in `KafkaSourceTableProvider::new` — filling the old `// TODO: use enum` — so a bad value fails config validation (and `--validate`) instead of surfacing as a librdkafka config error at execute time.
- **A seconds-sized number is rejected**, with an error naming milliseconds. Accepting `1754049600` would resolve to 1970 and rewind the source to the start of the topic — the exact opposite of "start here", and silent.
- **`auto.offset.reset` is derived from the parsed position.** A timestamp maps to `earliest`, so a partition handed over by a rebalance after startup replays rather than skips. The timestamp itself is only resolved at startup — same scope as the existing `latest` behaviour.
- **`Offset::Invalid` from the lookup is treated as "nothing that late"** (start at the end) rather than failing the source; a genuine broker error on an element still fails.

## Compatibility

- Persisted offsets keep precedence, unchanged: a partition with state in the backend always resumes from it and never consults `starting_offsets`.
- librdkafka's `smallest`/`beginning`/`largest`/`end` aliases still parse.
- One behaviour change: `starting_offsets: error` no longer loads. It previously passed validation and then silently seeked to the beginning of the topic.

## Testing

- 6 new unit tests on the parser (boundaries and aliases, epoch millis, the three datetime spellings resolving to one instant, seconds rejection, unparseable values, reset-policy fallback). All 31 kafka unit tests pass.
- `cargo clippy --all-targets` clean on connectors + core; fmt clean.
- **`kafka_json_source_starts_from_timestamp` (e2e) is written but was not run locally** — the k3s e2e stack wasn't up on my machine. It produces two batches around a cutoff and asserts only the post-cutoff rows are read. The broker-side `offsets_for_times` path is therefore unverified until this runs; worth a look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
