### PR TITLE
fix: keep checkpoint receives off Tokio workers

### DIFF
--- a/crates/streamling-bench/src/main.rs
+++ b/crates/streamling-bench/src/main.rs
@@ -19,6 +19,7 @@
 mod report;
 mod scenario;
 
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -45,6 +46,14 @@ const METRICS_FLUSH_WAIT: Duration = Duration::from_secs(3);
 /// Upper bound on a single pipeline run; a hang (e.g. an empty topic) fails
 /// loudly instead of blocking forever.
 const RUN_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// A deterministic scenario with selectivity `1 / n` may reach its final
+/// required output up to `n - 1` source rows before the end of the topic.
+/// Preserve that small tail while still rejecting materially incomplete runs.
+fn maximum_source_row_shortfall(selectivity: f64) -> u64 {
+    debug_assert!(selectivity > 0.0 && selectivity <= 1.0);
+    ((1.0 / selectivity).ceil() as u64).saturating_sub(1)
+}
 
 /// Avro schema for the benchmark payload. Field types map to Arrow as:
 /// long→int64, string→utf8, double→float64, int→int32, and the `bytes` decimal
@@ -124,6 +133,11 @@ struct Cli {
     #[arg(long, default_value_t = DEFAULT_WARMUP)]
     warmup: u32,
 
+    /// Tokio worker threads for each Streamling child process. This does not
+    /// resize the benchmark harness runtime.
+    #[arg(long)]
+    tokio_worker_threads: Option<NonZeroUsize>,
+
     /// Directory to write `<scenario>.json` result files (skipped if unset).
     #[arg(long)]
     out_dir: Option<PathBuf>,
@@ -143,6 +157,18 @@ struct Cli {
     update_baseline: bool,
 }
 
+/// Raw measurements for one non-warmup Streamling process.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchSample {
+    pub instance: String,
+    pub wall_clock_seconds: f64,
+    pub throughput_input_records_per_sec: f64,
+    pub throughput_output_records_per_sec: f64,
+    pub throughput_mb_per_sec: f64,
+    pub compute_us_per_input_record: f64,
+    pub source_output_rows_observed: u64,
+}
+
 /// One benchmark result, serialized to JSON and used as the baseline schema.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BenchResult {
@@ -152,6 +178,15 @@ pub struct BenchResult {
     pub records: u64,
     pub payload_bytes: u64,
     pub iterations: u32,
+    /// Explicit child runtime size, when supplied through the benchmark CLI.
+    /// Defaults preserve compatibility with baselines written before this knob.
+    #[serde(default)]
+    pub tokio_worker_threads: Option<usize>,
+    /// Per-process measurements used to compute the aggregate fields below.
+    /// Older committed baselines contain only aggregates and deserialize to an
+    /// empty sample list.
+    #[serde(default)]
+    pub samples: Vec<BenchSample>,
     pub wall_clock_seconds_median: f64,
     pub wall_clock_seconds_min: f64,
     pub input_rows: u64,
@@ -312,20 +347,22 @@ sinks:
             instance,
         );
 
+        let mut pipeline_opts = PipelineOpts::new()
+            .record_limit(stop)
+            .timeout(RUN_TIMEOUT)
+            .env("STREAMLING__APPLICATION_ID", instance.clone())
+            .env(
+                "STREAMLING__KAFKA_SOURCE__CONSUMER_GROUP_ID",
+                instance.clone(),
+            );
+        if let Some(worker_threads) = cli.tokio_worker_threads {
+            pipeline_opts = pipeline_opts.env("TOKIO_WORKER_THREADS", worker_threads.to_string());
+        }
+
         let start = Instant::now();
