### PR TITLE
fix(connectors): honor projection pushdown in the hybrid source

### DIFF
--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -881,7 +881,7 @@ impl TableProvider for HybridTableProvider {
             projection.cloned(),
             filters.to_vec(),
             limit,
-        )))
+        )?))
     }
 }
 
@@ -890,6 +890,12 @@ pub struct HybridSourceExec {
     inner: Arc<dyn ExecutionPlan>,
     provider: HybridTableProvider,
     cached_properties: Arc<PlanProperties>,
+    /// The schema this exec actually emits: the provider schema with the
+    /// pushed-down projection applied. Reporting the full provider schema
+    /// while a projection is in force makes DataFusion pair projection
+    /// expressions against full-schema fields by index and fail planning
+    /// ("Input field name X does not match with the projection expression Y").
+    schema: SchemaRef,
     projection: Option<Vec<usize>>,
     filters: Vec<Expr>,
     limit: Option<usize>,
@@ -902,9 +908,14 @@ impl HybridSourceExec {
         projection: Option<Vec<usize>>,
         filters: Vec<Expr>,
         limit: Option<usize>,
-    ) -> Self {
+    ) -> DataFusionResult<Self> {
+        let schema: SchemaRef = match projection.as_ref() {
+            Some(indices) => Arc::new(provider.schema.project(indices)?),
+            None => provider.schema.clone(),
+        };
+
         let cached_properties = PlanProperties::new(
-            EquivalenceProperties::new(provider.schema.clone()),
+            EquivalenceProperties::new(schema.clone()),
             inner.properties().partitioning.clone(),
             datafusion::physical_plan::execution_plan::EmissionType::Incremental,
             datafusion::physical_plan::execution_plan::Boundedness::Unbounded {
@@ -912,15 +923,59 @@ impl HybridSourceExec {
             },
         );
 
-        Self {
+        Ok(Self {
             inner,
             provider,
             cached_properties: Arc::new(cached_properties),
+            schema,
             projection,
             filters,
             limit,
-        }
+        })
     }
+}
+
+/// Align a batch to `target` by selecting the target's columns by NAME.
+///
+/// Inner phase plans do not reliably honor the projection pushed into the
+/// hybrid scan (the bounded ClickHouse provider ignores it entirely and emits
+/// every column, in ClickHouse DESCRIBE order rather than the hybrid/Kafka
+/// schema order), so the hybrid exec — which declares `target` as its output
+/// schema — must reshape each batch itself. Name-based selection is
+/// deliberately insensitive to both column order and extra columns.
+fn align_batch_to_schema(batch: &RecordBatch, target: &SchemaRef) -> DataFusionResult<RecordBatch> {
+    let batch_schema = batch.schema();
+    // Fast path: already the exact target shape (names, in order).
+    if batch_schema.fields().len() == target.fields().len()
+        && batch_schema
+            .fields()
+            .iter()
+            .zip(target.fields())
+            .all(|(a, b)| a.name() == b.name())
+    {
+        return Ok(batch.clone());
+    }
+
+    let indices = target
+        .fields()
+        .iter()
+        .map(|field| {
+            batch_schema.index_of(field.name()).map_err(|_| {
+                DataFusionError::from(streamling_err!(
+                    "hybrid source: column '{}' required by the query is missing from an \
+                     inner phase batch (batch columns: {:?})",
+                    field.name(),
+                    batch_schema
+                        .fields()
+                        .iter()
+                        .map(|f| f.name().as_str())
+                        .collect::<Vec<_>>()
+                ))
+            })
+        })
+        .collect::<DataFusionResult<Vec<usize>>>()?;
+
+    batch.project(&indices).map_err(Into::into)
 }
 
 impl DisplayAs for HybridSourceExec {
@@ -941,7 +996,7 @@ impl ExecutionPlan for HybridSourceExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.provider.schema.clone()
+        self.schema.clone()
     }
 
     fn properties(&self) -> &Arc<PlanProperties> {
@@ -965,7 +1020,7 @@ impl ExecutionPlan for HybridSourceExec {
             self.projection.clone(),
             self.filters.clone(),
             self.limit,
-        )))
+        )?))
     }
 
     fn execute(
@@ -1197,6 +1252,18 @@ impl ExecutionPlan for HybridSourceExec {
                     };
                     match batch_result {
                         Ok(batch) => {
+                            // Inner phases do not reliably honor the pushed-down
+                            // projection (the bounded ClickHouse scan ignores it
+                            // and emits every column, in ClickHouse order), so
+                            // align each batch to the declared (projected)
+                            // schema by name before anything downstream sees it.
+                            let batch = match align_batch_to_schema(&batch, &schema_for_main) {
+                                Ok(b) => b,
+                                Err(e) => {
+                                    let _ = tx.send(Err(e)).await;
+                                    break 'outer;
+                                }
+                            };
                             // Bounded sources (ClickHouse) emit u256/i256 columns as
                             // FixedSizeBinary(32) without extension metadata and in
                             // little-endian. Reverse the bytes and adopt the target
@@ -2789,6 +2856,203 @@ mod tests {
             state.completed_phases.iter().all(|&c| c),
             "All bounded phases should be marked complete"
         );
+    }
+
+    /// A bounded phase that behaves like the real ClickHouse provider: its
+    /// scan IGNORES the pushed-down projection and emits one full-width batch
+    /// whose column order differs from the hybrid (unbounded/Kafka) schema.
+    #[derive(Debug)]
+    struct ReorderedBatchMockProvider {
+        schema: SchemaRef,
+    }
+
+    impl ReorderedBatchMockProvider {
+        /// Schema is create_test_schema() reversed: [name, id] vs [id, name].
+        fn new() -> Self {
+            Self {
+                schema: Arc::new(Schema::new(vec![
+                    Field::new("name", DataType::Utf8, false),
+                    Field::new("id", DataType::Int32, false),
+                ])),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TableProvider for ReorderedBatchMockProvider {
+        fn schema(&self) -> SchemaRef {
+            self.schema.clone()
+        }
+        fn table_type(&self) -> TableType {
+            TableType::Base
+        }
+        async fn scan(
+            &self,
+            _state: &dyn datafusion::catalog::Session,
+            _projection: Option<&Vec<usize>>,
+            _filters: &[Expr],
+            _limit: Option<usize>,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            Ok(Arc::new(ReorderedBatchMockExec {
+                schema: self.schema.clone(),
+                properties: Arc::new(PlanProperties::new(
+                    EquivalenceProperties::new(self.schema.clone()),
+                    datafusion::physical_plan::Partitioning::UnknownPartitioning(1),
+                    datafusion::physical_plan::execution_plan::EmissionType::Final,
+                    datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+                )),
+            }))
+        }
+    }
+
+    /// Emits exactly one [name, id] batch, then ends.
+    #[derive(Debug)]
+    struct ReorderedBatchMockExec {
+        schema: SchemaRef,
+        properties: Arc<PlanProperties>,
+    }
+
+    impl DisplayAs for ReorderedBatchMockExec {
+        fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "ReorderedBatchMockExec")
+        }
+    }
+
+    impl ExecutionPlan for ReorderedBatchMockExec {
+        fn name(&self) -> &str {
+            "ReorderedBatchMockExec"
+        }
+        fn schema(&self) -> SchemaRef {
+            self.schema.clone()
+        }
+        fn properties(&self) -> &Arc<PlanProperties> {
+            &self.properties
+        }
+        fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+            vec![]
+        }
+        fn with_new_children(
+            self: Arc<Self>,
+            _children: Vec<Arc<dyn ExecutionPlan>>,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            Ok(self)
+        }
+        fn execute(
+            &self,
+            _partition: usize,
+            _context: Arc<TaskContext>,
+        ) -> DataFusionResult<SendableRecordBatchStream> {
+            use datafusion::arrow::array::{Int32Array, StringArray};
+            let batch = RecordBatch::try_new(
+                self.schema.clone(),
+                vec![
+                    Arc::new(StringArray::from(vec!["a", "b"])),
+                    Arc::new(Int32Array::from(vec![1, 2])),
+                ],
+            )
+            .expect("mock batch must build");
+            Ok(Box::pin(
+                datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
+                    self.schema.clone(),
+                    futures::stream::once(async move { Ok(batch) }),
+                ),
+            ))
+        }
+    }
+
+    /// Reproduces the production planner assertion ("Input field name
+    /// reward_type does not match with the projection expression
+    /// block_timestamp"): a scan given a projection must report the PROJECTED
+    /// schema. Reporting the provider's full schema makes DataFusion pair
+    /// projection expressions against full-schema fields by index.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_scan_with_projection_reports_projected_schema() {
+        let config = HybridSourceConfig {
+            bounded_sources: vec![Arc::new(FiniteMockTableProvider::new())],
+            unbounded_source: Arc::new(FiniteMockTableProvider::new()),
+            offset_provider: None,
+            job_mode: true,
+        };
+        let state_backend = create_state_backend("test_scan_projection_schema").await;
+        let hybrid_provider = HybridTableProvider::new(
+            "test_scan_projection_schema".to_string(),
+            config,
+            create_test_schema(),
+            state_backend,
+            SESSION_MANAGER.clone(),
+        )
+        .unwrap();
+
+        let session_state = SESSION_MANAGER.session_state();
+        let projection = vec![1usize]; // just "name"
+        let plan = hybrid_provider
+            .scan(&session_state, Some(&projection), &[], None)
+            .await
+            .expect("scan should succeed");
+
+        let expected = Arc::new(create_test_schema().project(&projection).unwrap());
+        assert_eq!(
+            plan.schema(),
+            expected,
+            "plan must report the projected schema, not the full provider schema"
+        );
+    }
+
+    /// The bounded ClickHouse provider ignores the pushed-down projection and
+    /// emits full-width batches in ITS OWN column order. The hybrid exec must
+    /// still deliver batches shaped exactly like its declared (projected)
+    /// schema, aligning columns by name.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_execute_with_projection_aligns_reordered_phase_batches() {
+        let config = HybridSourceConfig {
+            bounded_sources: vec![Arc::new(ReorderedBatchMockProvider::new())],
+            unbounded_source: Arc::new(FiniteMockTableProvider::new()),
+            offset_provider: None,
+            job_mode: true,
+        };
+        let state_backend = create_state_backend("test_execute_projection_align").await;
+        let hybrid_provider = HybridTableProvider::new(
+            "test_execute_projection_align".to_string(),
+            config,
+            create_test_schema(),
+            state_backend,
+            SESSION_MANAGER.clone(),
+        )
+        .unwrap();
+
+        let session_state = SESSION_MANAGER.session_state();
+        let projection = vec![1usize]; // just "name"
+        let plan = hybrid_provider
+            .scan(&session_state, Some(&projection), &[], None)
+            .await
+            .expect("scan should succeed");
+
+        let context = Arc::new(TaskContext::default());
+        let stream = plan.execute(0, context).expect("execute should succeed");
+        let batches: Vec<_> = stream.collect().await;
+
+        let expected_schema = Arc::new(create_test_schema().project(&projection).unwrap());
+        let mut saw_data = false;
+        for batch in batches {
+            let batch = batch.expect("stream batch should not be an error");
+            if batch.num_rows() == 0 {
+                continue; // synthetic marker-flush batches are empty
+            }
+            saw_data = true;
+            assert_eq!(
+                batch.schema(),
+                expected_schema,
+                "batches must match the declared projected schema"
+            );
+            let names = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringArray>()
+                .expect("projected column must be the utf8 'name' column");
+            assert_eq!(names.value(0), "a");
+            assert_eq!(names.value(1), "b");
+        }
+        assert!(saw_data, "the bounded phase's batch must be forwarded");
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Problem

