### PR TITLE
ci: restrict image publish to main and pin actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/workflows/** @goldsky-io/core

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,12 +1,11 @@
 name: AI Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review]
 permissions:
   contents: read
   pull-requests: write
-  id-token: write
 
 # Cancel in-progress reviews when new commits are pushed
 concurrency:
@@ -18,22 +17,19 @@ jobs:
   # Job 1: Deterministic risk scoring (fast, free)
   # ──────────────────────────────────────────────────────────────────────
   risk-scoring:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       risk_json: ${{ steps.score.outputs.risk_json }}
       overall_risk: ${{ steps.score.outputs.overall_risk }}
       risk_level: ${{ steps.score.outputs.risk_level }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.base.sha }}
 
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -48,7 +44,7 @@ jobs:
       - name: Compute risk scores
         id: score
         run: |
-          BASE_REF=$(git merge-base origin/${{ github.event.pull_request.base.ref }} HEAD 2>/dev/null || echo "origin/${{ github.event.pull_request.base.ref }}")
+          BASE_REF=HEAD
           echo "Using base ref: $BASE_REF"
 
           python scripts/ai-review/risk_score.py \
@@ -61,7 +57,7 @@ jobs:
           echo "overall_risk=$(jq -r .overall_risk risk_report.json)" >> "$GITHUB_OUTPUT"
           echo "risk_level=$(jq -r .risk_level risk_report.json)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: risk-report
           path: risk_report.json
@@ -71,19 +67,18 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────
   claude-review:
     needs: [risk-scoring]
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-      issues: write
-      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
+          ref: ${{ github.event.pull_request.base.sha }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: risk-report
 
@@ -125,7 +120,7 @@ jobs:
               f.write('risk_table<<EOF\n' + table + '\nEOF\n')
           "
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@833fb0f8c9f6686b33d963a8bae0a94f4936ab2a # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_sticky_comment: true

--- a/.github/workflows/plugin-examples.yml
+++ b/.github/workflows/plugin-examples.yml
@@ -7,6 +7,9 @@ on:
       - ".github/workflows/plugin-examples.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate-and-test:
     runs-on: blacksmith-8vcpu-ubuntu-2204
@@ -14,13 +17,14 @@ jobs:
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: "10G"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Configure Rust toolchain
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@06e5a564a0556e338780f5aecf2e7dcc9b267f07 # 1.90.0
         with:
+          toolchain: 1.90.0
           components: clippy, rustfmt
       - name: Install sccache
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@1ed6d7be6168f6c9046541087ff549b6bc581fdf # v2
         with:
           tool: sccache
       - name: Set SCCACHE_DIR env
@@ -28,7 +32,7 @@ jobs:
       - name: Prepare sccache dir
         run: mkdir -p "$SCCACHE_DIR"
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.SCCACHE_DIR }}
           key: sccache-plugin_examples-${{ runner.os }}-1.90.0-${{ github.ref_name }}-${{ github.sha }}
@@ -37,7 +41,7 @@ jobs:
             sccache-plugin_examples-${{ runner.os }}-1.90.0-main-
 
       - name: Setup rust cache (plugin_examples/basic)
-        uses: useblacksmith/rust-cache@v3
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
         with:
           shared-key: "plugin-examples"
           workspaces: |

--- a/.github/workflows/streamling-bench.yml
+++ b/.github/workflows/streamling-bench.yml
@@ -27,6 +27,9 @@ on:
         required: false
         default: "1"
 
+permissions:
+  contents: read
+
 concurrency:
   group: streamling-bench
   cancel-in-progress: false
@@ -38,11 +41,13 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       BENCH_RUNNER_LABEL: blacksmith-8vcpu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Configure Rust toolchain
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@06e5a564a0556e338780f5aecf2e7dcc9b267f07 # 1.90.0
+        with:
+          toolchain: 1.90.0
       - name: Setup rust cache
-        uses: useblacksmith/rust-cache@v3
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
         with:
           shared-key: "v0-streamling-bench"
           cache-targets: true
@@ -56,9 +61,9 @@ jobs:
 
       # Infrastructure setup (mirrors the e2e job).
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Set up Docker Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@9309da73a81f66976a6d750572e221508b1e2682 # v1
       - name: Pre-pull benchmark images
         run: |
           set -euo pipefail
@@ -109,7 +114,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bench-results
           path: bench-results/

--- a/.github/workflows/streamling-release.yml
+++ b/.github/workflows/streamling-release.yml
@@ -12,6 +12,9 @@ name: streamling-release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: streamling-release
   cancel-in-progress: false
@@ -37,13 +40,14 @@ jobs:
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: "10G"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Configure Rust toolchain
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@06e5a564a0556e338780f5aecf2e7dcc9b267f07 # 1.90.0
         with:
+          toolchain: 1.90.0
           components: clippy, rustfmt
       - name: Install sccache
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@1ed6d7be6168f6c9046541087ff549b6bc581fdf # v2
         with:
           tool: sccache
       - name: Set SCCACHE_DIR env
@@ -51,14 +55,14 @@ jobs:
       - name: Prepare sccache dir
         run: mkdir -p "$SCCACHE_DIR"
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.SCCACHE_DIR }}
           key: sccache-release-${{ runner.os }}-1.90.0-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             sccache-release-${{ runner.os }}-1.90.0-
       - name: Setup rust cache
-        uses: useblacksmith/rust-cache@v3
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
         with:
           shared-key: "streamling-release-test"
           cache-targets: true
@@ -67,7 +71,7 @@ jobs:
         run: |
           cargo fmt --check
           cargo clippy --locked --all-targets --all-features -- -D warnings --A clippy::result_large_err
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@1ed6d7be6168f6c9046541087ff549b6bc581fdf # v2
         with:
           tool: nextest
       - name: Run unit tests
@@ -88,9 +92,11 @@ jobs:
       version: ${{ steps.resolve.outputs.version }}
       tag: ${{ steps.resolve.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Configure Rust toolchain
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@06e5a564a0556e338780f5aecf2e7dcc9b267f07 # 1.90.0
+        with:
+          toolchain: 1.90.0
       - name: Resolve version from Cargo metadata
         id: resolve
         run: |
@@ -138,19 +144,21 @@ jobs:
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Cache release-optimized binary
         id: bin-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: target/release-optimized/streamling
           key: release-opt-bin-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('crates/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/config.toml') }}
       - name: Configure Rust toolchain
         if: steps.bin-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@06e5a564a0556e338780f5aecf2e7dcc9b267f07 # 1.90.0
+        with:
+          toolchain: 1.90.0
       - name: Install sccache
         if: steps.bin-cache.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@1ed6d7be6168f6c9046541087ff549b6bc581fdf # v2
         with:
           tool: sccache
       - name: Set SCCACHE_DIR env
@@ -161,7 +169,7 @@ jobs:
         run: mkdir -p "$SCCACHE_DIR"
       - name: Cache sccache
         if: steps.bin-cache.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.SCCACHE_DIR }}
           key: sccache-release-opt-${{ matrix.os }}-${{ matrix.arch }}-1.90.0-${{ hashFiles('Cargo.lock') }}
@@ -169,7 +177,7 @@ jobs:
             sccache-release-opt-${{ matrix.os }}-${{ matrix.arch }}-1.90.0-
       - name: Setup rust cache
         if: steps.bin-cache.outputs.cache-hit != 'true'
-        uses: useblacksmith/rust-cache@v3
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
         with:
           shared-key: "v0-release-opt-${{ matrix.os }}-${{ matrix.arch }}"
           cache-targets: true
@@ -187,7 +195,7 @@ jobs:
         if: steps.bin-cache.outputs.cache-hit != 'true'
         run: sccache --show-stats || true
       - name: Upload release binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-binary-${{ matrix.os }}-${{ matrix.arch }}
           path: target/release-optimized/streamling
@@ -210,19 +218,21 @@ jobs:
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Cache release-optimized binary
         id: bin-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: target/release-optimized/streamling
           key: release-opt-bin-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('crates/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/config.toml') }}
       - name: Configure Rust toolchain
         if: steps.bin-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@06e5a564a0556e338780f5aecf2e7dcc9b267f07 # 1.90.0
+        with:
+          toolchain: 1.90.0
       - name: Setup rust cache
         if: steps.bin-cache.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           shared-key: "v0-release-opt-darwin-${{ matrix.arch }}"
           cache-targets: true
@@ -233,7 +243,7 @@ jobs:
         env:
           CARGO_INCREMENTAL: 0
       - name: Upload release binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-binary-${{ matrix.os }}-${{ matrix.arch }}
           path: target/release-optimized/streamling
@@ -253,19 +263,21 @@ jobs:
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Cache release-optimized binary
         id: bin-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: target/release-optimized/streamling.exe
           key: release-opt-bin-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('crates/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml', '.cargo/config.toml') }}
       - name: Configure Rust toolchain
         if: steps.bin-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@06e5a564a0556e338780f5aecf2e7dcc9b267f07 # 1.90.0
+        with:
+          toolchain: 1.90.0
       - name: Setup rust cache
         if: steps.bin-cache.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           shared-key: "v0-release-opt-windows-${{ matrix.arch }}"
           cache-targets: true
@@ -276,7 +288,7 @@ jobs:
       # cmake and Strawberry perl ship on the windows-2025 image; nasm does not.
       - name: Install NASM
         if: steps.bin-cache.outputs.cache-hit != 'true'
-        uses: ilammy/setup-nasm@v1
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1
       - name: Verify native build tools
         if: steps.bin-cache.outputs.cache-hit != 'true'
         run: |
@@ -289,7 +301,7 @@ jobs:
         env:
           CARGO_INCREMENTAL: 0
       - name: Upload release binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-binary-${{ matrix.os }}-${{ matrix.arch }}
           path: target/release-optimized/streamling.exe
@@ -306,9 +318,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Download all binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: release-binary-*-*
           path: release-artifacts/
@@ -341,7 +353,7 @@ jobs:
           done
           ls -la release-assets/
       - name: Publish release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ needs.version.outputs.tag }}
           name: ${{ needs.version.outputs.tag }}
@@ -364,11 +376,13 @@ jobs:
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Configure Rust toolchain
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@06e5a564a0556e338780f5aecf2e7dcc9b267f07 # 1.90.0
+        with:
+          toolchain: 1.90.0
       - name: Setup rust cache
-        uses: useblacksmith/rust-cache@v3
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
         with:
           shared-key: "streamling-release-publish"
           cache-targets: true

--- a/.github/workflows/streamling.yml
+++ b/.github/workflows/streamling.yml
@@ -11,15 +11,18 @@ on:
       - ".github/workflows/streamling.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
       core: ${{ steps.filter.outputs.core == 'true' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3
         with:
           token: ${{ github.token }}
           filters: |
@@ -46,13 +49,14 @@ jobs:
       RUSTC_WRAPPER: sccache
       SCCACHE_CACHE_SIZE: "10G"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Configure Rust toolchain
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@06e5a564a0556e338780f5aecf2e7dcc9b267f07 # 1.90.0
         with:
+          toolchain: 1.90.0
           components: clippy, rustfmt
       - name: Install sccache
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@1ed6d7be6168f6c9046541087ff549b6bc581fdf # v2
         with:
           tool: sccache
       - name: Set SCCACHE_DIR env
@@ -60,14 +64,14 @@ jobs:
       - name: Prepare sccache dir
         run: mkdir -p "$SCCACHE_DIR"
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.SCCACHE_DIR }}
           key: sccache-streamling-${{ runner.os }}-1.90.0-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             sccache-streamling-${{ runner.os }}-1.90.0-
       - name: Setup rust cache
-        uses: useblacksmith/rust-cache@v3
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
         with:
           shared-key: "streamling"
           cache-targets: true
@@ -76,7 +80,7 @@ jobs:
         run: |
           cargo fmt --check
           cargo clippy --locked --all-targets --all-features -- -D warnings --A clippy::result_large_err
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@1ed6d7be6168f6c9046541087ff549b6bc581fdf # v2
         with:
           tool: nextest
       - name: Run unit tests
@@ -108,13 +112,13 @@ jobs:
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # Try to restore a previously-built binary.
       # Key covers all source inputs that affect the build output.
       - name: Cache main binary
         id: main-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: target/release/streamling
           key: main-bin-v2-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('crates/**', 'Cargo.toml', 'Cargo.lock', 'rust-toolchain.toml') }}
@@ -122,10 +126,12 @@ jobs:
       # Everything below only runs on cache miss
       - name: Configure Rust toolchain
         if: steps.main-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@06e5a564a0556e338780f5aecf2e7dcc9b267f07 # 1.90.0
+        with:
+          toolchain: 1.90.0
       - name: Install sccache
         if: steps.main-cache.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@1ed6d7be6168f6c9046541087ff549b6bc581fdf # v2
         with:
           tool: sccache
       - name: Set SCCACHE_DIR env
@@ -136,7 +142,7 @@ jobs:
         run: mkdir -p "$SCCACHE_DIR"
       - name: Cache sccache
         if: steps.main-cache.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.SCCACHE_DIR }}
           key: sccache-main-${{ matrix.os }}-${{ matrix.arch }}-1.90.0-${{ hashFiles('Cargo.lock') }}
@@ -144,7 +150,7 @@ jobs:
             sccache-main-${{ matrix.os }}-${{ matrix.arch }}-1.90.0-
       - name: Setup rust cache
         if: steps.main-cache.outputs.cache-hit != 'true'
-        uses: useblacksmith/rust-cache@v3
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
         with:
           shared-key: "v0-release-main-${{ matrix.os }}-${{ matrix.arch }}"
           cache-targets: true
@@ -163,7 +169,7 @@ jobs:
         run: sccache --show-stats || true
 
       - name: Upload release binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-binary-${{ matrix.os }}-${{ matrix.arch }}
           path: target/release/streamling
@@ -177,12 +183,14 @@ jobs:
     env:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       # Rust toolchain + caching (needed to compile the e2e test crate)
       - name: Configure Rust toolchain
-        uses: dtolnay/rust-toolchain@1.90.0
+        uses: dtolnay/rust-toolchain@06e5a564a0556e338780f5aecf2e7dcc9b267f07 # 1.90.0
+        with:
+          toolchain: 1.90.0
       - name: Setup rust cache
-        uses: useblacksmith/rust-cache@v3
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
         with:
           shared-key: "v0-streamling-e2e"
           cache-targets: true
@@ -190,7 +198,7 @@ jobs:
 
       # Reuse the release binary from build-release-main instead of rebuilding.
       - name: Download release binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: release-binary-linux-x86_64
           path: release-artifacts/
@@ -202,9 +210,9 @@ jobs:
 
       # Infrastructure setup
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Set up Docker Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@9309da73a81f66976a6d750572e221508b1e2682 # v1
       - name: Pre-pull e2e images
         run: |
           set -euo pipefail
@@ -233,7 +241,7 @@ jobs:
         timeout-minutes: 5
 
       # Build and run e2e tests
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@1ed6d7be6168f6c9046541087ff549b6bc581fdf # v2
         with:
           tool: nextest
       - name: Build e2e tests
@@ -296,14 +304,14 @@ jobs:
             os: linux
             arch: aarch64
             image_arch: arm64
-    steps: &image_push_steps
+    steps:
       - name: Mask AWS account ID
         env:
           AWS_DEV_ACCOUNT_ID: ${{ secrets.AWS_DEV_ACCOUNT_ID }}
         run: echo "::add-mask::$AWS_DEV_ACCOUNT_ID"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Download release binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: release-binary-${{ matrix.os }}-${{ matrix.arch }}
           path: release-artifacts/
@@ -313,17 +321,17 @@ jobs:
           cp release-artifacts/streamling target/release/
           chmod +x target/release/streamling
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ vars.DEV_GHA_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Set up Docker Builder
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: useblacksmith/setup-docker-builder@9309da73a81f66976a6d750572e221508b1e2682 # v1
       - name: Generate tags
         id: generate_tags
         env:
@@ -339,34 +347,13 @@ jobs:
           echo "tag_sha=$TAG_SHA" >> "$GITHUB_OUTPUT"
           echo "tag_latest=$TAG_LATEST" >> "$GITHUB_OUTPUT"
       - name: Build and push Docker image (prebuilt artifacts)
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@9b0579bbec7a6cad2f171596c57e7ac1e7658850 # v2
         with:
           context: .
           file: Dockerfile
           push: true
           tags: ${{ steps.generate_tags.outputs.tags }}
           provenance: false
-
-  build-and-push-image-branch:
-    needs: [validate-and-test, build-release-main]
-    if: ${{ always() && github.ref_name != 'main' && needs.validate-and-test.result != 'failure' && needs.build-release-main.result == 'success' }}
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      id-token: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: blacksmith-8vcpu-ubuntu-2204
-            os: linux
-            arch: x86_64
-            image_arch: amd64
-          - runner: blacksmith-8vcpu-ubuntu-2204-arm
-            os: linux
-            arch: aarch64
-            image_arch: arm64
-    steps: *image_push_steps
 
   create-manifest-main:
     needs: [build-and-push-image-main]
@@ -381,57 +368,13 @@ jobs:
           AWS_DEV_ACCOUNT_ID: ${{ secrets.AWS_DEV_ACCOUNT_ID }}
         run: echo "::add-mask::$AWS_DEV_ACCOUNT_ID"
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ vars.DEV_GHA_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Create and push multi-arch manifest
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: streamling
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          SAFE_IMAGE_BRANCH=$(echo ${{ github.ref_name }} | tr / -)
-          TAG_SHA=$ECR_REGISTRY/$ECR_REPOSITORY:$SAFE_IMAGE_BRANCH-$IMAGE_TAG
-          TAG_LATEST=$ECR_REGISTRY/$ECR_REPOSITORY:$SAFE_IMAGE_BRANCH-latest
-
-          docker manifest create $TAG_SHA \
-            $TAG_SHA-amd64 \
-            $TAG_SHA-arm64
-          docker manifest push $TAG_SHA
-
-          docker manifest create $TAG_LATEST \
-            $TAG_LATEST-amd64 \
-            $TAG_LATEST-arm64
-          docker manifest push $TAG_LATEST
-
-          echo "Created multi-arch manifests:"
-          echo "  - $TAG_SHA"
-          echo "  - $TAG_LATEST"
-
-  create-manifest-branch:
-    needs: [build-and-push-image-branch]
-    if: ${{ always() && github.ref_name != 'main' && needs.build-and-push-image-branch.result == 'success' }}
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Mask AWS account ID
-        env:
-          AWS_DEV_ACCOUNT_ID: ${{ secrets.AWS_DEV_ACCOUNT_ID }}
-        run: echo "::add-mask::$AWS_DEV_ACCOUNT_ID"
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ vars.DEV_GHA_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2
       - name: Create and push multi-arch manifest
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -468,7 +411,7 @@ jobs:
       contents: write
     steps:
       - name: Download release binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: release-binary-*-*
           path: release-artifacts/

--- a/plugin_examples/basic/Cargo.lock
+++ b/plugin_examples/basic/Cargo.lock
@@ -4314,6 +4314,7 @@ dependencies = [
  "async-trait",
  "config",
  "futures",
+ "humantime",
  "percent-encoding",
  "schema_registry_converter",
  "serde",

--- a/plugin_examples/low_level/Cargo.lock
+++ b/plugin_examples/low_level/Cargo.lock
@@ -4317,6 +4317,7 @@ dependencies = [
  "async-trait",
  "config",
  "futures",
+ "humantime",
  "percent-encoding",
  "schema_registry_converter",
  "serde",


### PR DESCRIPTION
Image publish stays on `main`. Branch pushes still build and test.

- drop branch ECR publish jobs
- set workflow `permissions` to read by default
- run AI review from the base branch; do not check out the PR head
- pin third-party actions to commit SHAs
- add CODEOWNERS for `.github/workflows/**`

Branch image tags are no longer published. Use a `main` build if you need an image.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Grok](https://img.shields.io/badge/Grok_4.6-000000)