-        ctx.run_pipeline_with_opts(
-            &pipeline_yaml,
-            PipelineOpts::new()
-                .record_limit(stop)
-                .timeout(RUN_TIMEOUT)
-                .env("STREAMLING__APPLICATION_ID", instance.clone())
-                .env(
-                    "STREAMLING__KAFKA_SOURCE__CONSUMER_GROUP_ID",
-                    instance.clone(),
-                ),
-        )
-        .await
-        .with_context(|| format!("pipeline run failed (iter {})", iter))?;
+        ctx.run_pipeline_with_opts(&pipeline_yaml, pipeline_opts)
+            .await
+            .with_context(|| format!("pipeline run failed (iter {})", iter))?;
         let wall = start.elapsed().as_secs_f64();
 
         if !is_warmup {
@@ -335,9 +372,7 @@ sinks:
 
     tokio::time::sleep(METRICS_FLUSH_WAIT).await;
 
-    let mut input_tps = Vec::new();
-    let mut output_tps = Vec::new();
-    let mut compute_us = Vec::new();
+    let mut samples = Vec::with_capacity(measured.len());
     let mut source_rows_observed = 0u64;
 
     for (instance, wall) in &measured {
@@ -345,17 +380,55 @@ sinks:
             "sum(streamling_elapsed_compute_milliseconds_sum{{instance=\"{}\"}})",
             instance
         );
-        let compute_ms = prometheus.query(&compute_query).await?.unwrap_or(0.0);
+        let compute_ms = prometheus
+            .query(&compute_query)
+            .await?
+            .with_context(|| format!("missing compute metric for measured instance {instance}"))?;
         let source_query = PrometheusResource::output_rows_query("kafka_source", Some(instance));
-        let src_rows = prometheus.query_count(&source_query).await?.unwrap_or(0);
+        let src_rows = prometheus
+            .query_count(&source_query)
+            .await?
+            .with_context(|| {
+                format!("missing source-row metric for measured instance {instance}")
+            })?;
+        let minimum_source_rows = cli
+            .records
+            .saturating_sub(maximum_source_row_shortfall(scenario.selectivity));
+        if src_rows < minimum_source_rows {
+            anyhow::bail!(
+                "source-row sanity check failed for {instance}: observed {src_rows}, expected at least {minimum_source_rows}"
+            );
+        }
         source_rows_observed = source_rows_observed.max(src_rows);
 
-        input_tps.push(cli.records as f64 / wall);
-        output_tps.push(stop as f64 / wall);
-        compute_us.push(compute_ms * 1e3 / cli.records as f64);
+        let input_tps = cli.records as f64 / wall;
+        samples.push(BenchSample {
+            instance: instance.clone(),
+            wall_clock_seconds: *wall,
+            throughput_input_records_per_sec: input_tps,
+            throughput_output_records_per_sec: stop as f64 / wall,
+            throughput_mb_per_sec: input_tps * payload_bytes as f64 / 1e6,
+            compute_us_per_input_record: compute_ms * 1e3 / cli.records as f64,
+            source_output_rows_observed: src_rows,
+        });
     }
 