Any pipeline that fast-scans a **column-sparse derived dataset** — one whose `transformSql` references only a subset of its root dataset's columns — fails physical planning. Today that set is exactly the four `<chain>.native_transfers` datasets (13 of raw_traces' 22 columns), which power wallet-feed native backfills (FOU-1173):

```
Internal error: Assertion failed: col.name() == matching_name: Input field name reward_type
does not match with the projection expression block_timestamp.
```

Minimal repro (fails at validation, no data needed; the identical pipeline with `start_at: latest` passes — `latest` resolves to a plain Kafka source, never a hybrid):

```yaml
sources:
  nt: { type: dataset, dataset_name: base_sepolia.native_transfers, version: 1.0.0, start_at: earliest, filter: "1=1" }
transforms:
  out: { type: sql, primary_key: id, sql: SELECT id, sender, recipient, amount FROM nt }
sinks:
  devnull: { type: blackhole, from: out }
```

## Root cause (two layers)

The projection DataFusion pushes into the hybrid scan is determined by the **dataset transformSql's referenced-column set** (transforms plan at their own boundary — the user's downstream SQL does not prune through it; the repro's assertion lists the transformSql's 13 columns, not the user query's 6).

1. **Plan time**: `HybridSourceExec` reported the provider's **full** schema — in `schema()` and in the `EquivalenceProperties` of its `PlanProperties` — even when a projection was pushed into `scan()`. DataFusion pairs projection expressions against schema fields **by index**: the 13 projected raw_traces columns put `block_timestamp` at projected index 12, while full-schema field 12 is `reward_type` — the two names in the assertion. This is independent of any column-order difference between storages (the first unit test reproduces it with identical bounded/unbounded schemas).
2. **Runtime**: the bounded `ClickHouseTableProvider::scan` ignores the projection argument entirely and emits every column in **ClickHouse DESCRIBE order**, which need not match the hybrid (Kafka) schema order the exec declares.

