### PR TITLE
fix(hybrid): defer phase-state persistence until a covering checkpoint finalizes

### DIFF
--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -831,6 +832,29 @@ impl HybridTableProvider {
             }
         }
         drop(state);
+        // Deliberately NOT persisted here. The rows the finished phase emitted
+        // are not durable until a sink-acknowledged checkpoint covers them;
+        // persisting `completed_phases` now would make a restart skip them if
+        // the sink fails first (observed: sink unavailable at first start).
+        // `persist_phase_state` runs from the execute loop on the first
+        // Finalizer whose Marker was created after this transition.
+        Ok(())
+    }
+
+    /// Durably record the current phase state plus the Kafka seed offsets
+    /// handed over at the last transition. Only call once a checkpoint that
+    /// covers everything emitted before the transition has finalized.
+    pub async fn persist_phase_state(&self) -> DataFusionResult<()> {
+        if let Some(wrapping_provider) = self
+            .config
+            .unbounded_source
+            .downcast_ref::<WrappingSourceTableProvider>()
+            && let Some(kafka_provider) = wrapping_provider
+                .get_inner()
+                .downcast_ref::<KafkaSourceTableProvider>()
+        {
+            kafka_provider.persist_seeded_offsets().await?;
+        }
         self.save_state().await
     }
 