-    let walls: Vec<f64> = measured.iter().map(|(_, w)| *w).collect();
+    let walls: Vec<f64> = samples
+        .iter()
+        .map(|sample| sample.wall_clock_seconds)
+        .collect();
+    let input_tps: Vec<f64> = samples
+        .iter()
+        .map(|sample| sample.throughput_input_records_per_sec)
+        .collect();
+    let output_tps: Vec<f64> = samples
+        .iter()
+        .map(|sample| sample.throughput_output_records_per_sec)
+        .collect();
+    let compute_us: Vec<f64> = samples
+        .iter()
+        .map(|sample| sample.compute_us_per_input_record)
+        .collect();
     let input_tps_median = report::median(&input_tps);
 
     Ok(BenchResult {
@@ -365,6 +438,8 @@ sinks:
         records: cli.records,
         payload_bytes,
         iterations: cli.iterations,
+        tokio_worker_threads: cli.tokio_worker_threads.map(NonZeroUsize::get),
+        samples,
         wall_clock_seconds_median: report::median(&walls),
         wall_clock_seconds_min: walls.iter().copied().fold(f64::INFINITY, f64::min),
         input_rows: cli.records,
@@ -401,4 +476,40 @@ fn write_json(path: &Path, result: &BenchResult) -> Result<()> {
     let json = serde_json::to_string_pretty(result)?;
     std::fs::write(path, json).with_context(|| format!("failed to write {}", path.display()))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_baseline_defaults_new_measurement_fields() {
+        let mut value: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../bench/baselines/blacksmith-8vcpu/avro_cdc_projection.json"
+        ))
+        .expect("committed baseline must be valid JSON");
+        let object = value
+            .as_object_mut()
+            .expect("committed baseline must be a JSON object");
+        object.remove("tokio_worker_threads");
+        object.remove("samples");
+
+        let result: BenchResult =
+            serde_json::from_value(value).expect("legacy baseline must remain readable");
+
+        assert_eq!(result.tokio_worker_threads, None);
+        assert!(result.samples.is_empty());
+    }
+
+    #[test]
+    fn worker_thread_count_must_be_nonzero() {
+        let parsed = Cli::try_parse_from(["streamling-bench", "--tokio-worker-threads", "0"]);
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn source_row_sanity_allows_only_the_final_filter_stride() {
+        assert_eq!(maximum_source_row_shortfall(1.0), 0);
+        assert_eq!(maximum_source_row_shortfall(0.1), 9);
+    }
 }

--- a/crates/streamling-bench/src/report.rs
+++ b/crates/streamling-bench/src/report.rs
@@ -80,12 +80,17 @@ pub fn compare(current: &BenchResult, baseline: &BenchResult, threshold: f64) ->
 /// empty when there is no baseline (or when seeding one).
 pub fn print_report(result: &BenchResult, comparison: &[MetricDelta]) {
     println!("\n### {} ({})", result.scenario, result.format);
+    let worker_threads = result
+        .tokio_worker_threads
+        .map(|count| count.to_string())
+        .unwrap_or_else(|| "runtime-default".to_string());
     println!(
-        "records={} payload={}B selectivity={} iterations={} runner={} version={}",
+        "records={} payload={}B selectivity={} iterations={} tokio_workers={} runner={} version={}",
         result.records,
         result.payload_bytes,
         result.selectivity,
         result.iterations,
+        worker_threads,
         result.runner_label,
         result.version,
     );

--- a/crates/streamling-core/src/checkpoints/checkpoint_management.rs
+++ b/crates/streamling-core/src/checkpoints/checkpoint_management.rs
@@ -702,7 +702,20 @@ impl CheckpointCoordinator {
             let metrics_recorder = get_checkpoint_metrics_recorder();
 
             while running.load(Ordering::SeqCst) {
-                match receiver.recv_timeout(Duration::from_millis(100)) {
+                let receiver = receiver.clone();
+                let received = match tokio::task::spawn_blocking(move || {
+                    receiver.recv_timeout(Duration::from_millis(100))
+                })
+                .await
+                {
+                    Ok(received) => received,
+                    Err(error) => {
+                        error!("Checkpoint subscriber receive task failed: {error}");
+                        break;
+                    }
+                };
+
+                match received {
                     Ok(CheckpointMessage::Ack { epoch, sink_id }) => {
                         debug!(
                             "[CheckpointCoordinator] Received checkpoint ACK for epoch: {} from sink: {}",
@@ -1368,6 +1381,24 @@ mod tests {
                 .contains_key(CHECKPOINT_MESSAGES_KEY)
         );
         assert_eq!(stripped.num_rows(), 5);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[serial]
+    async fn test_coordinator_subscriber_does_not_block_async_runtime() {
+        let mut coordinator = CheckpointCoordinator::with_timeout(300);
+        coordinator.start(3600, vec![]);
+
+        let yield_started = Instant::now();
+        tokio::task::yield_now().await;
+        let yield_elapsed = yield_started.elapsed();
+
+        coordinator.stop().await;
+
+        assert!(
+            yield_elapsed < Duration::from_millis(50),
+            "checkpoint subscriber blocked the single-threaded async runtime for {yield_elapsed:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- move the checkpoint coordinator's synchronous 100 ms receive into Tokio's blocking pool
- add a current-thread regression test for runtime starvation
- add child-only Tokio worker control and raw per-process samples to `streamling-bench`
- reject benchmark runs with missing Prometheus measurements or materially incomplete source rows

## Why

The coordinator called `crossbeam::Receiver::recv_timeout` from an async task. While idle, it occupied a Tokio worker for roughly 100 ms at a time, which can starve a one-worker runtime and consumes runtime capacity at larger worker counts.

Each receive remains bounded to 100 ms and message handling is unchanged. Dispatching individual receives also avoids making shutdown depend on an uncancellable lifetime-long blocking task.

## Benchmark

Real single-partition Kafka -> Avro decode -> SQL projection -> blackhole workload, repeated in both baseline-first and candidate-first order. Combined medians pool ten fresh measured processes per variant at each worker count:

| Tokio workers | Records/process | Baseline rows/s | Candidate rows/s | Throughput | Wall time |
|---:|---:|---:|---:|---:|---:|
| 1 | 1,000,000 | 88,986 | 107,145 | **+20.41%** | **-16.95%** |
| 2 | 5,000,000 | 106,770 | 107,218 | +0.42% | -0.42% |

The one-worker improvement was positive in both orders (+12.65% and +21.35%). The two-worker result is effectively neutral for this workload.

Process CPU per row fell slightly. Per-receive blocking-pool handoffs increased voluntary context switches and median RSS by roughly 2 MiB at one worker and 4 MiB at two workers.

## Validation

- red/green scheduler regression: baseline delayed an async yield by about 104.6 ms; candidate passes the 50 ms bound
- checkpoint-management module: 20 passed
- `streamling-bench`: 10 passed
- `test_checkpoint_progresses_through_a_union`: passed and persisted checkpoint state
- `just fix`, `just lint`, and `git diff --check`: passed

## Caveats

This demonstrates elimination of one-worker starvation, not a fleet-wide throughput improvement. The benchmark uses one Kafka partition and a blackhole sink; it does not cover multi-partition ingestion, durable sinks, or concurrent pipelines.

`perf task-clock` cannot directly sample the off-CPU blocking interval, so the CPU profiles are corroborating evidence rather than the primary benchmark.

The existing `test_multi_sink_checkpoint_finalizes_with_clickhouse_and_webhook` fixture did not yield a valid checkpoint run locally: its current record limit exited before the first checkpoint, while an experimental larger limit timed out. That test change was reverted; the fixture's record-limit interaction should be diagnosed separately.