**Why this was latent:** every previously fast-scanned dataset's transformSql references **all** of its root's columns — e.g. `erc20_transfers` uses 10/10 raw_logs columns (`SELECT *` CTE + decode consuming `topics`/`data`) — so DataFusion never had a projection to push and the broken path was never exercised. It was *not* protected by column-order compatibility. `native_transfers` is the first dataset sparse over a wide root (raw_traces' fat `input`/`output` calldata columns are exactly what it exists to strip), so it trips the assertion 100% of the time.

The Kafka source already implements the correct pattern (`kafka.rs`): it projects its `PlanProperties` schema, decodes payloads directly into the projected schema, and when a source-level `filter` needs pruned columns it builds unprojected, filters, and re-applies the projection on top.

## Fix

Both contained in `HybridSourceExec`, mirroring the Kafka provider's contract:

- `new()` computes the **projected schema** (`provider.schema.project(indices)`) and uses it for `schema()` and `PlanProperties` (constructor is now fallible; both call sites propagate).
- The phase-forwarding loop **aligns every batch to the declared schema by column name** (`align_batch_to_schema`) before the existing ClickHouse u256 normalization — so neither inner provider's projection behavior nor its column ordering is load-bearing. Kafka-phase batches arrive already projected, so the fast path is a no-op clone; the alignment does real work only for the bounded ClickHouse phase. A missing column now produces a clear error instead of a DataFusion internal assertion.

Deliberately *not* done here: pushing the projection into the ClickHouse `SELECT` itself (perf follow-up — skips shipping `input`/`output` calldata for matched granules).

## Blast radius

Nothing running can regress:
- Every pipeline that enters the changed code path (hybrid = `start_at: earliest` + filter, per the dataset preprocessor) with a sparse projection failed at planning and therefore **never deployed** — there is no workaround population to break.
- Source-level filters on root-dataset columns (`topics`, `from_address`, …) are the normal mechanism and are untouched — filter planning is separate from projection on both phases.
- `start_at: latest` pipelines (e.g. the one existing native_transfers consumer) resolve to plain Kafka sources and never touch `HybridSourceExec`.
- Datasets whose transformSql references all root columns (everything except the four native_transfers datasets today) produce no projection, so their plans are byte-for-byte unchanged.

## Testing

- Two new unit tests, written first and failing on the exact pre-fix behaviors: `test_scan_with_projection_reports_projected_schema` (fails with *identical* schemas — proving order-matching can't fix this) and `test_execute_with_projection_aligns_reordered_phase_batches` (bounded mock ignores projection and emits reordered columns, mirroring the real ClickHouse provider).
- 36/36 hybrid tests, 291/291 `streamling-connectors` lib tests, `cargo fix`/`fmt`/`clippy -D warnings` clean; CI green including e2e.
- **Live verification** in the foundry kind cluster (engine image built from this branch, validator swapped via the agent image): a wallet-feed native-transfers backfill that previously failed planning fast-scanned `base_sepolia` raw_traces + raw_logs to completion, and a live native ETH transfer on base from a watched wallet flowed through the edge pipeline to the sink.

## Urgency

Wallet-feed **native transfers backfills are blocked on this landing fleet-wide** — apply-time validation runs the fleet engine, so no per-pipeline `imageTag` override can dodge it. (Known fallback if this stalls: re-author the native datasets to reference every raw_traces column, which suppresses the projection — at the cost of shipping calldata through every scan and into the public schema. Prefer the engine fix.)

Conflicts with #124 (unbounded-phase parallelism) in `HybridSourceExec::new` and the forwarding loop — noted there; landing this first keeps the rebase mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
