### PR TITLE
fix(connectors): honor projection in the ClickHouse scan; harden hybrid alignment

### DIFF
--- a/crates/streamling-common/src/utils/batch.rs
+++ b/crates/streamling-common/src/utils/batch.rs
@@ -3,6 +3,7 @@
 use crate::error::{Result, ResultExt};
 use arrow_schema::Schema;
 use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::record_batch::RecordBatchOptions;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -21,6 +22,10 @@ pub fn enrich_batch_with_metadata(
 ) -> Result<RecordBatch> {
     let schema = batch.schema();
     let enriched_schema = Arc::new(Schema::new_with_metadata(schema.fields().clone(), metadata));
-    RecordBatch::try_new(enriched_schema, batch.columns().to_vec())
+    // Carry the row count explicitly: a batch whose projection pruned every
+    // column (e.g. a literal-only transform) has rows but no columns, and
+    // `try_new` cannot infer a row count from zero columns.
+    let options = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
+    RecordBatch::try_new_with_options(enriched_schema, batch.columns().to_vec(), &options)
         .streamling_context("failed to create RecordBatch with enriched metadata")
 }

--- a/crates/streamling-connectors/src/table_providers/clickhouse.rs
+++ b/crates/streamling-connectors/src/table_providers/clickhouse.rs
@@ -757,7 +757,7 @@ impl TableProvider for ClickHouseTableProvider {
     async fn scan(
         &self,
         _state: &dyn Session,
-        _projection: Option<&Vec<usize>>,
+        projection: Option<&Vec<usize>>,
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -766,13 +766,25 @@ impl TableProvider for ClickHouseTableProvider {
             .as_ref()
             .ok_or_else(|| streamling_err!("ClickHouseTableProvider is not a source"))?;
 
+        // Honor the pushed-down projection. DataFusion pairs the parent
+        // projection's column exprs against this plan's declared schema by
+        // index, so the exec must declare — and emit — exactly the projected
+        // schema (the same contract the Kafka and file sources uphold). The
+        // indices are relative to the external `self.schema`; the scan itself
+        // keeps reading its full column set (version-aware dedup needs the
+        // sorting keys, version column and `_gs_op`) and projects at the emit
+        // point, after the dedup-only version column is stripped.
+        let output_schema = datafusion::physical_plan::project_schema(&self.schema, projection)?;
+
         let clickhouse_source_exec = Arc::new(ClickHouseSourceExec {
             cached_properties: Arc::new(PlanProperties::new(
-                EquivalenceProperties::new(self.schema.clone()),
+                EquivalenceProperties::new(output_schema.clone()),
                 Partitioning::UnknownPartitioning(1),
                 EmissionType::Incremental,
                 Boundedness::Bounded,
             )),
+            projection: projection.cloned(),
+            output_schema,
             provider: (*self).clone(),
             split: ClickHouseSourceSplit {
                 sorting_keys: source_params.sorting_keys.clone(),
@@ -1329,6 +1341,13 @@ impl DisplayAs for ClickHouseSinkExec {
 #[derive(Debug)]
 pub struct ClickHouseSourceExec {
     cached_properties: Arc<PlanProperties>,
+    /// Pushed-down projection, relative to the provider's external schema.
+    /// Applied at the emit point (after the dedup-only version column is
+    /// stripped) so the emitted batches match `output_schema`.
+    projection: Option<Vec<usize>>,
+    /// The provider's external schema with `projection` applied — what this
+    /// exec declares and emits.
+    output_schema: SchemaRef,
     provider: ClickHouseTableProvider,
     split: ClickHouseSourceSplit,
 }
@@ -1346,6 +1365,10 @@ impl DisplayAs for ClickHouseSourceExec {
 impl ExecutionPlan for ClickHouseSourceExec {
     fn name(&self) -> &str {
         "ClickHouseSourceExec"
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.output_schema.clone()
     }
 
     fn properties(&self) -> &Arc<PlanProperties> {
@@ -1367,7 +1390,13 @@ impl ExecutionPlan for ClickHouseSourceExec {
         _partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
+        // `schema` is the provider's full external schema — the shape of a
+        // scan batch once the dedup-only version column is stripped, and the
+        // index space of `projection`. `output_schema` is what this exec
+        // declares and emits: `schema` with `projection` applied.
         let schema = self.provider.schema.clone();
+        let output_schema = self.output_schema.clone();
+        let projection = self.projection.clone();
 
         let source_params = self
             .provider
@@ -1376,7 +1405,7 @@ impl ExecutionPlan for ClickHouseSourceExec {
             .ok_or_else(|| streamling_err!("ClickHouseSourceExec is not a source"))?;
 
         let mut builder = RecordBatchReceiverStreamBuilder::new(
-            schema.clone(),
+            output_schema.clone(),
             source_params.datafusion_buffer_size,
         );
         let tx = builder.tx();
@@ -1417,7 +1446,7 @@ impl ExecutionPlan for ClickHouseSourceExec {
         let dedup_version_column = source_params.dedup_version_column.clone();
         let dedup_key = source_params.sorting_keys.join(",");
         let project_out_version_index = source_params.project_out_version_index;
-        let empty_batch_schema = schema.clone();
+        let empty_batch_schema = output_schema.clone();
 
         // Shared checkpoint buffer for metadata propagation
         let checkpoint_buffer = Arc::new(Mutex::new(Vec::<CheckpointMessage>::new()));
@@ -1852,6 +1881,26 @@ impl ExecutionPlan for ClickHouseSourceExec {
                                         .map(|b| {
                                             project_out_column(b, drop_idx, schema.clone())
                                         })
+                                        .collect::<Result<Vec<_>>>()
+                                    {
+                                        Ok(p) => emit_batches = p,
+                                        Err(e) => {
+                                            let _ = tx.send(Err(e)).await;
+                                            break;
+                                        }
+                                    }
+                                }
+                                // Apply the pushed-down projection. Indices are
+                                // relative to the external schema, so this must
+                                // run after the version column is stripped and
+                                // before checkpoint metadata is attached (so it
+                                // rides the final shape). `RecordBatch::project`
+                                // keeps the row count, so a projection that
+                                // prunes every column still emits its rows.
+                                if let Some(indices) = &projection {
+                                    match emit_batches
+                                        .into_iter()
+                                        .map(|b| b.project(indices).map_err(DataFusionError::from))
                                         .collect::<Result<Vec<_>>>()
                                     {
                                         Ok(p) => emit_batches = p,
@@ -4885,6 +4934,106 @@ mod tests {
             source_exec.split.args, initial_split_args,
             "scan should seed execution split with initial start args"
         );
+    }
+
+    /// The scan must honor a pushed-down projection: DataFusion pairs a parent
+    /// projection's column exprs against this plan's declared schema by index,
+    /// so declaring the full schema while a projection is in force fails
+    /// planning ("Input field name X does not match with the projection
+    /// expression Y") for any non-prefix subset. Both schema surfaces DataFusion
+    /// consults must be projected. `scan()` does no I/O, so no server is needed.
+    #[tokio::test]
+    async fn test_source_scan_reports_projected_schema() {
+        use datafusion::execution::context::SessionContext;
+        use streamling_state::StateOperatorBackendFactory;
+        use streamling_state::in_memory::InMemoryStateOperatorBackendFactory;
+
+        let pagination_config = ClickHousePaginationConfig {
+            sorting_keys: vec!["block_number".to_string(), "id".to_string()],
+            page_size: 1000,
+        };
+        let query_builder = ClickHouseQueryBuilder::of(
+            "test_table".to_string(),
+            vec![
+                "block_number".to_string(),
+                "id".to_string(),
+                "payload".to_string(),
+            ],
+            None,
+            Some(pagination_config),
+        );
+        let state_backend_factory = InMemoryStateOperatorBackendFactory::new()
+            .expect("failed to create in-memory state backend factory");
+        let state_store = Arc::new(ClickHouseSourceStateStore {
+            reference_name: "test_source".to_string(),
+            state_backend: state_backend_factory.create::<ClickHouseSourceSplit>("test_ns_proj"),
+        });
+        let full_schema = Arc::new(Schema::new(vec![
+            Field::new("block_number", DataType::Int64, false),
+            Field::new("id", DataType::Utf8, false),
+            Field::new("payload", DataType::Utf8, true),
+        ]));
+        let provider = ClickHouseTableProvider {
+            reference_name: "test_source".to_string(),
+            schema: full_schema.clone(),
+            client: ClickHouseClient::new(ClickHouseConfig {
+                url: "http://localhost:8123".to_string(),
+                database: "default".to_string(),
+                user: "default".to_string(),
+                password: "".to_string(),
+                compression: ClickHouseCompression::None,
+                compression_level: GzipCompressionLevel::default(),
+            }),
+            source_params: Some(SourceParams {
+                query_builder,
+                sorting_keys: vec!["block_number".to_string(), "id".to_string()],
+                initial_split_args: vec![ScalarValue::Int64(Some(0))],
+                state_store,
+                datafusion_buffer_size: 16,
+                record_batch_size: 1000,
+                sort_key_range: 1_000_000,
+                table_name: "test_table".to_string(),
+                has_persisted_split: false,
+                dedup_version_column: None,
+                project_out_version_index: None,
+            }),
+            sink_params: None,
+            metric_metadata_id: "test_metric".to_string(),
+        };
+
+        let session = SessionContext::new();
+        let session_state = session.state();
+
+        // Non-prefix, reordered subset: [payload, block_number].
+        let projection = vec![2usize, 0];
+        let plan = provider
+            .scan(&session_state, Some(&projection), &[], None)
+            .await
+            .expect("scan should succeed");
+        let expected = Arc::new(full_schema.project(&projection).unwrap());
+        assert_eq!(plan.schema(), expected, "schema() must be projected");
+        assert_eq!(
+            plan.properties().eq_properties.schema(),
+            &expected,
+            "PlanProperties must carry the projected schema"
+        );
+        let names: Vec<_> = plan
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["payload".to_string(), "block_number".to_string()]
+        );
+
+        // No projection: unchanged full schema.
+        let plan = provider
+            .scan(&session_state, None, &[], None)
+            .await
+            .expect("scan should succeed");
+        assert_eq!(plan.schema(), full_schema);
     }
 
     #[tokio::test]

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -3055,6 +3055,308 @@ mod tests {
         assert!(saw_data, "the bounded phase's batch must be forwarded");
     }
 
+    // ---- Projection-pushdown regression tests beyond the two above: real
+    // DataFusion SQL planning, checkpoint-metadata survival through the
+    // per-batch align, zero-column projections, and the missing-column path.
+
+    /// Bounded mock that IGNORES the pushed-down projection and emits exactly
+    /// one 2-row batch shaped like `emit_schema` (which may carry schema
+    /// metadata, the way checkpoint markers do), while declaring `emit_schema`
+    /// as its own schema.
+    #[derive(Debug)]
+    struct ShapedMockProvider {
+        /// What the provider CLAIMS (passes HybridTableProvider::new validation).
+        declared_schema: SchemaRef,
+        /// What its batches actually look like.
+        emit_schema: SchemaRef,
+    }
+
+    #[async_trait]
+    impl TableProvider for ShapedMockProvider {
+        fn schema(&self) -> SchemaRef {
+            self.declared_schema.clone()
+        }
+        fn table_type(&self) -> TableType {
+            TableType::Base
+        }
+        async fn scan(
+            &self,
+            _state: &dyn datafusion::catalog::Session,
+            _projection: Option<&Vec<usize>>,
+            _filters: &[Expr],
+            _limit: Option<usize>,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            Ok(Arc::new(ShapedMockExec {
+                schema: self.emit_schema.clone(),
+                properties: Arc::new(PlanProperties::new(
+                    EquivalenceProperties::new(self.emit_schema.clone()),
+                    datafusion::physical_plan::Partitioning::UnknownPartitioning(1),
+                    datafusion::physical_plan::execution_plan::EmissionType::Final,
+                    datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+                )),
+            }))
+        }
+    }
+
+    #[derive(Debug)]
+    struct ShapedMockExec {
+        schema: SchemaRef,
+        properties: Arc<PlanProperties>,
+    }
+
+    impl DisplayAs for ShapedMockExec {
+        fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "ShapedMockExec")
+        }
+    }
+
+    impl ExecutionPlan for ShapedMockExec {
+        fn name(&self) -> &str {
+            "ShapedMockExec"
+        }
+        fn schema(&self) -> SchemaRef {
+            self.schema.clone()
+        }
+        fn properties(&self) -> &Arc<PlanProperties> {
+            &self.properties
+        }
+        fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+            vec![]
+        }
+        fn with_new_children(
+            self: Arc<Self>,
+            _children: Vec<Arc<dyn ExecutionPlan>>,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            Ok(self)
+        }
+        fn execute(
+            &self,
+            _partition: usize,
+            _context: Arc<TaskContext>,
+        ) -> DataFusionResult<SendableRecordBatchStream> {
+            use datafusion::arrow::array::{ArrayRef, Int32Array, StringArray};
+            let columns: Vec<ArrayRef> = self
+                .schema
+                .fields()
+                .iter()
+                .map(|f| match f.data_type() {
+                    DataType::Int32 => Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
+                    DataType::Utf8 => Arc::new(StringArray::from(vec!["a", "b"])) as ArrayRef,
+                    other => panic!("mock: unsupported type {other:?}"),
+                })
+                .collect();
+            let batch = RecordBatch::try_new(self.schema.clone(), columns).expect("mock batch");
+            Ok(Box::pin(
+                datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
+                    self.schema.clone(),
+                    futures::stream::once(async move { Ok(batch) }),
+                ),
+            ))
+        }
+    }
+
+    async fn job_mode_hybrid(name: &str, bounded: Arc<dyn TableProvider>) -> HybridTableProvider {
+        let config = HybridSourceConfig {
+            bounded_sources: vec![bounded],
+            unbounded_source: Arc::new(FiniteMockTableProvider::new()),
+            offset_provider: None,
+            job_mode: true,
+        };
+        let state_backend = create_state_backend(name).await;
+        HybridTableProvider::new(
+            name.to_string(),
+            config,
+            create_test_schema(),
+            state_backend,
+            SESSION_MANAGER.clone(),
+        )
+        .unwrap()
+    }
+
+    /// Go through REAL DataFusion SQL planning, not just `provider.scan()`.
+    /// `upper(name)` keeps a ProjectionExec above the scan, so the projection
+    /// `[1]` is pushed into `scan()` AND `ProjectionMapping::try_new` runs
+    /// against the hybrid exec's declared schema — the production failure
+    /// path. Pre-fix this fails with `Input field name id does not match with
+    /// the projection expression name`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_datafusion_sql_projection_plans_and_executes_through_hybrid() {
+        let reordered = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("id", DataType::Int32, false),
+        ]));
+        let provider = job_mode_hybrid(
+            "test_df_sql_projection",
+            Arc::new(ShapedMockProvider {
+                declared_schema: reordered.clone(),
+                emit_schema: reordered,
+            }),
+        )
+        .await;
+        let ctx = SESSION_MANAGER.session_context();
+        ctx.register_table("test_df_sql_projection", Arc::new(provider))
+            .expect("register");
+        let df = ctx
+            .sql("SELECT upper(name) AS n FROM test_df_sql_projection")
+            .await
+            .expect("logical plan");
+        let plan = df
+            .create_physical_plan()
+            .await
+            .expect("physical plan must build");
+        let names: Vec<_> = plan
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+        assert_eq!(names, vec!["n".to_string()]);
+
+        let stream = plan
+            .execute(0, Arc::new(TaskContext::default()))
+            .expect("execute");
+        let batches: Vec<_> = stream.collect().await;
+        let mut values = Vec::new();
+        for b in batches {
+            let b = b.expect("batch ok");
+            if b.num_rows() == 0 {
+                continue;
+            }
+            let col = b
+                .column(0)
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringArray>()
+                .expect("utf8");
+            for i in 0..b.num_rows() {
+                values.push(col.value(i).to_string());
+            }
+        }
+        assert_eq!(values, vec!["A".to_string(), "B".to_string()]);
+    }
+
+    /// Schema metadata on inner batches (where checkpoint Markers/Finalizers
+    /// ride) must survive `align_batch_to_schema`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_align_preserves_batch_schema_metadata() {
+        let mut md = HashMap::new();
+        md.insert("test.marker".to_string(), "epoch-7".to_string());
+        let reordered_with_md = Arc::new(Schema::new_with_metadata(
+            vec![
+                Field::new("name", DataType::Utf8, false),
+                Field::new("id", DataType::Int32, false),
+            ],
+            md,
+        ));
+        let provider = job_mode_hybrid(
+            "test_align_metadata",
+            Arc::new(ShapedMockProvider {
+                declared_schema: reordered_with_md.clone(),
+                emit_schema: reordered_with_md,
+            }),
+        )
+        .await;
+        let session_state = SESSION_MANAGER.session_state();
+        let projection = vec![1usize];
+        let plan = provider
+            .scan(&session_state, Some(&projection), &[], None)
+            .await
+            .expect("scan");
+        let stream = plan
+            .execute(0, Arc::new(TaskContext::default()))
+            .expect("execute");
+        let batches: Vec<_> = stream.collect().await;
+        let mut saw = false;
+        for b in batches {
+            let b = b.expect("batch ok");
+            if b.num_rows() == 0 {
+                continue;
+            }
+            saw = true;
+            assert_eq!(b.num_columns(), 1);
+            assert_eq!(b.schema().field(0).name(), "name");
+            assert_eq!(
+                b.schema().metadata().get("test.marker").map(String::as_str),
+                Some("epoch-7"),
+                "schema metadata must survive align (checkpoint markers live there)"
+            );
+        }
+        assert!(saw);
+    }
+
+    /// Zero-column projection (`Some(vec![])`): the declared schema has no
+    /// fields and the aligned batch must keep its row count.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_empty_projection_keeps_row_count() {
+        let reordered = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("id", DataType::Int32, false),
+        ]));
+        let provider = job_mode_hybrid(
+            "test_empty_projection",
+            Arc::new(ShapedMockProvider {
+                declared_schema: reordered.clone(),
+                emit_schema: reordered,
+            }),
+        )
+        .await;
+        let session_state = SESSION_MANAGER.session_state();
+        let projection: Vec<usize> = vec![];
+        let plan = provider
+            .scan(&session_state, Some(&projection), &[], None)
+            .await
+            .expect("scan");
+        assert_eq!(plan.schema().fields().len(), 0);
+        let stream = plan
+            .execute(0, Arc::new(TaskContext::default()))
+            .expect("execute");
+        let batches: Vec<_> = stream.collect().await;
+        let mut saw = false;
+        for b in batches {
+            let b = b.expect("batch ok");
+            if b.num_rows() == 0 {
+                continue;
+            }
+            saw = true;
+            assert_eq!(b.num_columns(), 0);
+            assert_eq!(b.num_rows(), 2);
+        }
+        assert!(saw, "the 2-row batch must be forwarded with zero columns");
+    }
+
+    /// A bounded phase whose batches carry FEWER columns than its declared
+    /// schema must surface a clear error and end the stream, not hang.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_missing_column_in_phase_batch_errors_and_terminates() {
+        let narrow = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, false)]));
+        let provider = job_mode_hybrid(
+            "test_missing_column",
+            Arc::new(ShapedMockProvider {
+                declared_schema: create_test_schema(),
+                emit_schema: narrow,
+            }),
+        )
+        .await;
+        let session_state = SESSION_MANAGER.session_state();
+        let plan = provider
+            .scan(&session_state, None, &[], None)
+            .await
+            .expect("scan");
+        let stream = plan
+            .execute(0, Arc::new(TaskContext::default()))
+            .expect("execute");
+        let batches = tokio::time::timeout(Duration::from_secs(15), stream.collect::<Vec<_>>())
+            .await
+            .expect("stream must terminate after the align error");
+        let errs: Vec<String> = batches
+            .iter()
+            .filter_map(|r| r.as_ref().err().map(|e| e.to_string()))
+            .collect();
+        assert!(
+            errs.iter()
+                .any(|e| e.contains("column 'id'") && e.contains("missing")),
+            "expected a clear missing-column error, got: {errs:?}"
+        );
+    }
     #[tokio::test(flavor = "multi_thread")]
     async fn test_hybrid_source_execute_continues_to_unbounded_without_job_mode() {
         let bounded_sources: Vec<Arc<dyn TableProvider>> =

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -881,7 +881,7 @@ impl TableProvider for HybridTableProvider {
             projection.cloned(),
             filters.to_vec(),
             limit,
-        )))
+        )?))
     }
 }
 
