### PR TITLE
chore: point Maestro at the streamling baton workspace

### DIFF
--- a/.maestrorc.json
+++ b/.maestrorc.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://maestro.goldsky.com/maestrorc/schema",
+  "sandbox": {
+    "clone_strategy": "blobless",
+    "baton": {
+      "enabled": true,
+      "workspace_repo": "goldsky-io/streamling-workspace",
+      "workspace_ref": "main"
+    }
+  }
+}


### PR DESCRIPTION
Maestro sessions in this repo clone [goldsky-io/streamling-workspace](https://github.com/goldsky-io/streamling-workspace) instead of a single-repo sandbox.

Related to INFRA-6304