@@ -1024,6 +1048,18 @@ impl ExecutionPlan for HybridSourceExec {
         // to stay responsive to shutdown (same pattern as
         // `ClickHouseSourceExec::execute`'s `checkpointing_task`).
         let pending_for_drain = pending_markers.clone();
+
+        // Deferred phase-state persistence (see `advance_to_next_phase`): the
+        // main loop stamps `transition_at_ms` after a phase advance; the
+        // forwarder then waits for a Marker created after that instant and
+        // persists on that epoch's Finalizer. A Marker created after the last
+        // bounded batch was sent travels behind it, so its Finalizer proves
+        // every sink durably wrote the finished phase.
+        let transition_at_ms = Arc::new(AtomicU64::new(0));
+        let min_eligible_epoch = Arc::new(AtomicU64::new(u64::MAX));
+        let transition_for_drain = transition_at_ms.clone();
+        let eligible_for_drain = min_eligible_epoch.clone();
+        let provider_for_drain = provider.clone();
         let forwarder_handle = tokio::spawn(async move {
             loop {
                 let rx = hybrid_marker_rx.clone();
@@ -1035,6 +1071,36 @@ impl ExecutionPlan for HybridSourceExec {
                     _ = forwarder_shutdown_rx.changed() => break,
                     res = recv => match res {
                         Ok(Ok(msg)) => {
+                            match &msg {
+                                CheckpointMessage::Marker { epoch, created_at_ms } => {
+                                    let t = transition_for_drain.load(Ordering::SeqCst);
+                                    if t != 0 && *created_at_ms > t {
+                                        eligible_for_drain.fetch_min(epoch.0, Ordering::SeqCst);
+                                    }
+                                }
+                                CheckpointMessage::Finalizer(epoch) => {
+                                    if transition_for_drain.load(Ordering::SeqCst) != 0
+                                        && epoch.0 >= eligible_for_drain.load(Ordering::SeqCst)
+                                    {
+                                        match provider_for_drain.persist_phase_state().await {
+                                            Ok(()) => {
+                                                info!(
+                                                    "Hybrid source '{}': phase state persisted after epoch {} finalized",
+                                                    provider_for_drain.reference_name, epoch.0
+                                                );
+                                                transition_for_drain.store(0, Ordering::SeqCst);
+                                                eligible_for_drain.store(u64::MAX, Ordering::SeqCst);
+                                            }
+                                            Err(e) => warn!(
+                                                "Hybrid source '{}': deferred phase-state persist failed; \
+                                                 will retry on the next Finalizer: {:?}",
+                                                provider_for_drain.reference_name, e
+                                            ),
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            }
                             if matches!(
                                 msg,
                                 CheckpointMessage::Marker { .. }
@@ -1297,6 +1363,10 @@ impl ExecutionPlan for HybridSourceExec {
 
                 match provider.advance_to_next_phase().await {
                     Ok(()) => {
+                        // Arm the deferred persist: only a Marker created from
+                        // now on proves the finished phase is durable.
+                        min_eligible_epoch.store(u64::MAX, Ordering::SeqCst);
+                        transition_at_ms.store(now_ms(), Ordering::SeqCst);
                         let state = provider.state.read().await;
                         let now_unbounded =
                             state.current_phase >= provider.config.bounded_sources.len();
@@ -2881,7 +2951,8 @@ mod tests {
         )
         .unwrap();
 
-        let result = hybrid_provider.advance_to_next_phase().await;
+        hybrid_provider.advance_to_next_phase().await.unwrap();
+        let result = hybrid_provider.persist_phase_state().await;
         assert!(
             result.is_err(),
             "save_state should fail due to injected fault"
@@ -2931,6 +3002,62 @@ mod tests {
     }
 
     // ========================================================================
+    // Phase advance is not durable until persist_phase_state (first
+    // finalized checkpoint after the transition)
+    // ========================================================================
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_advance_to_next_phase_defers_persistence() {
+        let state_backend = create_state_backend("deferred_persist_test").await;
+        let config = HybridSourceConfig {
+            bounded_sources: vec![
+                Arc::new(MockTableProvider::new("bounded1".to_string())) as Arc<dyn TableProvider>
+            ],
+            unbounded_source: Arc::new(MockTableProvider::new("unbounded".to_string()))
+                as Arc<dyn TableProvider>,
+            offset_provider: Some(Arc::new(MockOffsetProvider::new(HashMap::from([(
+                0, 1000,
+            )])))),
+            job_mode: false,
+        };
+        let hybrid_provider = HybridTableProvider::new(
+            "test_hybrid".to_string(),
+            config,
+            create_test_schema(),
+            state_backend.clone(),
+            SESSION_MANAGER.clone(),
+        )
+        .unwrap();
+
+        hybrid_provider.advance_to_next_phase().await.unwrap();
+        assert_eq!(hybrid_provider.state.read().await.current_phase, 1);
+
+        // A sink failure between here and the first finalized checkpoint must
+        // leave a restart on phase 0, so the bounded rows are re-emitted.
+        let persisted = state_backend
+            .get(StateKey("hybrid_source_test_hybrid_v1".to_string()))
+            .await
+            .unwrap();
+        assert!(
+            persisted.is_none(),
+            "phase advance must not be durable before a finalized checkpoint"
+        );
+
+        hybrid_provider.persist_phase_state().await.unwrap();
+        let persisted = state_backend
+            .get(StateKey("hybrid_source_test_hybrid_v1".to_string()))
+            .await
+            .unwrap()
+            .expect("state persisted by persist_phase_state");
+        assert_eq!(persisted.current_phase, 1);
+        assert!(persisted.completed_phases[0]);
+        assert_eq!(
+            persisted.unbounded_offsets.as_ref().unwrap().get(&0),
+            Some(&1000)
+        );
+    }
+
+    // ========================================================================
     // FM1: hybrid state cleared, source silently regresses to phase 0
     // ========================================================================
 
@@ -2957,8 +3084,10 @@ mod tests {
         )
         .unwrap();
 
-        // Advance through bounded to unbounded
+        // Advance through bounded to unbounded, then persist (as the execute
+        // loop does once the covering checkpoint finalizes)
         hybrid_provider.advance_to_next_phase().await.unwrap();
+        hybrid_provider.persist_phase_state().await.unwrap();
         let state = hybrid_provider.state.read().await;
         assert_eq!(state.current_phase, 1, "should be in unbounded phase");
         drop(state);
@@ -3051,8 +3180,9 @@ mod tests {
         )
         .unwrap();
 
-        // advance_to_next_phase should succeed because retry recovers
-        let result = hybrid_provider.advance_to_next_phase().await;
+        hybrid_provider.advance_to_next_phase().await.unwrap();
+        // persist_phase_state should succeed because retry recovers
+        let result = hybrid_provider.persist_phase_state().await;
         assert!(
             result.is_ok(),
             "should succeed after retry: {:?}",
@@ -3107,7 +3237,8 @@ mod tests {
         )
         .unwrap();
 
-        let result = hybrid_provider.advance_to_next_phase().await;
+        hybrid_provider.advance_to_next_phase().await.unwrap();
+        let result = hybrid_provider.persist_phase_state().await;
         assert!(
             result.is_err(),
             "should fail after all retry attempts exhausted"

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1055,10 +1055,8 @@ impl ExecutionPlan for HybridSourceExec {
         // persists on that epoch's Finalizer. A Marker created after the last
         // bounded batch was sent travels behind it, so its Finalizer proves
         // every sink durably wrote the finished phase.
-        let transition_at_ms = Arc::new(AtomicU64::new(0));
-        let min_eligible_epoch = Arc::new(AtomicU64::new(u64::MAX));
-        let transition_for_drain = transition_at_ms.clone();
-        let eligible_for_drain = min_eligible_epoch.clone();
+        let gate = Arc::new(DeferredPersistGate::default());
+        let gate_for_drain = gate.clone();
         let provider_for_drain = provider.clone();
         let forwarder_handle = tokio::spawn(async move {
             loop {
@@ -1073,30 +1071,17 @@ impl ExecutionPlan for HybridSourceExec {
                         Ok(Ok(msg)) => {
                             match &msg {
                                 CheckpointMessage::Marker { epoch, created_at_ms } => {
-                                    let t = transition_for_drain.load(Ordering::SeqCst);
-                                    if t != 0 && *created_at_ms > t {
-                                        eligible_for_drain.fetch_min(epoch.0, Ordering::SeqCst);
-                                    }
+                                    gate_for_drain.observe_marker(epoch.0, *created_at_ms);
                                 }
                                 CheckpointMessage::Finalizer(epoch) => {
-                                    if transition_for_drain.load(Ordering::SeqCst) != 0
-                                        && epoch.0 >= eligible_for_drain.load(Ordering::SeqCst)
-                                    {
-                                        match provider_for_drain.persist_phase_state().await {
-                                            Ok(()) => {
-                                                info!(
-                                                    "Hybrid source '{}': phase state persisted after epoch {} finalized",
-                                                    provider_for_drain.reference_name, epoch.0
-                                                );
-                                                transition_for_drain.store(0, Ordering::SeqCst);
-                                                eligible_for_drain.store(u64::MAX, Ordering::SeqCst);
-                                            }
-                                            Err(e) => warn!(
-                                                "Hybrid source '{}': deferred phase-state persist failed; \
-                                                 will retry on the next Finalizer: {:?}",
-                                                provider_for_drain.reference_name, e
-                                            ),
-                                        }
+                                    if let Some(token) = gate_for_drain.covering_finalizer(epoch.0) {
+                                        persist_covered_phase_state(
+                                            &provider_for_drain,
+                                            &gate_for_drain,
+                                            token,
+                                            epoch.0,
+                                        )
+                                        .await;
                                     }
                                 }
                                 _ => {}
@@ -1326,7 +1311,7 @@ impl ExecutionPlan for HybridSourceExec {
                         warn!("Unbounded source stream ended, exiting hybrid source");
                     }
                     if let Some(control) = &checkpoint_control {
-                        emit_terminal_checkpoint(
+                        let finalized = emit_terminal_checkpoint(
                             control,
                             &pending_for_main,
                             &schema_for_synth,
@@ -1334,6 +1319,9 @@ impl ExecutionPlan for HybridSourceExec {
                             &reference_name_for_spawn,
                         )
                         .await;
+                        if finalized && let Some(token) = gate.covering_terminal() {
+                            persist_covered_phase_state(&provider, &gate, token, u64::MAX).await;
+                        }
                     }
                     break 'outer;
                 }
@@ -1349,7 +1337,7 @@ impl ExecutionPlan for HybridSourceExec {
                     );
                     provider.shutdown();
                     if let Some(control) = &checkpoint_control {
-                        emit_terminal_checkpoint(
+                        let finalized = emit_terminal_checkpoint(
                             control,
                             &pending_for_main,
                             &schema_for_synth,
@@ -1357,6 +1345,9 @@ impl ExecutionPlan for HybridSourceExec {
                             &reference_name_for_spawn,
                         )
                         .await;
+                        if finalized && let Some(token) = gate.covering_terminal() {
+                            persist_covered_phase_state(&provider, &gate, token, u64::MAX).await;
+                        }
                     }
                     break 'outer;
                 }
@@ -1365,8 +1356,7 @@ impl ExecutionPlan for HybridSourceExec {
                     Ok(()) => {
                         // Arm the deferred persist: only a Marker created from
                         // now on proves the finished phase is durable.
-                        min_eligible_epoch.store(u64::MAX, Ordering::SeqCst);
-                        transition_at_ms.store(now_ms(), Ordering::SeqCst);
+                        gate.arm(now_ms());
                         let state = provider.state.read().await;
                         let now_unbounded =
                             state.current_phase >= provider.config.bounded_sources.len();
@@ -1382,7 +1372,7 @@ impl ExecutionPlan for HybridSourceExec {
                             // rows are covered by a finalized checkpoint and the
                             // sinks flush + ack before teardown.
                             if let Some(control) = &checkpoint_control {
-                                emit_terminal_checkpoint(
+                                let finalized = emit_terminal_checkpoint(
                                     control,
                                     &pending_for_main,
                                     &schema_for_synth,
@@ -1390,6 +1380,10 @@ impl ExecutionPlan for HybridSourceExec {
                                     &reference_name_for_spawn,
                                 )
                                 .await;
+                                if finalized && let Some(token) = gate.covering_terminal() {
+                                    persist_covered_phase_state(&provider, &gate, token, u64::MAX)
+                                        .await;
+                                }
                             }
                             provider.shutdown();
                             break 'outer;
@@ -1577,13 +1571,129 @@ fn terminal_checkpoint_finalize_timeout() -> Duration {
 /// completion path that ends the stream immediately after this returns, and
 /// the only way the receiver is gone is that downstream already tore down —
 /// there is no caller decision an error could change.
+/// Decides when the in-memory phase advance made by
+/// `advance_to_next_phase` may be persisted.
+///
+/// `arm(now)` is called after an advance completes, i.e. after every batch
+/// of the finished phase was sent downstream. A coordinator Marker created
+/// after that instant travels behind those batches, so its Finalizer proves
+/// every sink durably wrote the finished phase; the first such Marker names
+/// the earliest covering epoch. `disarm` uses compare-exchange so a persist
+/// that completes after a newer arm cannot clobber it.
+#[derive(Debug, Default)]
+struct DeferredPersistGate {
+    /// Wall-clock ms of the last arm; 0 = not armed.
+    transition_at_ms: AtomicU64,
+    /// Earliest epoch whose Marker was created after `transition_at_ms`;
+    /// `u64::MAX` = none seen yet.
+    min_eligible_epoch: AtomicU64,
+}
+
+/// Snapshot handed from `covering_*` to `disarm`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GateToken {
+    transition_at_ms: u64,
+    min_eligible_epoch: u64,
+}
+
+impl DeferredPersistGate {
+    fn arm(&self, now_ms: u64) {
+        // Eligible first, then the stamp: a concurrent `disarm` for an older
+        // arm compares against the stamp, so it can never leave a stale
+        // eligible epoch behind a fresh stamp.
+        self.min_eligible_epoch.store(u64::MAX, Ordering::SeqCst);
+        self.transition_at_ms.store(now_ms, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    fn is_armed(&self) -> bool {
+        self.transition_at_ms.load(Ordering::SeqCst) != 0
+    }
+
+    fn observe_marker(&self, epoch: u64, created_at_ms: u64) {
+        let t = self.transition_at_ms.load(Ordering::SeqCst);
+        if t != 0 && created_at_ms > t {
+            self.min_eligible_epoch.fetch_min(epoch, Ordering::SeqCst);
+        }
+    }
+
+    /// `Some` if a Finalizer for `epoch` proves the armed transition durable.
+    fn covering_finalizer(&self, epoch: u64) -> Option<GateToken> {
+        let transition_at_ms = self.transition_at_ms.load(Ordering::SeqCst);
+        let min_eligible_epoch = self.min_eligible_epoch.load(Ordering::SeqCst);
+        (transition_at_ms != 0 && epoch >= min_eligible_epoch).then_some(GateToken {
+            transition_at_ms,
+            min_eligible_epoch,
+        })
+    }
+
+    /// A finalized terminal checkpoint always covers an armed transition:
+    /// its Marker is pushed inline after every row (it never travels on the
+    /// coordinator channel, so `observe_marker` never sees it).
+    fn covering_terminal(&self) -> Option<GateToken> {
+        let transition_at_ms = self.transition_at_ms.load(Ordering::SeqCst);
+        (transition_at_ms != 0).then_some(GateToken {
+            transition_at_ms,
+            min_eligible_epoch: self.min_eligible_epoch.load(Ordering::SeqCst),
+        })
+    }
+
+    /// Disarm only if no newer `arm` happened since `token` was taken.
+    fn disarm(&self, token: GateToken) {
+        if self
+            .transition_at_ms
+            .compare_exchange(
+                token.transition_at_ms,
+                0,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .is_ok()
+        {
+            let _ = self.min_eligible_epoch.compare_exchange(
+                token.min_eligible_epoch,
+                u64::MAX,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            );
+        }
+    }
+}
+
+/// Persist the phase advance guarded by `gate` using `token`, logging the
+/// outcome. On failure the gate stays armed so the next covering Finalizer
+/// retries.
+async fn persist_covered_phase_state(
+    provider: &HybridTableProvider,
+    gate: &DeferredPersistGate,
+    token: GateToken,
+    epoch: u64,
+) {
+    match provider.persist_phase_state().await {
+        Ok(()) => {
+            info!(
+                "Hybrid source '{}': phase state persisted after epoch {} finalized",
+                provider.reference_name, epoch
+            );
+            gate.disarm(token);
+        }
+        Err(e) => warn!(
+            "Hybrid source '{}': deferred phase-state persist failed after epoch {}; \
+             will retry on the next covering Finalizer: {:?}",
+            provider.reference_name, epoch, e
+        ),
+    }
+}
+
+/// Returns whether the terminal epoch finalized (and its Finalizer was
+/// emitted).
 async fn emit_terminal_checkpoint(
     control: &CheckpointControl,
     pending: &Arc<Mutex<Vec<CheckpointMessage>>>,
     schema_for_synth: &SchemaRef,
     tx: &tokio::sync::mpsc::Sender<DataFusionResult<RecordBatch>>,
     reference_name: &str,
-) {
+) -> bool {
     let terminal = control.begin_terminal_checkpoint();
 
     pending
@@ -1649,7 +1759,7 @@ async fn emit_terminal_checkpoint(
             "checkpoint_coordinator",
         )
         .record_count("checkpoint_terminal_finalizer_skipped", 1);
-        return;
+        return false;
     }
 
     pending
@@ -1657,6 +1767,7 @@ async fn emit_terminal_checkpoint(
         .expect("pending markers mutex poisoned")
         .push(CheckpointMessage::Finalizer(terminal));
     flush_pending_to_synth_batch(pending, schema_for_synth, tx, reference_name).await;
+    true
 }
 
 /// Flush any markers currently buffered in `pending` to the downstream
@@ -3055,6 +3166,72 @@ mod tests {
             persisted.unbounded_offsets.as_ref().unwrap().get(&0),
             Some(&1000)
         );
+    }
+
+    // ========================================================================
+    // DeferredPersistGate: which Finalizer may persist the phase advance
+    // ========================================================================
+
+    #[test]
+    fn gate_ignores_markers_created_before_the_transition() {
+        let gate = DeferredPersistGate::default();
+        gate.arm(1_000);
+        // Marker minted before (or at) the stamp may have been attached to a
+        // mid-phase batch: its Finalizer proves nothing about the tail.
+        gate.observe_marker(7, 900);
+        gate.observe_marker(8, 1_000);
+        assert!(gate.covering_finalizer(7).is_none());
+        assert!(gate.covering_finalizer(8).is_none());
+        // First Marker after the stamp names the earliest covering epoch.
+        gate.observe_marker(9, 1_001);
+        assert!(gate.covering_finalizer(8).is_none());
+        let token = gate.covering_finalizer(9).expect("epoch 9 covers");
+        assert!(
+            gate.covering_finalizer(10).is_some(),
+            "later epochs cover too"
+        );
+        gate.disarm(token);
+        assert!(!gate.is_armed());
+        assert!(gate.covering_finalizer(10).is_none());
+    }
+
+    #[test]
+    fn gate_not_armed_never_covers() {
+        let gate = DeferredPersistGate::default();
+        gate.observe_marker(1, 5_000);
+        assert!(gate.covering_finalizer(1).is_none());
+        assert!(gate.covering_terminal().is_none());
+    }
+
+    #[test]
+    fn gate_disarm_does_not_clobber_a_newer_arm() {
+        // Multi-bounded-phase race: the Finalizer for phase-0→1 is being
+        // persisted when phase 1 ends and re-arms for 1→2.
+        let gate = DeferredPersistGate::default();
+        gate.arm(1_000);
+        gate.observe_marker(5, 1_500);
+        let token = gate.covering_finalizer(5).expect("covers");
+        gate.arm(2_000); // persist still in flight
+        gate.disarm(token);
+        assert!(gate.is_armed(), "newer arm must survive the stale disarm");
+        assert!(
+            gate.covering_finalizer(5).is_none(),
+            "epochs from before the new arm must not cover it"
+        );
+        gate.observe_marker(6, 2_001);
+        assert!(gate.covering_finalizer(6).is_some());
+    }
+
+    #[test]
+    fn gate_terminal_covers_whenever_armed() {
+        let gate = DeferredPersistGate::default();
+        gate.arm(1_000);
+        // No channel Marker seen at all (terminal Marker travels inline).
+        let token = gate
+            .covering_terminal()
+            .expect("terminal covers an armed gate");
+        gate.disarm(token);
+        assert!(!gate.is_armed());
     }
 
     // ========================================================================

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -20,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use streamling_config::AppConfig;
 use streamling_core::checkpoints::channels::{subscribe_with_id, unsubscribe};
 use streamling_core::checkpoints::checkpoint_management::{
-    CHECKPOINT_COORDINATOR_CHANNEL, CheckpointControl, CheckpointMessage,
+    CHECKPOINT_COORDINATOR_CHANNEL, CheckpointControl, CheckpointEpoch, CheckpointMessage,
     enrich_batch_metadata_with_checkpoints, extract_checkpoint_messages, now_ms,
 };
 use streamling_core::data::COLUMN_NAME_OP;
@@ -704,8 +703,14 @@ impl HybridTableProvider {
     }
 
     async fn save_state(&self) -> DataFusionResult<()> {
-        let state = self.state.read().await;
-        info!("Saving hybrid source state: {:?}", *state);
+        let snapshot = self.state.read().await.clone();
+        self.save_state_snapshot(&snapshot).await
+    }
+
+    /// Write `state`, which is not necessarily the live state (see
+    /// `persist_phase_state`).
+    async fn save_state_snapshot(&self, state: &HybridSourceState) -> DataFusionResult<()> {
+        info!("Saving hybrid source state: {:?}", state);
 
         let key = StateKey(format!("hybrid_source_{}_v1", self.reference_name));
         let backoffs = [
@@ -841,21 +846,24 @@ impl HybridTableProvider {
         Ok(())
     }
 
-    /// Durably record the current phase state plus the Kafka seed offsets
-    /// handed over at the last transition. Only call once a checkpoint that
-    /// covers everything emitted before the transition has finalized.
-    pub async fn persist_phase_state(&self) -> DataFusionResult<()> {
-        if let Some(wrapping_provider) = self
-            .config
-            .unbounded_source
-            .downcast_ref::<WrappingSourceTableProvider>()
+    /// Durably record `snapshot` (the phase state as of a transition) plus
+    /// the Kafka seed offsets it carries. Only call once a checkpoint that
+    /// covers everything emitted before that transition has finalized. Takes
+    /// a snapshot rather than reading the live state because a later
+    /// transition may already have advanced it without being covered.
+    pub async fn persist_phase_state(&self, snapshot: &HybridSourceState) -> DataFusionResult<()> {
+        if let Some(offsets) = &snapshot.unbounded_offsets
+            && let Some(wrapping_provider) = self
+                .config
+                .unbounded_source
+                .downcast_ref::<WrappingSourceTableProvider>()
             && let Some(kafka_provider) = wrapping_provider
                 .get_inner()
                 .downcast_ref::<KafkaSourceTableProvider>()
         {
-            kafka_provider.persist_seeded_offsets().await?;
+            kafka_provider.persist_offsets_if_absent(offsets).await?;
         }
-        self.save_state().await
+        self.save_state_snapshot(snapshot).await
     }
 
     pub async fn get_current_execution_stream(
@@ -1319,8 +1327,10 @@ impl ExecutionPlan for HybridSourceExec {
                             &reference_name_for_spawn,
                         )
                         .await;
-                        if finalized && let Some(token) = gate.covering_terminal() {
-                            persist_covered_phase_state(&provider, &gate, token, u64::MAX).await;
+                        if let Some(terminal) = finalized
+                            && let Some(token) = gate.covering_terminal()
+                        {
+                            persist_covered_phase_state(&provider, &gate, token, terminal.0).await;
                         }
                     }
                     break 'outer;
@@ -1345,8 +1355,10 @@ impl ExecutionPlan for HybridSourceExec {
                             &reference_name_for_spawn,
                         )
                         .await;
-                        if finalized && let Some(token) = gate.covering_terminal() {
-                            persist_covered_phase_state(&provider, &gate, token, u64::MAX).await;
+                        if let Some(terminal) = finalized
+                            && let Some(token) = gate.covering_terminal()
+                        {
+                            persist_covered_phase_state(&provider, &gate, token, terminal.0).await;
                         }
                     }
                     break 'outer;
@@ -1356,8 +1368,8 @@ impl ExecutionPlan for HybridSourceExec {
                     Ok(()) => {
                         // Arm the deferred persist: only a Marker created from
                         // now on proves the finished phase is durable.
-                        gate.arm(now_ms());
                         let state = provider.state.read().await;
+                        gate.arm(now_ms(), state.clone());
                         let now_unbounded =
                             state.current_phase >= provider.config.bounded_sources.len();
                         drop(state);
@@ -1380,9 +1392,13 @@ impl ExecutionPlan for HybridSourceExec {
                                     &reference_name_for_spawn,
                                 )
                                 .await;
-                                if finalized && let Some(token) = gate.covering_terminal() {
-                                    persist_covered_phase_state(&provider, &gate, token, u64::MAX)
-                                        .await;
+                                if let Some(terminal) = finalized
+                                    && let Some(token) = gate.covering_terminal()
+                                {
+                                    persist_covered_phase_state(
+                                        &provider, &gate, token, terminal.0,
+                                    )
+                                    .await;
                                 }
                             }
                             provider.shutdown();
@@ -1571,111 +1587,117 @@ fn terminal_checkpoint_finalize_timeout() -> Duration {
 /// completion path that ends the stream immediately after this returns, and
 /// the only way the receiver is gone is that downstream already tore down —
 /// there is no caller decision an error could change.
-/// Decides when the in-memory phase advance made by
-/// `advance_to_next_phase` may be persisted.
+/// Decides when, and with what payload, the in-memory phase advance made
+/// by `advance_to_next_phase` may be persisted.
 ///
-/// `arm(now)` is called after an advance completes, i.e. after every batch
-/// of the finished phase was sent downstream. A coordinator Marker created
-/// after that instant travels behind those batches, so its Finalizer proves
-/// every sink durably wrote the finished phase; the first such Marker names
-/// the earliest covering epoch. `disarm` uses compare-exchange so a persist
-/// that completes after a newer arm cannot clobber it.
+/// `arm` is called right after an advance with a snapshot of the state that
+/// advance produced, i.e. after every batch of the finished phase was sent
+/// downstream. A coordinator Marker created after the arm travels behind
+/// those batches, so its Finalizer proves every sink durably wrote the
+/// finished phase; the first such Marker names the earliest covering epoch.
+///
+/// The persist writes the SNAPSHOT, never the live state: with several
+/// bounded phases the next phase may already have advanced in memory while
+/// the persist for the previous one is in flight, and writing that would
+/// mark rows durable that no checkpoint has covered yet. One mutex guards
+/// arm/observe/disarm so no interleaving pairs a fresh arm with a stale
+/// eligible epoch, and `disarm` clears only the generation it was issued
+/// for.
 #[derive(Debug, Default)]
-struct DeferredPersistGate {
-    /// Wall-clock ms of the last arm; 0 = not armed.
-    transition_at_ms: AtomicU64,
-    /// Earliest epoch whose Marker was created after `transition_at_ms`;
-    /// `u64::MAX` = none seen yet.
-    min_eligible_epoch: AtomicU64,
+struct DeferredPersistGate(Mutex<GateInner>);
+
+#[derive(Debug, Default)]
+struct GateInner {
+    /// Monotonic across arms; never reused, so a stale token can never
+    /// disarm a later arm.
+    generation: u64,
+    armed: Option<ArmedTransition>,
 }
 
-/// Snapshot handed from `covering_*` to `disarm`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct GateToken {
+#[derive(Debug, Clone)]
+struct ArmedTransition {
+    generation: u64,
     transition_at_ms: u64,
+    /// Earliest epoch whose Marker was created after `transition_at_ms`;
+    /// `u64::MAX` = none seen yet.
     min_eligible_epoch: u64,
+    /// State to persist once covered.
+    snapshot: HybridSourceState,
 }
 
 impl DeferredPersistGate {
-    fn arm(&self, now_ms: u64) {
-        // Eligible first, then the stamp: a concurrent `disarm` for an older
-        // arm compares against the stamp, so it can never leave a stale
-        // eligible epoch behind a fresh stamp.
-        self.min_eligible_epoch.store(u64::MAX, Ordering::SeqCst);
-        self.transition_at_ms.store(now_ms, Ordering::SeqCst);
+    fn lock(&self) -> std::sync::MutexGuard<'_, GateInner> {
+        self.0.lock().expect("deferred persist gate mutex poisoned")
+    }
+
+    fn arm(&self, now_ms: u64, snapshot: HybridSourceState) {
+        let mut inner = self.lock();
+        inner.generation += 1;
+        inner.armed = Some(ArmedTransition {
+            generation: inner.generation,
+            transition_at_ms: now_ms,
+            min_eligible_epoch: u64::MAX,
+            snapshot,
+        });
     }
 
     #[cfg(test)]
     fn is_armed(&self) -> bool {
-        self.transition_at_ms.load(Ordering::SeqCst) != 0
+        self.lock().armed.is_some()
     }
 
     fn observe_marker(&self, epoch: u64, created_at_ms: u64) {
-        let t = self.transition_at_ms.load(Ordering::SeqCst);
-        if t != 0 && created_at_ms > t {
-            self.min_eligible_epoch.fetch_min(epoch, Ordering::SeqCst);
+        if let Some(armed) = self.lock().armed.as_mut()
+            && created_at_ms > armed.transition_at_ms
+        {
+            armed.min_eligible_epoch = armed.min_eligible_epoch.min(epoch);
         }
     }
 
     /// `Some` if a Finalizer for `epoch` proves the armed transition durable.
-    fn covering_finalizer(&self, epoch: u64) -> Option<GateToken> {
-        let transition_at_ms = self.transition_at_ms.load(Ordering::SeqCst);
-        let min_eligible_epoch = self.min_eligible_epoch.load(Ordering::SeqCst);
-        (transition_at_ms != 0 && epoch >= min_eligible_epoch).then_some(GateToken {
-            transition_at_ms,
-            min_eligible_epoch,
-        })
+    fn covering_finalizer(&self, epoch: u64) -> Option<ArmedTransition> {
+        self.lock()
+            .armed
+            .as_ref()
+            .filter(|armed| epoch >= armed.min_eligible_epoch)
+            .cloned()
     }
 
     /// A finalized terminal checkpoint always covers an armed transition:
     /// its Marker is pushed inline after every row (it never travels on the
     /// coordinator channel, so `observe_marker` never sees it).
-    fn covering_terminal(&self) -> Option<GateToken> {
-        let transition_at_ms = self.transition_at_ms.load(Ordering::SeqCst);
-        (transition_at_ms != 0).then_some(GateToken {
-            transition_at_ms,
-            min_eligible_epoch: self.min_eligible_epoch.load(Ordering::SeqCst),
-        })
+    fn covering_terminal(&self) -> Option<ArmedTransition> {
+        self.lock().armed.clone()
     }
 
-    /// Disarm only if no newer `arm` happened since `token` was taken.
-    fn disarm(&self, token: GateToken) {
-        if self
-            .transition_at_ms
-            .compare_exchange(
-                token.transition_at_ms,
-                0,
-                Ordering::SeqCst,
-                Ordering::SeqCst,
-            )
-            .is_ok()
+    /// Disarm only if `armed` is still the current arm.
+    fn disarm(&self, armed: &ArmedTransition) {
+        let mut inner = self.lock();
+        if inner
+            .armed
+            .as_ref()
+            .is_some_and(|current| current.generation == armed.generation)
         {
-            let _ = self.min_eligible_epoch.compare_exchange(
-                token.min_eligible_epoch,
-                u64::MAX,
-                Ordering::SeqCst,
-                Ordering::SeqCst,
-            );
+            inner.armed = None;
         }
     }
 }
 
-/// Persist the phase advance guarded by `gate` using `token`, logging the
-/// outcome. On failure the gate stays armed so the next covering Finalizer
-/// retries.
+/// Persist the snapshot carried by `armed`, logging the outcome. On failure
+/// the gate stays armed so the next covering Finalizer retries.
 async fn persist_covered_phase_state(
     provider: &HybridTableProvider,
     gate: &DeferredPersistGate,
-    token: GateToken,
+    armed: ArmedTransition,
     epoch: u64,
 ) {
-    match provider.persist_phase_state().await {
+    match provider.persist_phase_state(&armed.snapshot).await {
         Ok(()) => {
             info!(
                 "Hybrid source '{}': phase state persisted after epoch {} finalized",
                 provider.reference_name, epoch
             );
-            gate.disarm(token);
+            gate.disarm(&armed);
         }
         Err(e) => warn!(
             "Hybrid source '{}': deferred phase-state persist failed after epoch {}; \
@@ -1685,15 +1707,15 @@ async fn persist_covered_phase_state(
     }
 }
 
-/// Returns whether the terminal epoch finalized (and its Finalizer was
-/// emitted).
+/// Returns the terminal epoch if it finalized (and its Finalizer was
+/// emitted), `None` otherwise.
 async fn emit_terminal_checkpoint(
     control: &CheckpointControl,
     pending: &Arc<Mutex<Vec<CheckpointMessage>>>,
     schema_for_synth: &SchemaRef,
     tx: &tokio::sync::mpsc::Sender<DataFusionResult<RecordBatch>>,
     reference_name: &str,
-) -> bool {
+) -> Option<CheckpointEpoch> {
     let terminal = control.begin_terminal_checkpoint();
 
     pending
@@ -1759,15 +1781,15 @@ async fn emit_terminal_checkpoint(
             "checkpoint_coordinator",
         )
         .record_count("checkpoint_terminal_finalizer_skipped", 1);
-        return false;
+        return None;
     }
 
     pending
         .lock()
         .expect("pending markers mutex poisoned")
-        .push(CheckpointMessage::Finalizer(terminal));
+        .push(CheckpointMessage::Finalizer(terminal.clone()));
     flush_pending_to_synth_batch(pending, schema_for_synth, tx, reference_name).await;
-    true
+    Some(terminal)
 }
 
 /// Flush any markers currently buffered in `pending` to the downstream
@@ -3063,7 +3085,9 @@ mod tests {
         .unwrap();
 
         hybrid_provider.advance_to_next_phase().await.unwrap();
-        let result = hybrid_provider.persist_phase_state().await;
+        let result = hybrid_provider
+            .persist_phase_state(&hybrid_provider.state.read().await.clone())
+            .await;
         assert!(
             result.is_err(),
             "save_state should fail due to injected fault"
@@ -3154,7 +3178,10 @@ mod tests {
             "phase advance must not be durable before a finalized checkpoint"
         );
 
-        hybrid_provider.persist_phase_state().await.unwrap();
+        hybrid_provider
+            .persist_phase_state(&hybrid_provider.state.read().await.clone())
+            .await
+            .unwrap();
         let persisted = state_backend
             .get(StateKey("hybrid_source_test_hybrid_v1".to_string()))
             .await
@@ -3169,13 +3196,21 @@ mod tests {
     }
 
     // ========================================================================
-    // DeferredPersistGate: which Finalizer may persist the phase advance
+    // DeferredPersistGate: which Finalizer may persist which snapshot
     // ========================================================================
+
+    fn snap(phase: usize) -> HybridSourceState {
+        HybridSourceState {
+            current_phase: phase,
+            completed_phases: vec![true; phase],
+            unbounded_offsets: None,
+        }
+    }
 
     #[test]
     fn gate_ignores_markers_created_before_the_transition() {
         let gate = DeferredPersistGate::default();
-        gate.arm(1_000);
+        gate.arm(1_000, snap(1));
         // Marker minted before (or at) the stamp may have been attached to a
         // mid-phase batch: its Finalizer proves nothing about the tail.
         gate.observe_marker(7, 900);
@@ -3190,7 +3225,7 @@ mod tests {
             gate.covering_finalizer(10).is_some(),
             "later epochs cover too"
         );
-        gate.disarm(token);
+        gate.disarm(&token);
         assert!(!gate.is_armed());
         assert!(gate.covering_finalizer(10).is_none());
     }
@@ -3205,14 +3240,14 @@ mod tests {
 
     #[test]
     fn gate_disarm_does_not_clobber_a_newer_arm() {
-        // Multi-bounded-phase race: the Finalizer for phase-0→1 is being
+        // Multi-bounded-phase race: the Finalizer for phase 0→1 is being
         // persisted when phase 1 ends and re-arms for 1→2.
         let gate = DeferredPersistGate::default();
-        gate.arm(1_000);
+        gate.arm(1_000, snap(1));
         gate.observe_marker(5, 1_500);
         let token = gate.covering_finalizer(5).expect("covers");
-        gate.arm(2_000); // persist still in flight
-        gate.disarm(token);
+        gate.arm(2_000, snap(2)); // persist still in flight
+        gate.disarm(&token);
         assert!(gate.is_armed(), "newer arm must survive the stale disarm");
         assert!(
             gate.covering_finalizer(5).is_none(),
@@ -3223,14 +3258,46 @@ mod tests {
     }
 
     #[test]
+    fn gate_token_carries_the_snapshot_of_its_own_transition() {
+        // Same race: the in-flight persist must write phase 1, not the live
+        // phase 2 that no checkpoint has covered yet.
+        let gate = DeferredPersistGate::default();
+        gate.arm(1_000, snap(1));
+        gate.observe_marker(5, 1_500);
+        let token = gate.covering_finalizer(5).expect("covers");
+        gate.arm(2_000, snap(2));
+        assert_eq!(token.snapshot.current_phase, 1);
+        assert_eq!(
+            gate.covering_terminal()
+                .expect("armed")
+                .snapshot
+                .current_phase,
+            2
+        );
+    }
+
+    #[test]
+    fn gate_generation_is_never_reused() {
+        // arm → disarm → arm again: a token from the first arm must not be
+        // able to disarm the second one.
+        let gate = DeferredPersistGate::default();
+        gate.arm(1_000, snap(1));
+        let stale = gate.covering_terminal().expect("armed");
+        gate.disarm(&stale);
+        gate.arm(2_000, snap(1));
+        gate.disarm(&stale);
+        assert!(gate.is_armed());
+    }
+
+    #[test]
     fn gate_terminal_covers_whenever_armed() {
         let gate = DeferredPersistGate::default();
-        gate.arm(1_000);
+        gate.arm(1_000, snap(1));
         // No channel Marker seen at all (terminal Marker travels inline).
         let token = gate
             .covering_terminal()
             .expect("terminal covers an armed gate");
-        gate.disarm(token);
+        gate.disarm(&token);
         assert!(!gate.is_armed());
     }
 
@@ -3264,7 +3331,10 @@ mod tests {
         // Advance through bounded to unbounded, then persist (as the execute
         // loop does once the covering checkpoint finalizes)
         hybrid_provider.advance_to_next_phase().await.unwrap();
-        hybrid_provider.persist_phase_state().await.unwrap();
+        hybrid_provider
+            .persist_phase_state(&hybrid_provider.state.read().await.clone())
+            .await
+            .unwrap();
         let state = hybrid_provider.state.read().await;
         assert_eq!(state.current_phase, 1, "should be in unbounded phase");
         drop(state);
@@ -3359,7 +3429,9 @@ mod tests {
 
         hybrid_provider.advance_to_next_phase().await.unwrap();
         // persist_phase_state should succeed because retry recovers
-        let result = hybrid_provider.persist_phase_state().await;
+        let result = hybrid_provider
+            .persist_phase_state(&hybrid_provider.state.read().await.clone())
+            .await;
         assert!(
             result.is_ok(),
             "should succeed after retry: {:?}",
@@ -3415,7 +3487,9 @@ mod tests {
         .unwrap();
 
         hybrid_provider.advance_to_next_phase().await.unwrap();
-        let result = hybrid_provider.persist_phase_state().await;
+        let result = hybrid_provider
+            .persist_phase_state(&hybrid_provider.state.read().await.clone())
+            .await;
         assert!(
             result.is_err(),
             "should fail after all retry attempts exhausted"

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -607,6 +607,10 @@ struct KafkaSourceExec {
     state_backend: Arc<dyn StateOperatorBackend<TopicPartitionOffset>>,
     shutdown_rx: watch::Receiver<bool>,
     num_records_before_stop: Option<u64>,
+    /// In-memory start offsets handed over by the hybrid source (ClickHouse
+    /// max offsets). Used only for partitions with no committed offset in the
+    /// state backend; never persisted from here.
+    seeded_offsets: Arc<std::sync::Mutex<HashMap<i32, u32>>>,
     /// Number of concurrent consumer instances; one `execute` call per instance.
     parallelism: usize,
     /// Resolved once at construction so every instance joins the *same* consumer
@@ -666,6 +670,7 @@ impl KafkaSourceExec {
         num_records_before_stop: Option<u64>,
         metric_metadata_id: String,
         parallelism: usize,
+        seeded_offsets: Arc<std::sync::Mutex<HashMap<i32, u32>>>,
     ) -> Self {
         let full_schema_projected = project_schema(&full_schema, projections).unwrap();
         let cached_properties =
@@ -702,6 +707,7 @@ impl KafkaSourceExec {
             state_backend,
             shutdown_rx,
             num_records_before_stop,
+            seeded_offsets,
             parallelism,
             group_id,
             lag_group_id,
@@ -1300,6 +1306,7 @@ impl ExecutionPlan for KafkaSourceExec {
                 .field_with_name(COLUMN_NAME_OP)
                 .is_ok();
         let start_at = self.start_at.clone();
+        let seeded_offsets = self.seeded_offsets.clone();
         let mut shutdown_rx = self.shutdown_rx.clone();
         let num_records_before_stop = self.num_records_before_stop;
         let metric_metadata_id = self.metric_metadata_id.clone();
@@ -1349,11 +1356,46 @@ impl ExecutionPlan for KafkaSourceExec {
                     shutdown_rx.clone(),
                 ));
             }
-            let kafka_topic_partition_list_to_seek = Self::find_offsets_in_state_backend(
+            let mut kafka_topic_partition_list_to_seek = Self::find_offsets_in_state_backend(
                 state_backend.clone(),
                 reference_name.clone(),
-                kafka_topic_partition_list,
+                kafka_topic_partition_list.clone(),
             ).await;
+
+            // Partitions with no committed offset fall back to the in-memory
+            // seed from the hybrid handover. Seeds are deliberately NOT written
+            // to the state backend here: only a finalized checkpoint (below, or
+            // the hybrid source's deferred persist) may durably advance a
+            // source position.
+            let seeds = seeded_offsets.lock().unwrap().clone();
+            if !seeds.is_empty() {
+                let already_seeking: std::collections::HashSet<i32> = kafka_topic_partition_list_to_seek
+                    .elements()
+                    .iter()
+                    .map(|tp| tp.partition())
+                    .collect();
+                let mut seeded_count = 0usize;
+                for tp in TopicPartitionList::from(kafka_topic_partition_list).topic_partitions {
+                    if already_seeking.contains(&tp.partition) {
+                        continue;
+                    }
+                    if let Some(offset) = seeds.get(&tp.partition) {
+                        kafka_topic_partition_list_to_seek
+                            .add_partition_offset(&tp.topic, tp.partition, Offset::Offset(*offset as i64))
+                            .streamling_with_context(|| format!(
+                                "seeding partition {} from hybrid handover (topic: {})",
+                                tp.partition, tp.topic
+                            ))?;
+                        seeded_count += 1;
+                    }
+                }
+                if seeded_count > 0 {
+                    info!(
+                        "Seeking {} partition(s) of topic '{}' from in-memory hybrid seed offsets",
+                        seeded_count, topic
+                    );
+                }
+            }
 
             if kafka_topic_partition_list_to_seek.count() > 0 {
                 // One info! summary so the multi-partition case doesn't dump
@@ -1833,6 +1875,10 @@ pub struct KafkaSourceTableProvider {
     num_records_before_stop: Option<u64>,
     extracted_primary_key: Option<String>,
     parallelism: usize,
+    /// Start offsets handed over by the hybrid source at the bounded→unbounded
+    /// transition. Held in memory; persisted only by `persist_seeded_offsets`
+    /// once a checkpoint covering the bounded phase has finalized.
+    seeded_offsets: Arc<std::sync::Mutex<HashMap<i32, u32>>>,
 }
 
 impl Debug for KafkaSourceTableProvider {
@@ -2004,6 +2050,7 @@ impl KafkaSourceTableProvider {
             shutdown_rx,
             num_records_before_stop,
             extracted_primary_key,
+            seeded_offsets: Arc::new(std::sync::Mutex::new(HashMap::new())),
             parallelism: Self::effective_parallelism(
                 &config_for_metadata,
                 &topic_for_metadata,
@@ -2074,43 +2121,76 @@ impl KafkaSourceTableProvider {
         let _ = self.shutdown_tx.send(true);
     }
 
-    /// Seed the Kafka state backend with offsets from an external source (e.g., ClickHouse).
-    /// This is used during hybrid source handoff to ensure the Kafka consumer starts
-    /// from the correct position after the bounded source completes.
+    /// Hand over start offsets from an external source (e.g. ClickHouse max
+    /// offsets at the hybrid bounded→unbounded transition). Held in memory
+    /// only: the consumer seeks to them for partitions without a committed
+    /// offset. Nothing is written to the state backend here — a position may
+    /// only become durable once a checkpoint covering everything emitted
+    /// before it has finalized (see `persist_seeded_offsets`).
     pub async fn seed_offsets(&self, offsets: &HashMap<i32, u32>) -> Result<()> {
+        *self.seeded_offsets.lock().unwrap() = offsets.clone();
+        debug!(
+            "Seeded {} in-memory Kafka partition offset(s) for topic '{}'",
+            offsets.len(),
+            self.topic
+        );
+        Ok(())
+    }
+
+    /// Persist the seeded offsets for every partition that does not already
+    /// have a committed offset in the state backend. Called by the hybrid
+    /// source once the first checkpoint after the transition has finalized;
+    /// partitions the consumer has since committed keep their (newer) offset.
+    pub async fn persist_seeded_offsets(&self) -> Result<()> {
+        let seeds = self.seeded_offsets.lock().unwrap().clone();
+        if seeds.is_empty() {
+            return Ok(());
+        }
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_millis() as u64;
 
-        for (partition, offset) in offsets {
+        let mut written = 0usize;
+        for (partition, offset) in &seeds {
             let state_key = StateKey::from(format!(
                 "{}:{}:{}",
                 self.reference_name, self.topic, partition
             ));
-            let offset_state = TopicPartitionOffset {
-                offset: *offset as i64,
-                updated_at: now,
-            };
-            self.state_backend
-                .put(state_key, offset_state)
+            let existing = self
+                .state_backend
+                .get(state_key.clone())
                 .await
                 .map_err(|e| {
-                    streamling_err!("seeding offset for partition {}: {:?}", partition, e)
+                    streamling_err!("reading offset for partition {}: {:?}", partition, e)
                 })?;
-            // Per-partition seed line, kept at debug! since this fires once
-            // per hybrid bounded→unbounded transition (not per checkpoint).
-            debug!(
-                "Seeded Kafka offset for topic {} partition {} to offset {}",
-                self.topic, partition, offset
-            );
+            if existing.is_some() {
+                continue;
+            }
+            self.state_backend
+                .put(
+                    state_key,
+                    TopicPartitionOffset {
+                        offset: *offset as i64,
+                        updated_at: now,
+                    },
+                )
+                .await
+                .map_err(|e| {
+                    streamling_err!(
+                        "persisting seeded offset for partition {}: {:?}",
+                        partition,
+                        e
+                    )
+                })?;
+            written += 1;
         }
         debug!(
-            "Seeded {} Kafka partition offset(s) for topic '{}'",
-            offsets.len(),
+            "Persisted {} of {} seeded Kafka partition offset(s) for topic '{}' (rest already committed)",
+            written,
+            seeds.len(),
             self.topic
         );
-
         Ok(())
     }
 
@@ -2181,6 +2261,7 @@ impl KafkaSourceTableProvider {
             self.num_records_before_stop,
             self.metric_metadata_id.clone(),
             self.parallelism,
+            self.seeded_offsets.clone(),
         ));
 
         if let Some(filter_expr) = &filter {

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -1876,7 +1876,7 @@ pub struct KafkaSourceTableProvider {
     extracted_primary_key: Option<String>,
     parallelism: usize,
     /// Start offsets handed over by the hybrid source at the bounded→unbounded
-    /// transition. Held in memory; persisted only by `persist_seeded_offsets`
+    /// transition. Held in memory; persisted only by `persist_offsets_if_absent`
     /// once a checkpoint covering the bounded phase has finalized.
     seeded_offsets: Arc<std::sync::Mutex<HashMap<i32, u32>>>,
 }
@@ -2126,7 +2126,7 @@ impl KafkaSourceTableProvider {
     /// only: the consumer seeks to them for partitions without a committed
     /// offset. Nothing is written to the state backend here — a position may
     /// only become durable once a checkpoint covering everything emitted
-    /// before it has finalized (see `persist_seeded_offsets`).
+    /// before it has finalized (see `persist_offsets_if_absent`).
     pub async fn seed_offsets(&self, offsets: &HashMap<i32, u32>) -> Result<()> {
         *self.seeded_offsets.lock().unwrap() = offsets.clone();
         debug!(
@@ -2137,13 +2137,15 @@ impl KafkaSourceTableProvider {
         Ok(())
     }
 
-    /// Persist the seeded offsets for every partition that does not already
-    /// have a committed offset in the state backend. Called by the hybrid
-    /// source once the first checkpoint after the transition has finalized;
-    /// partitions the consumer has since committed keep their (newer) offset.
-    pub async fn persist_seeded_offsets(&self) -> Result<()> {
-        let seeds = self.seeded_offsets.lock().unwrap().clone();
-        if seeds.is_empty() {
+    /// Persist `offsets` for every partition that does not already have a
+    /// committed offset in the state backend. Called by the hybrid source
+    /// with the seeds of a transition once a checkpoint covering it has
+    /// finalized; partitions the consumer has since committed keep their
+    /// (newer) offset. The get→put is not atomic against the commit path
+    /// running on the same Finalizer, so a seed can land over a fresher
+    /// commit; that only replays up to one epoch of that partition.
+    pub async fn persist_offsets_if_absent(&self, offsets: &HashMap<i32, u32>) -> Result<()> {
+        if offsets.is_empty() {
             return Ok(());
         }
         let now = SystemTime::now()
@@ -2152,7 +2154,7 @@ impl KafkaSourceTableProvider {
             .as_millis() as u64;
 
         let mut written = 0usize;
-        for (partition, offset) in &seeds {
+        for (partition, offset) in offsets {
             let state_key = StateKey::from(format!(
                 "{}:{}:{}",
                 self.reference_name, self.topic, partition
@@ -2186,9 +2188,9 @@ impl KafkaSourceTableProvider {
             written += 1;
         }
         debug!(
-            "Persisted {} of {} seeded Kafka partition offset(s) for topic '{}' (rest already committed)",
+            "Persisted {} of {} handed-over Kafka partition offset(s) for topic '{}' (rest already committed)",
             written,
-            seeds.len(),
+            offsets.len(),
             self.topic
         );
         Ok(())
@@ -3212,7 +3214,7 @@ mod tests {
     use super::*;
 
     /// Hybrid handover seeds must not become durable on their own: only a
-    /// finalized checkpoint may persist a position. `persist_seeded_offsets`
+    /// finalized checkpoint may persist a position. `persist_offsets_if_absent`
     /// then writes only partitions the commit path has not already covered.
     #[tokio::test]
     async fn seed_offsets_stay_in_memory_until_persist_seeded_offsets() {
@@ -3255,10 +3257,8 @@ mod tests {
 
         let key = |p: i32| StateKey::from(format!("src:test-topic:{p}"));
 
-        provider
-            .seed_offsets(&HashMap::from([(0, 100), (1, 200)]))
-            .await
-            .unwrap();
+        let seeds = HashMap::from([(0, 100), (1, 200)]);
+        provider.seed_offsets(&seeds).await.unwrap();
         assert!(
             state_backend.get(key(0)).await.unwrap().is_none()
                 && state_backend.get(key(1)).await.unwrap().is_none(),
@@ -3277,7 +3277,7 @@ mod tests {
             .await
             .unwrap();
 
-        provider.persist_seeded_offsets().await.unwrap();
+        provider.persist_offsets_if_absent(&seeds).await.unwrap();
         assert_eq!(
             state_backend.get(key(0)).await.unwrap().unwrap().offset,
             100,

--- a/crates/streamling-connectors/src/table_providers/kafka.rs
+++ b/crates/streamling-connectors/src/table_providers/kafka.rs
@@ -3211,6 +3211,85 @@ impl TableProvider for KafkaSinkTableProvider {
 mod tests {
     use super::*;
 
+    /// Hybrid handover seeds must not become durable on their own: only a
+    /// finalized checkpoint may persist a position. `persist_seeded_offsets`
+    /// then writes only partitions the commit path has not already covered.
+    #[tokio::test]
+    async fn seed_offsets_stay_in_memory_until_persist_seeded_offsets() {
+        use streamling_core::dynamic_table::DynamicTableRegistry;
+        use streamling_state::StateOperatorBackendFactory;
+        use streamling_state::in_memory::InMemoryStateOperatorBackendFactory;
+
+        let session_manager =
+            SessionManager::new(8192, 10, DynamicTableRegistry::new(), 1).unwrap();
+        let state_backend = InMemoryStateOperatorBackendFactory::new()
+            .unwrap()
+            .create::<TopicPartitionOffset>("test-kafka-seeds");
+
+        let mut json_schema = BTreeMap::new();
+        json_schema.insert("a".to_string(), "string".to_string());
+
+        let provider = KafkaSourceTableProvider::new(
+            "src".to_string(),
+            "src-metrics".to_string(),
+            test_kafka_config(),
+            "test-topic".to_string(),
+            None,
+            None,
+            1000,
+            10,
+            10,
+            false,
+            state_backend.clone(),
+            session_manager,
+            None,
+            false,
+            vec![],
+            true,
+            vec![],
+            KafkaFormat::Json,
+            Some(json_schema),
+            1,
+        )
+        .unwrap();
+
+        let key = |p: i32| StateKey::from(format!("src:test-topic:{p}"));
+
+        provider
+            .seed_offsets(&HashMap::from([(0, 100), (1, 200)]))
+            .await
+            .unwrap();
+        assert!(
+            state_backend.get(key(0)).await.unwrap().is_none()
+                && state_backend.get(key(1)).await.unwrap().is_none(),
+            "seeding must not write the state backend"
+        );
+
+        // Partition 1 was committed by the Finalizer path in the meantime.
+        state_backend
+            .put(
+                key(1),
+                TopicPartitionOffset {
+                    offset: 999,
+                    updated_at: 0,
+                },
+            )
+            .await
+            .unwrap();
+
+        provider.persist_seeded_offsets().await.unwrap();
+        assert_eq!(
+            state_backend.get(key(0)).await.unwrap().unwrap().offset,
+            100,
+            "uncommitted partition gets its seed"
+        );
+        assert_eq!(
+            state_backend.get(key(1)).await.unwrap().unwrap().offset,
+            999,
+            "committed partition keeps the newer offset"
+        );
+    }
+
     /// A topology-level source `filter:` is defined against the source's full
     /// payload schema. When the engine pushes a scan projection that prunes a
     /// column the filter references, the filter must still plan against the

--- a/docs/hybrid-source-state.allium
+++ b/docs/hybrid-source-state.allium
@@ -216,31 +216,59 @@ rule HybridSourceRecoversAsFirstRun {
 -- ---- Phase advancement -------------------------------------------------
 
 -- When the active bounded phase's stream ends, the hybrid source
--- advances to the next phase. The phase state is persisted to the
--- state backend immediately after the in-memory advance.
+-- advances to the next phase IN MEMORY. The phase state is NOT
+-- persisted at this point: the rows the finished phase emitted are only
+-- durable once every sink has acknowledged a checkpoint Marker that
+-- travelled behind them. Persisting `completed_phases` earlier would let
+-- a restart skip those rows if a sink fails before that (observed when
+-- the sink was unavailable at first start).
 --
--- The bounded source's own resume cursor was already saved during the
--- most recent epoch finalization (see checkpointing.allium). Phase state
--- and bounded cursors are persisted independently and there is no
--- atomicity between them.
+-- The bounded source's own resume cursor is saved during epoch
+-- finalization (see checkpointing.allium). Phase state and bounded
+-- cursors are persisted independently and there is no atomicity between
+-- them.
 rule AdvanceFromBoundedPhase {
     when: BoundedStreamEnded(hybrid)
     requires: hybrid.is_in_bounded_phase
     ensures: hybrid.current_phase = hybrid.current_phase + 1
+    ensures: hybrid.transition_at = now
+    ensures: not HybridPhaseStatePersisted(hybrid)
+}
+
+-- The phase state (and the seeded offsets below) become durable on the
+-- first Finalizer whose Marker was created after the transition. Such a
+-- Marker was broadcast after the last bounded batch was sent downstream,
+-- so it reaches every sink behind that batch; its Finalizer therefore
+-- proves the finished phase is durable everywhere. Until then a restart
+-- lands on the phase the persisted state names (phase 0 on a first run),
+-- re-emitting the finished phase's rows -- at-least-once, never loss.
+rule PersistPhaseStateOnFirstCoveringFinalizer {
+    when: FinalizerObserved(hybrid, epoch)
+    requires: hybrid.transition_at != null
+    requires: exists marker: MarkerObserved(hybrid, marker)
+        and marker.epoch <= epoch
+        and marker.created_at > hybrid.transition_at
     ensures: HybridPhaseStatePersisted(hybrid)
+    ensures:
+        for offset in hybrid.seeded_offsets
+            where UnboundedPersistedOffset(hybrid.unbounded_phase, offset.partition) = null:
+                UnboundedPartitionOffsetPersisted(
+                    source: hybrid.unbounded_phase,
+                    offset: offset
+                )
+    ensures: hybrid.transition_at = null
 }
 
 -- When advancing OUT of the last bounded phase, fetch unbounded
--- partition offsets from the offset provider and seed them into the
--- unbounded source's per-partition state BEFORE the unbounded phase
--- begins consuming. The offsets are also recorded in hybrid phase
--- state for diagnostic purposes.
+-- partition offsets from the offset provider and hand them to the
+-- unbounded source IN MEMORY before the unbounded phase begins
+-- consuming. The offsets are also recorded in hybrid phase state.
 --
 -- Seeding ensures the unbounded source resumes from the correct
 -- position relative to where the final bounded phase left off, rather
--- than from its configured default (earliest/latest). After seeding,
--- the unbounded source's per-partition state contains a value for each
--- seeded partition, regardless of whether one already existed.
+-- than from its configured default (earliest/latest). Nothing is
+-- written to the unbounded source's per-partition state here; see
+-- PersistPhaseStateOnFirstCoveringFinalizer.
 rule SeedUnboundedOffsetsAtHandoff {
     when: BoundedStreamEnded(hybrid)
     requires: hybrid.is_in_bounded_phase
@@ -256,15 +284,16 @@ rule SeedUnboundedOffsetsAtHandoff {
             )
 }
 
--- The unbounded source observes seeded offsets via direct write to the
--- same per-partition state key it reads on its own startup. The
--- unbounded source itself does not need to be running at the time of
--- seeding -- the write is durable and is consumed by its next startup.
--- See checkpointing.allium for the unbounded source's normal commit
--- path during steady state.
+-- The unbounded source keeps seeded offsets in memory and, on startup,
+-- seeks each assigned partition to its persisted offset if one exists,
+-- else to its seeded offset if one exists, else to its configured
+-- default. Its own steady-state commit path (see checkpointing.allium)
+-- persists positions on Finalizer; partitions that saw no traffic since
+-- the seek are covered by PersistPhaseStateOnFirstCoveringFinalizer.
 rule UnboundedAcceptsSeededOffset {
     when: UnboundedPartitionOffsetSeeded(source, offset)
-    -- Effect: the source's persisted partition offset becomes `offset`.
+    -- Effect: the source's in-memory start position for the partition
+    -- becomes `offset`; the persisted partition offset is unchanged.
     -- Modeled as a contract on UnboundedSource (see
     -- UnboundedOffsetSeedingContract surface).
 }
@@ -318,21 +347,27 @@ rule HybridPhaseStatePersisted {
 ------------------------------------------------------------
 
 -- Contract for unbounded source implementations consuming seeded
--- offsets. The hybrid source writes seed offsets to the same per-
--- partition state keys the unbounded source reads on startup, so this
--- contract is satisfied implicitly by any unbounded source that
--- prefers persisted offsets over its configured default.
+-- offsets. The hybrid source hands seed offsets to the unbounded source
+-- in memory; the unbounded source must prefer, in order, a persisted
+-- per-partition offset, then a seeded one, then its configured default.
 surface UnboundedOffsetSeedingContract {
     facing implementer: UnboundedSource
 
     context offset: PartitionOffset
 
-    @guarantee UnboundedPrefersPersistedOffset
-        -- An UnboundedSource MUST, on startup, prefer a persisted
-        -- per-partition offset over its configured default
+    @guarantee UnboundedPrefersPersistedThenSeededOffset
+        -- An UnboundedSource MUST, on startup, seek each partition to
+        -- its persisted offset if one exists, else to its seeded
+        -- offset if one exists, else to its configured default
         -- (earliest/latest). Violation breaks the bounded ->
         -- unbounded handoff: the unbounded source would resume from
         -- the wrong position despite seeding.
+
+    @guarantee SeedIsNotDurable
+        -- Seeding MUST NOT write the per-partition state key. Only a
+        -- finalized checkpoint (the source's own commit path, or the
+        -- hybrid source's PersistPhaseStateOnFirstCoveringFinalizer)
+        -- may persist a position.
 }
 
 -- Contract for bounded source implementations exposing resume state.

--- a/docs/hybrid-source-state.allium
+++ b/docs/hybrid-source-state.allium
@@ -256,15 +256,21 @@ rule PersistPhaseStateOnFirstCoveringFinalizer {
         or exists marker: MarkerObserved(hybrid, marker)
             and marker.epoch <= epoch
             and marker.created_at > hybrid.transition_at
-    ensures: HybridPhaseStatePersisted(hybrid)
-    ensures:
-        for offset in hybrid.seeded_offsets
+    -- Writes the snapshot captured when the transition armed, never the
+    -- live state: with several bounded phases the next phase may already
+    -- have advanced in memory without any checkpoint covering it.
+    let covered = state_as_of(hybrid.transition_at)
+    ensures: persist_succeeded implies HybridPhaseStatePersisted(hybrid, covered)
+    ensures: persist_succeeded implies
+        for offset in covered.seeded_offsets
             where UnboundedPersistedOffset(hybrid.unbounded_phase, offset.partition) = null:
                 UnboundedPartitionOffsetPersisted(
                     source: hybrid.unbounded_phase,
                     offset: offset
                 )
-    ensures: hybrid.transition_at = null
+    -- On failure transition_at stays set; the next covering Finalizer
+    -- retries. A disarm applies only to the arm it was issued for.
+    ensures: persist_succeeded implies hybrid.transition_at = null
 }
 
 -- When advancing OUT of the last bounded phase, fetch unbounded

--- a/docs/hybrid-source-state.allium
+++ b/docs/hybrid-source-state.allium
@@ -242,12 +242,20 @@ rule AdvanceFromBoundedPhase {
 -- proves the finished phase is durable everywhere. Until then a restart
 -- lands on the phase the persisted state names (phase 0 on a first run),
 -- re-emitting the finished phase's rows -- at-least-once, never loss.
+--
+-- A finalized terminal checkpoint (job completion or shutdown) also
+-- covers: its Marker is emitted inline after every row of the source.
+-- If the persist fails, the transition stays armed and the next covering
+-- Finalizer retries. A disarm compares against the arm it observed, so
+-- a persist that completes after a newer transition re-armed the source
+-- (multiple bounded phases) cannot clear the newer arm.
 rule PersistPhaseStateOnFirstCoveringFinalizer {
-    when: FinalizerObserved(hybrid, epoch)
+    when: FinalizerObserved(hybrid, epoch) or TerminalCheckpointFinalized(hybrid)
     requires: hybrid.transition_at != null
-    requires: exists marker: MarkerObserved(hybrid, marker)
-        and marker.epoch <= epoch
-        and marker.created_at > hybrid.transition_at
+    requires: TerminalCheckpointFinalized(hybrid)
+        or exists marker: MarkerObserved(hybrid, marker)
+            and marker.epoch <= epoch
+            and marker.created_at > hybrid.transition_at
     ensures: HybridPhaseStatePersisted(hybrid)
     ensures:
         for offset in hybrid.seeded_offsets
@@ -307,7 +315,10 @@ rule JobModeTerminatesAfterFinalBounded {
     requires: hybrid.current_phase + 1 = hybrid.bounded_phases.count
     requires: hybrid.job_mode
     ensures: hybrid.current_phase = hybrid.bounded_phases.count + 1   -- finished
-    ensures: HybridPhaseStatePersisted(hybrid)
+    -- Persisted iff the terminal checkpoint finalized: its Marker is
+    -- emitted inline after every row, so a finalized terminal epoch
+    -- covers the last phase (PersistPhaseStateOnFirstCoveringFinalizer).
+    ensures: TerminalCheckpointFinalized(hybrid) implies HybridPhaseStatePersisted(hybrid)
     ensures: HybridSourceShutdown(hybrid)
 }
 


### PR DESCRIPTION
## Problem

The hybrid source persisted `completed_phases: [true]` and the seeded Kafka offsets the instant the bounded stream ended (`advance_to_next_phase` → `save_state()` + `seed_offsets()`), before any sink acknowledged a checkpoint. If the sink failed inside that window (seen in production: topic ACL denied at first start, process exited 2s after the handover), every restart skipped the bounded phase and the rows it had read but the sink never wrote were lost silently. Only a full state reset recovered them.

This violates the documented rule that a source commits its position only after every sink has durably written the records before the Marker. The ClickHouse source (split on `Finalizer`) and the Kafka source (commit on `Finalizer`) already follow it; the hybrid phase pointer did not.

## Fix

- `advance_to_next_phase` changes in-memory state only.
- Kafka seed offsets are held in memory (`KafkaSourceTableProvider` / `KafkaSourceExec`). Seek order at startup: persisted offset → seeded offset → `starting_offsets`. `persist_offsets_if_absent` writes a given set put-if-absent.
- `DeferredPersistGate` (one mutex): the execute loop arms it after a phase advance with a wall-clock stamp and a **snapshot** of the state that advance produced. The existing checkpoint forwarder feeds it Markers; the first Marker created after the stamp names the earliest covering epoch, and that epoch's `Finalizer` persists the snapshot (`persist_phase_state(&snapshot)` = seeds from the snapshot + hybrid state). Writing the snapshot rather than the live state matters with several bounded phases: the next phase may already have advanced in memory without being covered. Arm generations are monotonic, so a persist finishing after a newer advance cannot disarm it.
- A finalized terminal checkpoint (job completion or shutdown) also persists an armed transition. Its Marker is pushed inline after every row and never travels on the coordinator channel, so the forwarder cannot see it.
- Spec updated (`docs/hybrid-source-state.allium`): `AdvanceFromBoundedPhase` no longer persists; new `PersistPhaseStateOnFirstCoveringFinalizer` (snapshot, terminal, retry, re-arm); `SeedIsNotDurable` guarantee.

## Behaviour change

Phase state becomes durable up to one checkpoint interval later. A restart inside that window replays the bounded phase (duplicates, at-least-once) where it previously skipped it (loss).

## Tests

- `test_advance_to_next_phase_defers_persistence`; six `DeferredPersistGate` tests (pre-stamp Markers ignored, lower epochs ignored, re-arm race, snapshot isolation, generation reuse, terminal); `seed_offsets_stay_in_memory_until_persist_seeded_offsets`.
- `fm6`, `fm1`, and both `save_state` retry tests now target `persist_phase_state`, the durable step.
- `cargo test -p streamling-connectors --lib -- table_providers::hybrid table_providers::kafka`: 84 pass. Clippy clean. `cargo check --workspace --all-targets` clean.
- e2e not run locally (needs the cluster). `test_hybrid_source_checkpoints_after_unbounded_transition` uses the `hybrid_source:%` key as its transition signal; it now appears on the first Finalizer (1s interval there) rather than immediately. `test_hybrid_clickhouse_resume_from_high_saved_split` deletes the hybrid key before run 2; the job's terminal checkpoint still writes it, so that step still exercises the fallback path.

## Known gaps

- `persist_offsets_if_absent` get→put is not atomic against the Kafka commit loop on the same Finalizer; a seed can land over a fresher commit. Replays at most one epoch of that partition; documented in the method comment.
- No unit test drives the execute loop's deferral end to end (`test_hybrid_source_execute_terminates_in_job_mode` runs with `checkpoint_control: None`); the gate is tested in isolation and the loop wiring only by the e2e hybrid suite. No e2e covers the exact incident (sink unavailable at handover, then restart). Both worth follow-ups.
- Eligibility compares the coordinator's `created_at_ms` with a stamp from the same `now_ms()`; a backwards clock step only delays persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)