@@ -890,6 +890,12 @@ pub struct HybridSourceExec {
     inner: Arc<dyn ExecutionPlan>,
     provider: HybridTableProvider,
     cached_properties: Arc<PlanProperties>,
+    /// The schema this exec actually emits: the provider schema with the
+    /// pushed-down projection applied. Reporting the full provider schema
+    /// while a projection is in force makes DataFusion pair projection
+    /// expressions against full-schema fields by index and fail planning
+    /// ("Input field name X does not match with the projection expression Y").
+    schema: SchemaRef,
     projection: Option<Vec<usize>>,
     filters: Vec<Expr>,
     limit: Option<usize>,
@@ -902,9 +908,14 @@ impl HybridSourceExec {
         projection: Option<Vec<usize>>,
         filters: Vec<Expr>,
         limit: Option<usize>,
-    ) -> Self {
+    ) -> DataFusionResult<Self> {
+        let schema: SchemaRef = match projection.as_ref() {
+            Some(indices) => Arc::new(provider.schema.project(indices)?),
+            None => provider.schema.clone(),
+        };
+
         let cached_properties = PlanProperties::new(
-            EquivalenceProperties::new(provider.schema.clone()),
+            EquivalenceProperties::new(schema.clone()),
             inner.properties().partitioning.clone(),
             datafusion::physical_plan::execution_plan::EmissionType::Incremental,
             datafusion::physical_plan::execution_plan::Boundedness::Unbounded {
@@ -912,15 +923,59 @@ impl HybridSourceExec {
             },
         );
 
-        Self {
+        Ok(Self {
             inner,
             provider,
             cached_properties: Arc::new(cached_properties),
+            schema,
             projection,
             filters,
             limit,
-        }
+        })
     }
+}
+
+/// Align a batch to `target` by selecting the target's columns by NAME.
+///
+/// Inner phase plans do not reliably honor the projection pushed into the
+/// hybrid scan (the bounded ClickHouse provider ignores it entirely and emits
+/// every column, in ClickHouse DESCRIBE order rather than the hybrid/Kafka
+/// schema order), so the hybrid exec — which declares `target` as its output
+/// schema — must reshape each batch itself. Name-based selection is
+/// deliberately insensitive to both column order and extra columns.
+fn align_batch_to_schema(batch: &RecordBatch, target: &SchemaRef) -> DataFusionResult<RecordBatch> {
+    let batch_schema = batch.schema();
+    // Fast path: already the exact target shape (names, in order).
+    if batch_schema.fields().len() == target.fields().len()
+        && batch_schema
+            .fields()
+            .iter()
+            .zip(target.fields())
+            .all(|(a, b)| a.name() == b.name())
+    {
+        return Ok(batch.clone());
+    }
+
+    let indices = target
+        .fields()
+        .iter()
+        .map(|field| {
+            batch_schema.index_of(field.name()).map_err(|_| {
+                DataFusionError::from(streamling_err!(
+                    "hybrid source: column '{}' required by the query is missing from an \
+                     inner phase batch (batch columns: {:?})",
+                    field.name(),
+                    batch_schema
+                        .fields()
+                        .iter()
+                        .map(|f| f.name().as_str())
+                        .collect::<Vec<_>>()
+                ))
+            })
+        })
+        .collect::<DataFusionResult<Vec<usize>>>()?;
+
+    batch.project(&indices).map_err(Into::into)
 }
 
 impl DisplayAs for HybridSourceExec {
@@ -941,7 +996,7 @@ impl ExecutionPlan for HybridSourceExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        self.provider.schema.clone()
+        self.schema.clone()
     }
 
     fn properties(&self) -> &Arc<PlanProperties> {
@@ -965,7 +1020,7 @@ impl ExecutionPlan for HybridSourceExec {
             self.projection.clone(),
             self.filters.clone(),
             self.limit,
-        )))
+        )?))
     }
 
     fn execute(
@@ -1197,6 +1252,18 @@ impl ExecutionPlan for HybridSourceExec {
                     };
                     match batch_result {
                         Ok(batch) => {
+                            // Inner phases do not reliably honor the pushed-down
+                            // projection (the bounded ClickHouse scan ignores it
+                            // and emits every column, in ClickHouse order), so
+                            // align each batch to the declared (projected)
+                            // schema by name before anything downstream sees it.
+                            let batch = match align_batch_to_schema(&batch, &schema_for_main) {
+                                Ok(b) => b,
+                                Err(e) => {
+                                    let _ = tx.send(Err(e)).await;
+                                    break 'outer;
+                                }
+                            };
                             // Bounded sources (ClickHouse) emit u256/i256 columns as
                             // FixedSizeBinary(32) without extension metadata and in
                             // little-endian. Reverse the bytes and adopt the target
@@ -2789,6 +2856,203 @@ mod tests {
             state.completed_phases.iter().all(|&c| c),
             "All bounded phases should be marked complete"
         );
+    }
+
+    /// A bounded phase that behaves like the real ClickHouse provider: its
+    /// scan IGNORES the pushed-down projection and emits one full-width batch
+    /// whose column order differs from the hybrid (unbounded/Kafka) schema.
+    #[derive(Debug)]
+    struct ReorderedBatchMockProvider {
+        schema: SchemaRef,
+    }
+
+    impl ReorderedBatchMockProvider {
+        /// Schema is create_test_schema() reversed: [name, id] vs [id, name].
+        fn new() -> Self {
+            Self {
+                schema: Arc::new(Schema::new(vec![
+                    Field::new("name", DataType::Utf8, false),
+                    Field::new("id", DataType::Int32, false),
+                ])),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl TableProvider for ReorderedBatchMockProvider {
+        fn schema(&self) -> SchemaRef {
+            self.schema.clone()
+        }
+        fn table_type(&self) -> TableType {
+            TableType::Base
+        }
+        async fn scan(
+            &self,
+            _state: &dyn datafusion::catalog::Session,
+            _projection: Option<&Vec<usize>>,
+            _filters: &[Expr],
+            _limit: Option<usize>,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            Ok(Arc::new(ReorderedBatchMockExec {
+                schema: self.schema.clone(),
+                properties: Arc::new(PlanProperties::new(
+                    EquivalenceProperties::new(self.schema.clone()),
+                    datafusion::physical_plan::Partitioning::UnknownPartitioning(1),
+                    datafusion::physical_plan::execution_plan::EmissionType::Final,
+                    datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+                )),
+            }))
+        }
+    }
+
+    /// Emits exactly one [name, id] batch, then ends.
+    #[derive(Debug)]
+    struct ReorderedBatchMockExec {
+        schema: SchemaRef,
+        properties: Arc<PlanProperties>,
+    }
+
+    impl DisplayAs for ReorderedBatchMockExec {
+        fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "ReorderedBatchMockExec")
+        }
+    }
+
+    impl ExecutionPlan for ReorderedBatchMockExec {
+        fn name(&self) -> &str {
+            "ReorderedBatchMockExec"
+        }
+        fn schema(&self) -> SchemaRef {
+            self.schema.clone()
+        }
+        fn properties(&self) -> &Arc<PlanProperties> {
+            &self.properties
+        }
+        fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+            vec![]
+        }
+        fn with_new_children(
+            self: Arc<Self>,
+            _children: Vec<Arc<dyn ExecutionPlan>>,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            Ok(self)
+        }
+        fn execute(
+            &self,
+            _partition: usize,
+            _context: Arc<TaskContext>,
+        ) -> DataFusionResult<SendableRecordBatchStream> {
+            use datafusion::arrow::array::{Int32Array, StringArray};
+            let batch = RecordBatch::try_new(
+                self.schema.clone(),
+                vec![
+                    Arc::new(StringArray::from(vec!["a", "b"])),
+                    Arc::new(Int32Array::from(vec![1, 2])),
+                ],
+            )
+            .expect("mock batch must build");
+            Ok(Box::pin(
+                datafusion::physical_plan::stream::RecordBatchStreamAdapter::new(
+                    self.schema.clone(),
+                    futures::stream::once(async move { Ok(batch) }),
+                ),
+            ))
+        }
+    }
+
+    /// Reproduces the production planner assertion ("Input field name
+    /// reward_type does not match with the projection expression
+    /// block_timestamp"): a scan given a projection must report the PROJECTED
+    /// schema. Reporting the provider's full schema makes DataFusion pair
+    /// projection expressions against full-schema fields by index.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_scan_with_projection_reports_projected_schema() {
+        let config = HybridSourceConfig {
+            bounded_sources: vec![Arc::new(FiniteMockTableProvider::new())],
+            unbounded_source: Arc::new(FiniteMockTableProvider::new()),
+            offset_provider: None,
+            job_mode: true,
+        };
+        let state_backend = create_state_backend("test_scan_projection_schema").await;
+        let hybrid_provider = HybridTableProvider::new(
+            "test_scan_projection_schema".to_string(),
+            config,
+            create_test_schema(),
+            state_backend,
+            SESSION_MANAGER.clone(),
+        )
+        .unwrap();
+
+        let session_state = SESSION_MANAGER.session_state();
+        let projection = vec![1usize]; // just "name"
+        let plan = hybrid_provider
+            .scan(&session_state, Some(&projection), &[], None)
+            .await
+            .expect("scan should succeed");
+
+        let expected = Arc::new(create_test_schema().project(&projection).unwrap());
+        assert_eq!(
+            plan.schema(),
+            expected,
+            "plan must report the projected schema, not the full provider schema"
+        );
+    }
+
+    /// The bounded ClickHouse provider ignores the pushed-down projection and
+    /// emits full-width batches in ITS OWN column order. The hybrid exec must
+    /// still deliver batches shaped exactly like its declared (projected)
+    /// schema, aligning columns by name.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_execute_with_projection_aligns_reordered_phase_batches() {
+        let config = HybridSourceConfig {
+            bounded_sources: vec![Arc::new(ReorderedBatchMockProvider::new())],
+            unbounded_source: Arc::new(FiniteMockTableProvider::new()),
+            offset_provider: None,
+            job_mode: true,
+        };
+        let state_backend = create_state_backend("test_execute_projection_align").await;
+        let hybrid_provider = HybridTableProvider::new(
+            "test_execute_projection_align".to_string(),
+            config,
+            create_test_schema(),
+            state_backend,
+            SESSION_MANAGER.clone(),
+        )
+        .unwrap();
+
+        let session_state = SESSION_MANAGER.session_state();
+        let projection = vec![1usize]; // just "name"
+        let plan = hybrid_provider
+            .scan(&session_state, Some(&projection), &[], None)
+            .await
+            .expect("scan should succeed");
+
+        let context = Arc::new(TaskContext::default());
+        let stream = plan.execute(0, context).expect("execute should succeed");
+        let batches: Vec<_> = stream.collect().await;
+
+        let expected_schema = Arc::new(create_test_schema().project(&projection).unwrap());
+        let mut saw_data = false;
+        for batch in batches {
+            let batch = batch.expect("stream batch should not be an error");
+            if batch.num_rows() == 0 {
+                continue; // synthetic marker-flush batches are empty
+            }
+            saw_data = true;
+            assert_eq!(
+                batch.schema(),
+                expected_schema,
+                "batches must match the declared projected schema"
+            );
+            let names = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringArray>()
+                .expect("projected column must be the utf8 'name' column");
+            assert_eq!(names.value(0), "a");
+            assert_eq!(names.value(1), "b");
+        }
+        assert!(saw_data, "the bounded phase's batch must be forwarded");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/streamling-connectors/src/table_providers/hybrid.rs
+++ b/crates/streamling-connectors/src/table_providers/hybrid.rs
@@ -7,7 +7,7 @@ use crate::table_providers::clickhouse::{ClickHouseClient, ClickHouseTableProvid
 use crate::table_providers::kafka::KafkaSourceTableProvider;
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
-use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::array::{RecordBatch, RecordBatchOptions};
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -844,11 +844,63 @@ impl HybridTableProvider {
     ) -> DataFusionResult<SendableRecordBatchStream> {
         let current_source = self.get_current_source().await?;
         let session_state = self.session_manager.session_state();
+        let inner_projection = translate_projection(
+            &self.reference_name,
+            &self.schema,
+            &current_source.schema(),
+            projection.as_ref(),
+        )?;
         let plan = current_source
-            .scan(&session_state, projection.as_ref(), filters, limit)
+            .scan(&session_state, inner_projection.as_ref(), filters, limit)
             .await?;
         plan.execute(partition, context)
     }
+}
+
+/// Re-express a projection pushed against the hybrid schema in an inner
+/// phase's own index space, matching columns by name.
+///
+/// Phase schemas are validated against the hybrid schema by NAME only
+/// (`validate_schemas`), so a phase may be a permutation of it: the ClickHouse
+/// SELECT always appends `_gs_op` last, while a Kafka payload that carries its
+/// own `_gs_op` keeps it in place. Pushing hybrid indices through untranslated
+/// would make any phase that honors the projection select the wrong columns.
+fn translate_projection(
+    reference_name: &str,
+    hybrid_schema: &Schema,
+    inner_schema: &Schema,
+    projection: Option<&Vec<usize>>,
+) -> DataFusionResult<Option<Vec<usize>>> {
+    let Some(indices) = projection else {
+        return Ok(None);
+    };
+    indices
+        .iter()
+        .map(|&i| {
+            let name = hybrid_schema.fields().get(i).map(|f| f.name()).ok_or_else(|| {
+                DataFusionError::from(streamling_err!(
+                    "hybrid source '{}': projection index {} is out of range for a {}-column schema",
+                    reference_name,
+                    i,
+                    hybrid_schema.fields().len()
+                ))
+            })?;
+            inner_schema.index_of(name).map_err(|_| {
+                DataFusionError::from(streamling_err!(
+                    "hybrid source '{}': column '{}' is missing from the current phase schema \
+                     (phase columns: {:?})",
+                    reference_name,
+                    name,
+                    inner_schema
+                        .fields()
+                        .iter()
+                        .map(|f| f.name().as_str())
+                        .collect::<Vec<_>>()
+                ))
+            })
+        })
+        .collect::<DataFusionResult<Vec<usize>>>()
+        .map(Some)
 }
 
 #[async_trait]
@@ -871,8 +923,14 @@ impl TableProvider for HybridTableProvider {
         self.load_state().await?;
 
         let current_source = self.get_current_source().await?;
+        let inner_projection = translate_projection(
+            &self.reference_name,
+            &self.schema,
+            &current_source.schema(),
+            projection,
+        )?;
         let inner_plan = current_source
-            .scan(state, projection, filters, limit)
+            .scan(state, inner_projection.as_ref(), filters, limit)
             .await?;
 
         Ok(Arc::new(HybridSourceExec::new(
@@ -937,12 +995,25 @@ impl HybridSourceExec {
 
 /// Align a batch to `target` by selecting the target's columns by NAME.
 ///
-/// Inner phase plans do not reliably honor the projection pushed into the
-/// hybrid scan (the bounded ClickHouse provider ignores it entirely and emits
-/// every column, in ClickHouse DESCRIBE order rather than the hybrid/Kafka
-/// schema order), so the hybrid exec — which declares `target` as its output
-/// schema — must reshape each batch itself. Name-based selection is
-/// deliberately insensitive to both column order and extra columns.
+/// The hybrid exec declares `target` (the hybrid schema with the pushed-down
+/// projection applied) as its output, but inner phases are only validated
+/// against the hybrid schema by name, so a phase batch may legitimately be a
+/// permutation or a superset of it:
+///
+/// - the ClickHouse SELECT is generated from the Kafka schema but always moves
+///   `_gs_op` last, while a Kafka payload that carries its own `_gs_op` keeps
+///   it in place — so even with `projection == None` the two phases can
+///   disagree on column order;
+/// - a phase that does not honor the pushed-down projection emits its full
+///   column set, i.e. a superset of `target`;
+/// - a pushed projection need not be a prefix, so positional pairing against a
+///   full-width batch reads the wrong arrays.
+///
+/// Name-based selection is insensitive to all three. Only names and order are
+/// normalized: each column keeps the phase's own `Field` (nullability, List
+/// child names, u256 metadata) — the u256 normalizer downstream pairs by name
+/// and tolerates those differences on purpose. `RecordBatch::project` preserves
+/// schema metadata, so checkpoint markers riding on the batch survive.
 fn align_batch_to_schema(batch: &RecordBatch, target: &SchemaRef) -> DataFusionResult<RecordBatch> {
     let batch_schema = batch.schema();
     // Fast path: already the exact target shape (names, in order).
@@ -1252,11 +1323,10 @@ impl ExecutionPlan for HybridSourceExec {
                     };
                     match batch_result {
                         Ok(batch) => {
-                            // Inner phases do not reliably honor the pushed-down
-                            // projection (the bounded ClickHouse scan ignores it
-                            // and emits every column, in ClickHouse order), so
-                            // align each batch to the declared (projected)
-                            // schema by name before anything downstream sees it.
+                            // Phase batches may be a permutation or superset of
+                            // the declared (projected) schema — see
+                            // `align_batch_to_schema` — so align each batch by
+                            // name before anything downstream sees it.
                             let batch = match align_batch_to_schema(&batch, &schema_for_main) {
                                 Ok(b) => b,
                                 Err(e) => {
@@ -1510,7 +1580,12 @@ fn merge_pending_markers(
         batch.schema().fields().clone(),
         md,
     ));
-    match RecordBatch::try_new(new_schema, batch.columns().to_vec()) {
+    // Carry the row count explicitly: a projection that prunes every column
+    // (e.g. a literal-only transform) yields batches with rows but no columns,
+    // and `try_new` cannot infer a row count from zero columns — it would fail
+    // on every data batch and strand the buffered markers until phase end.
+    let options = RecordBatchOptions::new().with_row_count(Some(batch.num_rows()));
+    match RecordBatch::try_new_with_options(new_schema, batch.columns().to_vec(), &options) {
         Ok(merged) => merged,
         Err(e) => {
             // Re-queue the drained markers so the next merge or the final
@@ -2858,9 +2933,13 @@ mod tests {
         );
     }
 
-    /// A bounded phase that behaves like the real ClickHouse provider: its
-    /// scan IGNORES the pushed-down projection and emits one full-width batch
-    /// whose column order differs from the hybrid (unbounded/Kafka) schema.
+    /// A bounded phase that declares the hybrid's columns in a different ORDER
+    /// (`[name, id]` vs the hybrid's `[id, name]`), IGNORES the pushed-down
+    /// projection, and emits one full-width batch in its own order. Phase
+    /// schemas are validated by name only, so this is a legal phase — it is
+    /// the shape the ClickHouse phase takes when the Kafka payload carries its
+    /// own `_gs_op` (the ClickHouse SELECT always moves `_gs_op` last), and a
+    /// stricter stand-in for a phase that emits a column superset.
     #[derive(Debug)]
     struct ReorderedBatchMockProvider {
         schema: SchemaRef,
@@ -2996,12 +3075,31 @@ mod tests {
             expected,
             "plan must report the projected schema, not the full provider schema"
         );
+        // DataFusion derives a parent's output properties from the child's
+        // equivalence properties, so that schema surface must be projected too.
+        assert_eq!(
+            plan.properties().eq_properties.schema(),
+            &expected,
+            "PlanProperties must carry the projected schema as well"
+        );
+        // Building a projection over the scan runs ProjectionMapping::try_new —
+        // the code that raised the production assertion when the child still
+        // declared the full schema (`name` is index 0 of the projected schema
+        // but index 1 of the full one).
+        let exprs: Vec<(Arc<dyn datafusion::physical_expr::PhysicalExpr>, String)> = vec![(
+            Arc::new(datafusion::physical_expr::expressions::Column::new(
+                "name", 0,
+            )),
+            "name".to_string(),
+        )];
+        datafusion::physical_plan::projection::ProjectionExec::try_new(exprs, plan)
+            .expect("a projection over the projected scan must plan");
     }
 
-    /// The bounded ClickHouse provider ignores the pushed-down projection and
-    /// emits full-width batches in ITS OWN column order. The hybrid exec must
-    /// still deliver batches shaped exactly like its declared (projected)
-    /// schema, aligning columns by name.
+    /// A bounded phase that ignores the pushed-down projection and emits
+    /// full-width batches in its own column order. The hybrid exec must still
+    /// deliver batches whose columns are those of its declared (projected)
+    /// schema, in that order, aligning by name.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_execute_with_projection_aligns_reordered_phase_batches() {
         let config = HybridSourceConfig {
@@ -3357,6 +3455,263 @@ mod tests {
             "expected a clear missing-column error, got: {errs:?}"
         );
     }
+
+    /// An unbounded phase that HONORS the pushed-down projection (like the real
+    /// Kafka source): it declares the projected schema and emits one batch
+    /// shaped exactly like it.
+    #[derive(Debug)]
+    struct ProjectingMockProvider {
+        schema: SchemaRef,
+    }
+
+    #[async_trait]
+    impl TableProvider for ProjectingMockProvider {
+        fn schema(&self) -> SchemaRef {
+            self.schema.clone()
+        }
+        fn table_type(&self) -> TableType {
+            TableType::Base
+        }
+        async fn scan(
+            &self,
+            _state: &dyn datafusion::catalog::Session,
+            projection: Option<&Vec<usize>>,
+            _filters: &[Expr],
+            _limit: Option<usize>,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            let schema = datafusion::physical_plan::project_schema(&self.schema, projection)?;
+            Ok(Arc::new(ShapedMockExec {
+                schema: schema.clone(),
+                properties: Arc::new(PlanProperties::new(
+                    EquivalenceProperties::new(schema),
+                    datafusion::physical_plan::Partitioning::UnknownPartitioning(1),
+                    datafusion::physical_plan::execution_plan::EmissionType::Final,
+                    datafusion::physical_plan::execution_plan::Boundedness::Bounded,
+                )),
+            }))
+        }
+    }
+
+    /// Production phase shape under a projection: a bounded phase that ignores
+    /// the projection and emits full-width, reordered batches, followed
+    /// (job_mode=false) by an unbounded phase that honors it and emits
+    /// already-projected batches. Both must reach the consumer shaped like
+    /// the declared projected schema — the first through the by-name path,
+    /// the second through the fast path.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_execute_with_projection_across_ignoring_and_honoring_phases() {
+        let config = HybridSourceConfig {
+            bounded_sources: vec![Arc::new(ReorderedBatchMockProvider::new())],
+            unbounded_source: Arc::new(ProjectingMockProvider {
+                schema: create_test_schema(),
+            }),
+            offset_provider: None,
+            job_mode: false,
+        };
+        let state_backend = create_state_backend("test_execute_projection_two_phases").await;
+        let hybrid_provider = HybridTableProvider::new(
+            "test_execute_projection_two_phases".to_string(),
+            config,
+            create_test_schema(),
+            state_backend,
+            SESSION_MANAGER.clone(),
+        )
+        .unwrap();
+
+        let session_state = SESSION_MANAGER.session_state();
+        let projection = vec![1usize]; // just "name"
+        let plan = hybrid_provider
+            .scan(&session_state, Some(&projection), &[], None)
+            .await
+            .expect("scan should succeed");
+
+        let stream = plan
+            .execute(0, Arc::new(TaskContext::default()))
+            .expect("execute should succeed");
+        let batches: Vec<_> = stream.collect().await;
+
+        let expected_names = vec!["name".to_string()];
+        let mut data_batches = 0;
+        for batch in batches {
+            let batch = batch.expect("stream batch should not be an error");
+            if batch.num_rows() == 0 {
+                continue; // synthetic marker-flush batches
+            }
+            data_batches += 1;
+            let names: Vec<_> = batch
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect();
+            assert_eq!(names, expected_names);
+            let col = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringArray>()
+                .expect("projected column must be the utf8 'name' column");
+            assert_eq!(col.value(0), "a");
+            assert_eq!(col.value(1), "b");
+        }
+        assert_eq!(
+            data_batches, 2,
+            "one data batch from the bounded phase and one from the unbounded phase"
+        );
+        let state = hybrid_provider.state.read().await;
+        assert!(
+            state.current_phase >= hybrid_provider.config.bounded_sources.len(),
+            "should have reached the unbounded phase"
+        );
+    }
+
+    /// With NO projection in force, a phase whose column order is a
+    /// permutation of the hybrid schema (the `_gs_op`-mid-schema case) must
+    /// still be delivered in hybrid order — pre-alignment the batch was
+    /// forwarded as-is and every positional consumer read swapped arrays.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_execute_without_projection_reorders_permuted_phase_batch() {
+        let config = HybridSourceConfig {
+            bounded_sources: vec![Arc::new(ReorderedBatchMockProvider::new())],
+            unbounded_source: Arc::new(FiniteMockTableProvider::new()),
+            offset_provider: None,
+            job_mode: true,
+        };
+        let state_backend = create_state_backend("test_execute_no_projection_reorder").await;
+        let hybrid_provider = HybridTableProvider::new(
+            "test_execute_no_projection_reorder".to_string(),
+            config,
+            create_test_schema(),
+            state_backend,
+            SESSION_MANAGER.clone(),
+        )
+        .unwrap();
+
+        let session_state = SESSION_MANAGER.session_state();
+        let plan = hybrid_provider
+            .scan(&session_state, None, &[], None)
+            .await
+            .expect("scan should succeed");
+        let stream = plan
+            .execute(0, Arc::new(TaskContext::default()))
+            .expect("execute should succeed");
+        let batches: Vec<_> = stream.collect().await;
+
+        let mut saw_data = false;
+        for batch in batches {
+            let batch = batch.expect("stream batch should not be an error");
+            if batch.num_rows() == 0 {
+                continue;
+            }
+            saw_data = true;
+            let names: Vec<_> = batch
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().clone())
+                .collect();
+            assert_eq!(names, vec!["id".to_string(), "name".to_string()]);
+            let ids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::Int32Array>()
+                .expect("column 0 must be the Int32 'id' column, not the swapped 'name'");
+            assert_eq!(ids.values().to_vec(), vec![1, 2]);
+            let names = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringArray>()
+                .expect("column 1 must be the utf8 'name' column");
+            assert_eq!(names.value(0), "a");
+            assert_eq!(names.value(1), "b");
+        }
+        assert!(saw_data);
+    }
+
+    /// Hybrid-schema indices must be re-expressed in each phase's own index
+    /// space by name: the ClickHouse SELECT moves `_gs_op` last, so a Kafka
+    /// payload that carries `_gs_op` mid-schema makes the phases permutations
+    /// of each other.
+    #[test]
+    fn test_translate_projection_maps_hybrid_indices_to_phase_indices_by_name() {
+        let hybrid = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(COLUMN_NAME_OP, DataType::Utf8, false),
+            Field::new("name", DataType::Utf8, false),
+        ]);
+        let clickhouse_phase = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new(COLUMN_NAME_OP, DataType::Utf8, false),
+        ]);
+
+        // [name, _gs_op] in hybrid space is [2, 1]; in the phase it is [1, 2].
+        let translated = translate_projection("src", &hybrid, &clickhouse_phase, Some(&vec![2, 1]))
+            .expect("translation should succeed");
+        assert_eq!(translated, Some(vec![1, 2]));
+
+        // Identity phase (Kafka == hybrid) is a no-op mapping.
+        let identity = translate_projection("src", &hybrid, &hybrid, Some(&vec![2, 0]))
+            .expect("translation should succeed");
+        assert_eq!(identity, Some(vec![2, 0]));
+
+        // No projection stays None.
+        assert_eq!(
+            translate_projection("src", &hybrid, &clickhouse_phase, None).unwrap(),
+            None
+        );
+
+        // A phase missing a projected column is a clear error, not a wrong index.
+        let narrow = Schema::new(vec![Field::new("id", DataType::Int32, false)]);
+        let err = translate_projection("src", &hybrid, &narrow, Some(&vec![2]))
+            .expect_err("missing column must error")
+            .to_string();
+        assert!(
+            err.contains("'name'"),
+            "error should name the column, got: {err}"
+        );
+
+        // Out-of-range hybrid index is a clear error too.
+        let err = translate_projection("src", &hybrid, &clickhouse_phase, Some(&vec![7]))
+            .expect_err("out-of-range index must error")
+            .to_string();
+        assert!(err.contains("out of range"), "got: {err}");
+    }
+
+    /// A projection that prunes every column yields batches with rows but no
+    /// columns. Hybrid-buffered markers must still attach to them (and not be
+    /// requeued until phase end), so the merge must carry the row count
+    /// explicitly.
+    #[test]
+    fn test_merge_pending_markers_attaches_to_zero_column_batch() {
+        use streamling_core::checkpoints::checkpoint_management::{CheckpointEpoch, now_ms};
+
+        let zero_col = RecordBatch::try_new_with_options(
+            Arc::new(Schema::empty()),
+            vec![],
+            &RecordBatchOptions::new().with_row_count(Some(2)),
+        )
+        .expect("zero-column batch with a row count");
+        let pending: Arc<Mutex<Vec<CheckpointMessage>>> =
+            Arc::new(Mutex::new(vec![CheckpointMessage::Marker {
+                epoch: CheckpointEpoch(7),
+                created_at_ms: now_ms(),
+            }]));
+
+        let merged = merge_pending_markers(zero_col, &pending);
+
+        assert_eq!(merged.num_rows(), 2, "row count must survive the re-tag");
+        assert_eq!(merged.num_columns(), 0);
+        let attached = extract_checkpoint_messages(merged.schema().metadata());
+        assert!(
+            matches!(attached.as_slice(), [CheckpointMessage::Marker { epoch, .. }] if epoch.0 == 7),
+            "marker must ride the zero-column batch, got {attached:?}"
+        );
+        assert!(
+            pending.lock().unwrap().is_empty(),
+            "marker must not be requeued"
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_hybrid_source_execute_continues_to_unbounded_without_job_mode() {
         let bounded_sources: Vec<Arc<dyn TableProvider>> =

--- a/crates/streamling-e2e/tests/clickhouse_source.rs
+++ b/crates/streamling-e2e/tests/clickhouse_source.rs
@@ -992,3 +992,110 @@ sinks:
         "tied live+delete rows must both be dropped (delete wins the tie)"
     );
 }
+
+// ============================================================================
+// Scenario: non-prefix projection through a standalone ClickHouse source
+// ============================================================================
+
+/// A transform that selects a strict, REORDERED, non-prefix subset of a
+/// standalone ClickHouse source's columns. DataFusion pushes the projection
+/// into `ClickHouseTableProvider::scan`; the exec must declare and emit exactly
+/// that schema — declaring the full schema fails planning with "Input field
+/// name X does not match with the projection expression Y", and emitting
+/// full-width batches under a projected schema would swap columns.
+#[tokio::test]
+async fn test_clickhouse_source_non_prefix_projection() {
+    init_tracing();
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE projection_test (
+                block_number UInt64,
+                id String,
+                payload String,
+                extra String,
+                is_deleted UInt8
+            ) ENGINE = MergeTree()
+            ORDER BY (block_number, id)",
+        )
+        .await
+        .expect("Failed to create source table");
+
+    clickhouse
+        .execute(
+            "INSERT INTO projection_test VALUES
+                (1, 'a', 'payload_a', 'extra_a', 0),
+                (2, 'b', 'payload_b', 'extra_b', 0),
+                (3, 'c', 'payload_c', 'extra_c', 0)",
+        )
+        .await
+        .expect("Failed to insert source data");
+
+    // `payload` (index 2) then `id` (index 1): not a prefix, not in table order.
+    let pipeline = r#"
+sources:
+  ch_source:
+    type: clickhouse
+    table_name: projection_test
+    columns: "block_number,id,payload,extra"
+    primary_key: id
+
+transforms:
+  narrow:
+    type: sql
+    primary_key: id
+    sql: "SELECT payload, id FROM ch_source"
+
+sinks:
+  pg_sink:
+    type: postgres
+    from: narrow
+    table: projection_results
+    schema: public
+    primary_key: id
+    on_conflict: update
+"#;
+
+    let status = ctx
+        .run_pipeline_with_opts(
+            pipeline,
+            PipelineOpts::new()
+                .record_limit(3)
+                .timeout(std::time::Duration::from_secs(60)),
+        )
+        .await
+        .expect("Streamling execution failed");
+    assert!(status.success(), "pipeline should exit successfully");
+
+    let rows: Vec<(String, String)> = ctx
+        .postgres
+        .query("SELECT id, payload FROM public.projection_results ORDER BY id")
+        .await
+        .expect("query failed");
+    assert_eq!(
+        rows,
+        vec![
+            ("a".to_string(), "payload_a".to_string()),
+            ("b".to_string(), "payload_b".to_string()),
+            ("c".to_string(), "payload_c".to_string()),
+        ],
+        "projected columns must carry the right values under the right ids"
+    );
+
+    let cols = ctx
+        .postgres
+        .get_column_names("projection_results")
+        .await
+        .expect("failed to read column names");
+    for pruned in ["block_number", "extra"] {
+        assert!(
+            !cols.iter().any(|c| c == pruned),
+            "column '{pruned}' should have been pruned by the projection (got columns: {cols:?})"
+        );
+    }
+}

--- a/crates/streamling-e2e/tests/hybrid_source.rs
+++ b/crates/streamling-e2e/tests/hybrid_source.rs
@@ -1812,3 +1812,158 @@ sinks:
         by_id.get("null")
     );
 }
+
+// ============================================================================
+// Scenario: non-prefix projection through a hybrid source
+// ============================================================================
+
+/// A transform that selects a strict, REORDERED, non-prefix subset of the
+/// hybrid source's columns (`timestamp`, `id` out of `block, id, data,
+/// timestamp`). Regression for the planner assertion ("Input field name X does
+/// not match with the projection expression Y") hit by raw_traces-derived
+/// datasets: DataFusion pushes the projection into the hybrid scan, the
+/// bounded ClickHouse phase and the unbounded Kafka phase must both emit
+/// batches shaped like it, and — because the projection is not a prefix — a
+/// positional mismatch would silently swap columns rather than fail. Both
+/// phases run (job_mode=false), so both the by-name and fast-path alignments
+/// are exercised against real ClickHouse + Kafka.
+#[tokio::test]
+async fn test_hybrid_non_prefix_projection_selects_correct_columns() {
+    init_tracing();
+
+    let ctx = TestContext::with_options(TestContextOptions::new().with_clickhouse())
+        .await
+        .expect("Failed to create test context");
+    let clickhouse = ctx.clickhouse.as_ref().expect("ClickHouse not initialized");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE hybrid_proj_test (
+                block Int64,
+                id String,
+                data String,
+                timestamp Int64,
+                is_deleted UInt8
+            ) ENGINE = MergeTree()
+            ORDER BY (block, id)",
+        )
+        .await
+        .expect("Failed to create ClickHouse table");
+
+    // Distinct per-row timestamps so a swapped column is detectable.
+    clickhouse
+        .execute(
+            "INSERT INTO hybrid_proj_test VALUES
+            (1, 'Alice', 'A', 1001, 0),
+            (2, 'Bob', 'B', 1002, 0),
+            (3, 'Charlie', 'C', 1003, 0)",
+        )
+        .await
+        .expect("Failed to insert ClickHouse data");
+
+    ctx.kafka
+        .register_schema(TEST_SCHEMA)
+        .await
+        .expect("Failed to register schema");
+
+    let kafka_records: Vec<TestRecord> = (1..=3)
+        .map(|i| TestRecord {
+            block: 100 + i,
+            id: format!("kafka_user_{}", i),
+            data: format!("kafka_data_{}", i),
+            timestamp: 2000 + i,
+        })
+        .collect();
+    ctx.kafka
+        .produce_avro_records(&kafka_records)
+        .await
+        .expect("Failed to produce Kafka records");
+
+    clickhouse
+        .execute(
+            "CREATE TABLE kafka_offsets_proj (
+                topic String,
+                partition Int32,
+                offset UInt32
+            ) ENGINE = MergeTree()
+            ORDER BY (topic, partition)",
+        )
+        .await
+        .expect("Failed to create offset table");
+
+    let pipeline = format!(
+        r#"
+sources:
+  hybrid_source:
+    type: hybrid
+    bounded_sources:
+      - source_type: clickhouse
+        table_name: hybrid_proj_test
+        columns: block,id,data,timestamp
+    unbounded_source:
+      source_type: kafka
+      topic: {kafka_topic}
+      start_at: earliest
+    offset_table:
+      topic_name: {kafka_topic}
+      table_name: kafka_offsets_proj
+    primary_key: id
+
+transforms:
+  narrow:
+    type: sql
+    primary_key: id
+    sql: "SELECT timestamp AS ts, id FROM hybrid_source"
+
+sinks:
+  pg_sink:
+    type: postgres
+    from: narrow
+    table: hybrid_proj_results
+    schema: public
+    primary_key: id
+    on_conflict: update
+"#,
+        kafka_topic = ctx.kafka_topic,
+    );
+
+    let status = ctx
+        .run_pipeline_with_opts(
+            &pipeline,
+            PipelineOpts::new()
+                .record_limit(6) // 3 from ClickHouse + 3 from Kafka
+                .timeout(std::time::Duration::from_secs(120)),
+        )
+        .await
+        .expect("Streamling execution failed");
+    assert!(status.success(), "Streamling should exit successfully");
+
+    let rows: Vec<(String, i64)> = ctx
+        .postgres
+        .query("SELECT id, ts FROM public.hybrid_proj_results ORDER BY id")
+        .await
+        .expect("Failed to query results");
+    let by_id: std::collections::HashMap<String, i64> = rows.into_iter().collect();
+
+    // Bounded (ClickHouse) phase: values must land under the right ids.
+    assert_eq!(by_id.get("Alice"), Some(&1001), "got {:?}", by_id);
+    assert_eq!(by_id.get("Bob"), Some(&1002), "got {:?}", by_id);
+    assert_eq!(by_id.get("Charlie"), Some(&1003), "got {:?}", by_id);
+    // Unbounded (Kafka) phase.
+    assert_eq!(by_id.get("kafka_user_1"), Some(&2001), "got {:?}", by_id);
+    assert_eq!(by_id.get("kafka_user_2"), Some(&2002), "got {:?}", by_id);
+    assert_eq!(by_id.get("kafka_user_3"), Some(&2003), "got {:?}", by_id);
+
+    // The pruned columns must not reach the sink.
+    let cols = ctx
+        .postgres
+        .get_column_names("hybrid_proj_results")
+        .await
+        .expect("Failed to read column names");
+    for pruned in ["block", "data", "timestamp"] {
+        assert!(
+            !cols.iter().any(|c| c == pruned),
+            "column '{pruned}' should have been pruned by the projection (got columns: {cols:?})"
+        );
+    }
+}


### PR DESCRIPTION
Stacked on #127 (base: `fix/hybrid-projection-pushdown`); retarget to `main` once #127 lands. Hardening and the provider-side half of the fix, from the review of #127.

## What #127 left open

#127 makes `HybridSourceExec` declare the projected schema and realign inner batches by name, which fixes the planner assertion for hybrid sources. Reviewing it turned up four things worth closing while the code is fresh:

1. **Standalone `type: clickhouse` sources still fail planning identically.** `ClickHouseTableProvider::scan` ignored the pushed-down projection and `ClickHouseSourceExec` declared/emitted the full schema, so any SQL transform selecting a non-prefix column subset from a standalone ClickHouse source hits the same `ProjectionMapping::try_new` assertion. #127 only repaired this from the hybrid side.
2. **Hybrid pushed untranslated indices into inner phases.** Phase schemas are validated against the hybrid schema by *name* only, so a phase can be a permutation of it (the ClickHouse SELECT always moves `_gs_op` last; a Kafka payload carrying its own `_gs_op` keeps it in place). Harmless while ClickHouse discarded the projection — a silent column swap the moment it honors it (which this PR makes it do).
3. **Zero-column projections stranded hybrid safety-net markers.** A projection that prunes every column (a literal-only transform such as `SELECT 1 AS x FROM src`; aggregates are rejected by transform validation) yields batches with rows but no columns. `merge_pending_markers` and `enrich_batch_with_metadata` rebuilt batches with `RecordBatch::try_new`, which cannot infer a row count from zero columns, so every hybrid-buffered Marker/Finalizer was requeued with a warning until the phase-end flush.
4. **The "ClickHouse DESCRIBE order" rationale in the comments was wrong.** `ClickHouseSchemaAdapter::get_columns` builds the SELECT list *from the Kafka schema*; the real reasons alignment is needed are a column superset from a phase that ignores the projection, `_gs_op` placement, and non-prefix indices.

## Changes

**`clickhouse.rs` — the scan honors the projection** (mirrors `kafka.rs` / `file.rs`): `scan` computes `project_schema(&self.schema, projection)`, `ClickHouseSourceExec` stores the projection + output schema, overrides `schema()`, builds `PlanProperties` from the output schema, and applies `batch.project(indices)` at the emit point — after version-aware dedup and after the dedup-only version column is stripped (indices are relative to the external schema), before checkpoint metadata is attached. Empty-page / all-tombstoned / final-flush batches use the output schema. The SQL SELECT list is unchanged.

**`hybrid.rs` — per-phase index translation**: `translate_projection` re-expresses hybrid-schema indices in each phase's index space by name, in both `HybridTableProvider::scan` and `get_current_execution_stream`. Identity for the Kafka phase (hybrid schema == Kafka schema). `align_batch_to_schema` stays as defense in depth — it also closes the pre-existing `projection == None` column swap when the Avro payload carries `_gs_op` — with its doc rewritten to say what it actually guards against.

**Zero-column safety**: `merge_pending_markers` (hybrid.rs) and `enrich_batch_with_metadata` (streamling-common) use `try_new_with_options(..., with_row_count(num_rows))`. The latter is `.expect()`ed inside `ClickHouseSourceExec::attach_checkpoints`, so it is a prerequisite for the ClickHouse change above.

## Tests

Unit (all in `streamling-connectors` / `streamling-common`, no server needed):

- `test_datafusion_sql_projection_plans_and_executes_through_hybrid` — plans `SELECT upper(name) AS n FROM hybrid` through **real DataFusion SQL planning**, so the pushed projection reaches `ProjectionMapping::try_new` (the code that raised the production error) and executes end to end. Fails on the pre-#127 code with the exact assertion.
- `test_scan_with_projection_reports_projected_schema` now also asserts `PlanProperties.eq_properties.schema()` and builds a `ProjectionExec` over the scan.
- `test_execute_with_projection_across_ignoring_and_honoring_phases` — job_mode=false: a bounded phase that ignores the projection followed by an unbounded phase that honors it (the production shape); both phases' batches must match the projected schema.
- `test_execute_without_projection_reorders_permuted_phase_batch` — the `projection == None` `_gs_op`-permutation case.
- `test_translate_projection_maps_hybrid_indices_to_phase_indices_by_name`, `test_merge_pending_markers_attaches_to_zero_column_batch`, `test_align_preserves_batch_schema_metadata`, `test_empty_projection_keeps_row_count`, `test_missing_column_in_phase_batch_errors_and_terminates`.
- `clickhouse::tests::test_source_scan_reports_projected_schema` — `scan(Some(&[2, 0]))` reports the reordered, non-prefix projected schema on both schema surfaces.

e2e (CI containers): `test_hybrid_non_prefix_projection_selects_correct_columns` (hybrid, job_mode=false, both phases, `SELECT timestamp AS ts, id`) and `test_clickhouse_source_non_prefix_projection` (standalone ClickHouse, `SELECT payload, id`). Both assert values land under the right ids and pruned columns don't reach the sink. Every existing hybrid e2e either has no transform or selects a prefix, which passes by coincidence on the pre-fix code.

Local: `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings -A clippy::result_large_err` (the `just lint` flags), and the full `streamling-common` + `streamling-connectors` lib test suites are clean.

## Not in this PR

Pushing the projection into the ClickHouse `SELECT` list (skipping `input`/`output` calldata and the `*_evm_transfers` arrays for raw_traces-derived backfills). That is the dominant I/O win for a full-history `native_transfers` backfill and should land before that runs at scale, but it changes query shape and needs verification against live ClickHouse. Design note for it: the only consumer of non-projected columns is version-aware dedup (sorting keys + version column + `_gs_op`, when a version column is inferred) — `extract_keyset_from_batch` is dead code, pagination is range-based inside the CTE `WHERE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVLDM9cmAy4DyYaryLDniU

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVLDM9cmAy4DyYaryLDniU)_