### PR TITLE
feat: add to_base58 scalar UDF (_gs_to_base58)

### DIFF
--- a/crates/streamling-common/src/functions.rs
+++ b/crates/streamling-common/src/functions.rs
@@ -21,6 +21,7 @@ use crate::functions::json_objects_to_clickhouse_tuples::JsonObjectsToClickhouse
 use crate::functions::keccak256::Keccak256Func;
 use crate::functions::now::VolatileNowFunc;
 use crate::functions::split_string_to_array::SplitStringToArrayFunc;
+use crate::functions::to_base58::ToBase58Func;
 use crate::functions::to_large_list::ToLargeListFunc;
 use crate::functions::u256_ops::{
     ToU256Func, U256AddFunc, U256DivFunc, U256ModFunc, U256MulFunc, U256SubFunc, U256ToStringFunc,
@@ -51,6 +52,7 @@ pub mod json_string;
 pub mod keccak256;
 pub mod now;
 pub mod split_string_to_array;
+pub mod to_base58;
 pub mod to_large_list;
 pub mod u256_ops;
 pub mod util;
@@ -84,6 +86,7 @@ impl CommonFunctions {
             create_from_base58_udf(),
             ScalarUDF::from(HexToByteFunc::new()),
             ScalarUDF::from(ByteToHexFunc::new()),
+            ScalarUDF::from(ToBase58Func::new()),
             ScalarUDF::from(ReverseBytes32Func::new()),
             create_gs_map_to_array_struct_udf(),
             // U256 functions

--- a/crates/streamling-common/src/functions/to_base58.rs
+++ b/crates/streamling-common/src/functions/to_base58.rs
@@ -1,0 +1,159 @@
+use crate::functions::util::unary_binary_to_string;
+use arrow_schema::FieldRef;
+use datafusion::arrow::datatypes::DataType;
+use datafusion::common::Result;
+use datafusion::logical_expr::{
+    ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
+use std::sync::Arc;
+
+/// Encodes byte arrays to Base58 strings.
+///
+/// Takes a byte array and converts it to its Base58 string representation.
+/// This is the inverse of `from_base58`. Returns null for null inputs.
+///
+/// # Arguments
+/// * `bytes` - The byte array to encode
+///
+/// # Returns
+/// A Base58 string representation of the bytes
+///
+/// # Examples
+/// * `to_base58([72, 101, 108, 108, 111])` returns `'9Ajdvzr'` (Base58 for "Hello")
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct ToBase58Func {
+    signature: Signature,
+}
+
+impl Default for ToBase58Func {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ToBase58Func {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::exact(vec![DataType::Binary], Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for ToBase58Func {
+    fn name(&self) -> &str {
+        "_gs_to_base58"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn return_field_from_args(&self, _args: ReturnFieldArgs) -> Result<FieldRef> {
+        Ok(Arc::new(arrow_schema::Field::new(
+            self.name(),
+            DataType::Utf8,
+            false,
+        )))
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        unary_binary_to_string(&args, self.name(), |bytes| {
+            bs58::encode(bytes).into_string()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{Array, BinaryArray, StringArray};
+
+    fn invoke(values: Vec<Option<&[u8]>>) -> StringArray {
+        let func = ToBase58Func::new();
+        let len = values.len();
+        let binary_array = BinaryArray::from(values);
+
+        let args = ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(Arc::new(binary_array))],
+            arg_fields: vec![Arc::new(arrow_schema::Field::new(
+                "bytes",
+                DataType::Binary,
+                false,
+            ))],
+            number_rows: len,
+            return_field: Arc::new(arrow_schema::Field::new("result", DataType::Utf8, false)),
+            config_options: ::std::sync::Arc::new(::datafusion::config::ConfigOptions::default()),
+        };
+
+        let result = func.invoke_with_args(args).unwrap();
+        if let ColumnarValue::Array(result_array) = result {
+            result_array
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap()
+                .clone()
+        } else {
+            panic!("Expected array result");
+        }
+    }
+
+    #[test]
+    fn test_to_base58_basic() {
+        let string_array = invoke(vec![
+            Some(b"Hello"),
+            Some(&[]),
+            None,
+            // Leading zero bytes encode as leading '1's
+            Some(&[0, 0, 0xde, 0xad]),
+        ]);
+
+        // "Hello" to Base58
+        assert_eq!(string_array.value(0), "9Ajdvzr");
+
+        // Empty bytes to empty string
+        assert_eq!(string_array.value(1), "");
+
+        // Null returns null
+        assert!(string_array.is_null(2));
+
+        // Leading zero bytes become leading '1's
+        assert_eq!(string_array.value(3), "11Hwr");
+    }
+
+    #[test]
+    fn test_to_base58_known_vector() {
+        // 32-byte value (e.g. a Solana account key) with a known Base58 encoding
+        let bytes: [u8; 32] = [1; 32];
+        let string_array = invoke(vec![Some(&bytes)]);
+        assert_eq!(string_array.value(0), bs58::encode(&bytes).into_string(),);
+        assert_eq!(
+            string_array.value(0),
+            "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi"
+        );
+    }
+
+    #[test]
+    fn test_to_base58_round_trip_with_from_base58() {
+        let original: &[u8] = &[0, 1, 2, 3, 0xff, 0xde, 0xad, 0xbe, 0xef];
+        let string_array = invoke(vec![Some(original)]);
+        let encoded = string_array.value(0);
+
+        // from_base58 decodes back to the original bytes
+        let decoded = bs58::decode(encoded).into_vec().unwrap();
+        assert_eq!(decoded.as_slice(), original);
+
+        let input = StringArray::from(vec![Some(encoded)]);
+        let args = vec![ColumnarValue::Array(Arc::new(input))];
+        let result = crate::functions::from_base58::from_base58_impl(&args).unwrap();
+        if let ColumnarValue::Array(result_array) = result {
+            let binary_array = result_array.as_any().downcast_ref::<BinaryArray>().unwrap();
+            assert_eq!(binary_array.value(0), original);
+        } else {
+            panic!("Expected array result");
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Core ships `_gs_from_base58` (Utf8 → Binary) and `_gs_byte_to_hex` (encode-direction precedent), but no base58 **encode** primitive. Any SQL transform over a Binary column — and future byte-native datasets — has no way to produce base58 output, while ClickHouse consumers get `base58Encode` natively. This adds the encode twin of `from_base58` for symmetry and consumer-facing enablement.

## Change

- New `ToBase58Func` (`_gs_to_base58`): `Binary → Utf8` via the `bs58` crate streamling-common already depends on, registered in `CommonFunctions` alongside `from_base58`/`byte_to_hex`.
- Mirrors `ByteToHexFunc` exactly: `Signature::exact(vec![DataType::Binary])`, null in → null out via `unary_binary_to_string`. Utf8 input is deliberately **not** accepted (`byte_to_hex` doesn't accept it either); pass bytes explicitly.
- Encoding cannot fail, so unlike `from_base58` there is no invalid-input fallback path.

## Tests

Unit tests in `to_base58.rs`: basic values, empty bytes → empty string, null → null, leading zero bytes → leading `'1'`s, 32-byte known vector (`4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi`), and a round-trip through `from_base58_impl`.

`cargo test -p streamling-common to_base58` green; `just fix && just lint` clean.
